### PR TITLE
Incremental / delta checkpoints for HMR route simulation

### DIFF
--- a/packages/spark-engine/src/game/core/classes/CheckpointStore.ts
+++ b/packages/spark-engine/src/game/core/classes/CheckpointStore.ts
@@ -1,0 +1,308 @@
+// Incremental / delta checkpoint storage.
+//
+// For live preview the engine saves a checkpoint at EVERY beat (so re-planning a
+// route can resume from the last valid checkpoint instead of replaying from
+// zero). A full save() is dominated by the two UNBOUNDED count maps inside the
+// ink story state (visitCounts + turnIndices, keyed by container path, never
+// pruned). Storing N full saves of O(N) state each is O(n^2) time + memory.
+//
+// This store keeps the SAME integer-index contract that the route planner relies
+// on (`step.checkpoint` indexes into the store; index i ↔ the full save string
+// for the i-th beat) but, when `incremental` is enabled, stores periodic full
+// KEYFRAMES (every `baseInterval` beats) plus per-beat DELTAS in between. A delta
+// stores the bounded body (everything except the two count maps, full-copied)
+// plus only the count-map entries that changed that beat. The full save string
+// for any beat is reconstructed lazily by replaying deltas onto the nearest
+// keyframe.
+//
+// SAFETY: with `verify` on, every delta is reconstructed and asserted
+// byte-identical to a real full save() at capture time; on ANY mismatch the
+// entry falls back to a full keyframe. A subtle delta bug therefore degrades to
+// "stored a full save" — never a corrupted one. With `incremental` off the store
+// is a thin wrapper over the original `string[]` behavior (every entry a full
+// keyframe), so it is a drop-in no-op.
+
+/** Ordered full / per-beat runtime collections (executed paths, choices,
+ *  conditions). */
+export interface RuntimeCollections {
+  pe: string[];
+  ce: { options: string[]; selected: number }[];
+  cde: { selected: boolean }[];
+}
+
+/** Host hooks the store needs from the Game (kept minimal to avoid coupling to
+ *  the Game generic). */
+export interface CheckpointHost {
+  /** Full SaveData JSON for the current beat (all collections included). */
+  save(): string;
+  /** SaveData JSON for the current beat with the unbounded, per-beat-growing
+   *  collections (story count maps + runtime collections) emptied. */
+  saveDeltaBody(): string;
+  /** Full ordered snapshot of both count maps (Map insertion order). */
+  snapshotCounts(): {
+    vc: [string, number][];
+    ti: [string, number][];
+  };
+  /** Count-map entries changed since the last drain (first-touch order), and
+   *  clear the change log. Called once per captured beat. */
+  drainCountDeltas(): {
+    vc: [string, number][];
+    ti: [string, number][];
+  };
+  /** Full ordered snapshot of the runtime collections. */
+  snapshotRuntime(): RuntimeCollections;
+  /** Runtime-collection changes since the last drain, and advance the marks. */
+  drainRuntime(): RuntimeCollections;
+}
+
+interface KeyframeEntry {
+  kind: "keyframe";
+  json: string;
+  // Ordered full collections (only populated in incremental mode — needed to
+  // seed reconstruction of the deltas that follow this keyframe).
+  vc?: [string, number][];
+  ti?: [string, number][];
+  rt?: RuntimeCollections;
+}
+
+interface DeltaEntry {
+  kind: "delta";
+  // SaveData JSON with the unbounded collections serialized empty.
+  body: string;
+  // Count-map entries that changed this beat (replayed onto the keyframe).
+  vc: [string, number][];
+  ti: [string, number][];
+  // Runtime-collection changes this beat (replayed onto the keyframe).
+  rt: RuntimeCollections;
+}
+
+type CheckpointEntry = KeyframeEntry | DeltaEntry;
+
+export class CheckpointStore {
+  protected _entries: CheckpointEntry[] = [];
+
+  protected _host: CheckpointHost;
+  protected _incremental: boolean;
+  protected _verify: boolean;
+  protected _baseInterval: number;
+
+  /** Optional diagnostic callback fired when a delta fails the byte-identical
+   *  self-check and falls back to a full keyframe. */
+  public onVerifyFallback?: (index: number) => void;
+
+  protected _fallbacks = 0;
+
+  /** Introspection for tests/diagnostics: how the N checkpoints are stored. */
+  get stats(): {
+    total: number;
+    keyframes: number;
+    deltas: number;
+    fallbacks: number;
+  } {
+    let keyframes = 0;
+    let deltas = 0;
+    for (const e of this._entries) {
+      if (e.kind === "keyframe") {
+        keyframes++;
+      } else {
+        deltas++;
+      }
+    }
+    return { total: this._entries.length, keyframes, deltas, fallbacks: this._fallbacks };
+  }
+
+  constructor(
+    host: CheckpointHost,
+    options?: {
+      incremental?: boolean;
+      verify?: boolean;
+      baseInterval?: number;
+    },
+  ) {
+    this._host = host;
+    this._incremental = options?.incremental ?? false;
+    // Self-check defaults ON whenever deltas are enabled — it is the guard that
+    // makes a delta bug a fall-back-to-full rather than a silent corruption.
+    this._verify = options?.verify ?? true;
+    this._baseInterval = Math.max(1, options?.baseInterval ?? 50);
+  }
+
+  get length(): number {
+    return this._entries.length;
+  }
+
+  /** Append a checkpoint capturing the host's CURRENT beat state. */
+  capture(): void {
+    const index = this._entries.length;
+
+    if (!this._incremental) {
+      this._entries.push({ kind: "keyframe", json: this._host.save() });
+      return;
+    }
+
+    const isKeyframeSlot = index % this._baseInterval === 0;
+    if (isKeyframeSlot) {
+      this._entries.push(this.buildKeyframe());
+      return;
+    }
+
+    // Delta slot: bounded body + only this beat's changed collection entries.
+    const body = this._host.saveDeltaBody();
+    const drained = this._host.drainCountDeltas();
+    const rt = this._host.drainRuntime();
+    const entry: DeltaEntry = {
+      kind: "delta",
+      body,
+      vc: drained.vc,
+      ti: drained.ti,
+      rt,
+    };
+    this._entries.push(entry);
+
+    if (this._verify) {
+      const reconstructed = this.reconstruct(index);
+      const full = this._host.save();
+      if (reconstructed !== full) {
+        // Self-check failed — fall back to a full keyframe (which also re-seeds
+        // the count maps for any deltas that follow). The drain already cleared
+        // the change log for this beat, so the keyframe's full snapshot is the
+        // authoritative baseline going forward.
+        const snap = this._host.snapshotCounts();
+        this._entries[index] = {
+          kind: "keyframe",
+          json: full,
+          vc: snap.vc,
+          ti: snap.ti,
+          rt: this._host.snapshotRuntime(),
+        };
+        this._fallbacks++;
+        this.onVerifyFallback?.(index);
+      }
+    }
+  }
+
+  protected buildKeyframe(): KeyframeEntry {
+    const snap = this._host.snapshotCounts();
+    const rt = this._host.snapshotRuntime();
+    // Drain to reset the per-beat change logs so the deltas after this keyframe
+    // start from a clean window (the drained values are already captured by the
+    // full snapshots above).
+    this._host.drainCountDeltas();
+    this._host.drainRuntime();
+    return {
+      kind: "keyframe",
+      json: this._host.save(),
+      vc: snap.vc,
+      ti: snap.ti,
+      rt,
+    };
+  }
+
+  /** Full save string for beat `index`, or null if out of range. Strict: does
+   *  NOT do Array-style negative indexing (preserves the old `arr[-1] ===
+   *  undefined` semantics that callers relied on). */
+  getJson(index: number): string | null {
+    if (!Number.isInteger(index) || index < 0 || index >= this._entries.length) {
+      return null;
+    }
+    return this.reconstruct(index);
+  }
+
+  /** Array-like accessor (supports negative indices like Array.prototype.at).
+   *  Used by callers that previously did `checkpoints.at(-1)`. */
+  at(index: number): string | null {
+    const n = this._entries.length;
+    const i = index < 0 ? n + index : index;
+    if (i < 0 || i >= n) {
+      return null;
+    }
+    return this.reconstruct(i);
+  }
+
+  /** Keep only the first `keepCount` checkpoints (mirrors the old
+   *  `_checkpoints.slice(0, keepCount)`). */
+  truncate(keepCount: number): void {
+    this._entries.length = Math.max(0, Math.min(keepCount, this._entries.length));
+  }
+
+  protected reconstruct(index: number): string {
+    const entry = this._entries[index]!;
+    if (entry.kind === "keyframe") {
+      return entry.json;
+    }
+
+    // Walk back to the nearest keyframe and replay every delta up to `index`
+    // onto its count maps.
+    let baseIndex = index - 1;
+    while (baseIndex >= 0 && this._entries[baseIndex]!.kind !== "keyframe") {
+      baseIndex--;
+    }
+    const base = this._entries[baseIndex] as KeyframeEntry | undefined;
+    if (!base) {
+      // Should never happen (index 0 is always a keyframe). Defensive: a delta
+      // with no keyframe can't be reconstructed.
+      throw new Error(
+        `CheckpointStore: no keyframe found before delta index ${index}`,
+      );
+    }
+
+    const vc = new Map<string, number>(base.vc ?? []);
+    const ti = new Map<string, number>(base.ti ?? []);
+    // Runtime collections: paths are a recency-ordered set (delete+add replay),
+    // choices/conditions are append-only (concat).
+    const pe = new Set<string>(base.rt?.pe ?? []);
+    const ce = (base.rt?.ce ?? []).slice();
+    const cde = (base.rt?.cde ?? []).slice();
+    for (let i = baseIndex + 1; i <= index; i++) {
+      const e = this._entries[i] as DeltaEntry;
+      for (const [k, v] of e.vc) {
+        vc.set(k, v);
+      }
+      for (const [k, v] of e.ti) {
+        ti.set(k, v);
+      }
+      for (const p of e.rt.pe) {
+        pe.delete(p);
+        pe.add(p);
+      }
+      for (const c of e.rt.ce) {
+        ce.push(c);
+      }
+      for (const c of e.rt.cde) {
+        cde.push(c);
+      }
+    }
+
+    return this.injectCounts(entry.body, vc, ti, { pe: Array.from(pe), ce, cde });
+  }
+
+  /** Splice the reconstructed collections back into the body. The story count
+   *  maps fill the empty `{}` slots inside the story JSON; the runtime field is
+   *  rebuilt wholesale. Both reproduce exactly what the engine serializers wrote
+   *  (`JSON.stringify` of plain objects / arrays built in the same order), so
+   *  the result is byte-identical to a full save(). */
+  protected injectCounts(
+    body: string,
+    vc: Map<string, number>,
+    ti: Map<string, number>,
+    rt: RuntimeCollections,
+  ): string {
+    const saveObj = JSON.parse(body);
+    let story = saveObj.story as string;
+    story = story.replace(
+      '"visitCounts":{}',
+      '"visitCounts":' + JSON.stringify(Object.fromEntries(vc)),
+    );
+    story = story.replace(
+      '"turnIndices":{}',
+      '"turnIndices":' + JSON.stringify(Object.fromEntries(ti)),
+    );
+    saveObj.story = story;
+    saveObj.runtime = JSON.stringify({
+      pathsExecutedThisFrame: rt.pe,
+      choicesEncountered: rt.ce,
+      conditionsEncountered: rt.cde,
+    });
+    return JSON.stringify(saveObj);
+  }
+}

--- a/packages/spark-engine/src/game/core/classes/Game.ts
+++ b/packages/spark-engine/src/game/core/classes/Game.ts
@@ -28,6 +28,7 @@ import { Thread } from "../types/Thread";
 import { Variable, VariablePresentationHint } from "../types/Variable";
 import { findClosestPath } from "../utils/findClosestPath";
 import { findClosestPathLocation } from "../utils/findClosestPathLocation";
+import { CheckpointStore } from "./CheckpointStore";
 import { Clock } from "./Clock";
 import { Connection } from "./Connection";
 import { Coordinator } from "./Coordinator";
@@ -119,6 +120,11 @@ export class Game<T extends M = {}> {
   // copied.
   protected _runtimeSnapshot: {
     pathsExecutedThisFrame: Set<string>;
+    // Mirror of pathsExecutedThisFrame's per-checkpoint delta log — snapshotted
+    // alongside it so a lookahead rewind reverts the delta tracking too (else a
+    // speculative-then-rewound execution would leak into the next checkpoint's
+    // delta). Bounded by one beat's executions (we checkpoint every beat).
+    executedSinceCheckpoint: Set<string>;
     choicesLength: number;
     conditionsLength: number;
   } | null = null;
@@ -214,7 +220,7 @@ export class Game<T extends M = {}> {
 
   protected _plannedRouteStepMap: { [seq: string]: number } = {};
 
-  protected _checkpoints: string[] = [];
+  protected _checkpoints!: CheckpointStore;
   get checkpoints() {
     return this._checkpoints;
   }
@@ -256,6 +262,28 @@ export class Game<T extends M = {}> {
     if (options?.executionTimeout) {
       this._executionTimeout = options.executionTimeout;
     }
+
+    this._checkpoints = new CheckpointStore(
+      {
+        save: () => this.save(),
+        saveDeltaBody: () => this.saveDeltaBody(),
+        snapshotCounts: () => ({
+          vc: this._story.state.GetVisitCountEntries(),
+          ti: this._story.state.GetTurnIndexEntries(),
+        }),
+        drainCountDeltas: () => ({
+          vc: this._story.state.DrainVisitCountDeltas(),
+          ti: this._story.state.DrainTurnIndexDeltas(),
+        }),
+        snapshotRuntime: () => this._runtimeState.snapshotFull(),
+        drainRuntime: () => this._runtimeState.drainDeltas(),
+      },
+      {
+        incremental: options?.incrementalCheckpoints ?? false,
+        verify: options?.verifyCheckpoints ?? true,
+        baseInterval: options?.checkpointBaseInterval ?? 50,
+      },
+    );
 
     // Create context
     this._context = {
@@ -421,6 +449,9 @@ export class Game<T extends M = {}> {
         pathsExecutedThisFrame: new Set(
           this._runtimeState.pathsExecutedThisFrame,
         ),
+        executedSinceCheckpoint: new Set(
+          this._runtimeState.executedSinceCheckpoint,
+        ),
         choicesLength: this._runtimeState.choicesEncountered.length,
         conditionsLength: this._runtimeState.conditionsEncountered.length,
       };
@@ -431,6 +462,9 @@ export class Game<T extends M = {}> {
         // back to the snapshot Set, and truncate the appended choices/conditions.
         this._runtimeState.pathsExecutedThisFrame = new Set(
           this._runtimeSnapshot.pathsExecutedThisFrame,
+        );
+        this._runtimeState.executedSinceCheckpoint = new Set(
+          this._runtimeSnapshot.executedSinceCheckpoint,
         );
         this._runtimeState.choicesEncountered.length =
           this._runtimeSnapshot.choicesLength;
@@ -688,7 +722,7 @@ export class Game<T extends M = {}> {
         const step = this._plannedRoute.steps[stepIndex];
         if (step) {
           if (step.checkpoint != null) {
-            return this._checkpoints[step.checkpoint] ?? null;
+            return this._checkpoints.getJson(step.checkpoint);
           }
         }
       }
@@ -700,8 +734,8 @@ export class Game<T extends M = {}> {
     const startStep = route.steps[fromStep];
     const fromDecision = startStep?.decision ?? 0;
     const fromCheckpoint = startStep?.checkpoint ?? -1;
-    const startCheckpoint = this._checkpoints[fromCheckpoint];
-    this._checkpoints = this._checkpoints.slice(0, fromCheckpoint + 1);
+    const startCheckpoint = this._checkpoints.getJson(fromCheckpoint);
+    this._checkpoints.truncate(fromCheckpoint + 1);
     this._plannedRoute = route;
     this._simulatePath = route.fromPath;
     this._startPath = route.toPath;
@@ -878,17 +912,34 @@ export class Game<T extends M = {}> {
   }
 
   checkpoint(): void {
-    this._checkpoints.push(this.save());
+    this._checkpoints.capture();
   }
 
   save(): string {
+    return this.buildSave(false);
+  }
+
+  /** Like `save()` but serializes the unbounded, per-beat-growing collections
+   *  (story visit/turn count maps + runtime executed-paths/choices/conditions)
+   *  as empty. The CheckpointStore stores this bounded body for delta beats and
+   *  re-injects the (delta-reconstructed) collections to rebuild a
+   *  byte-identical full save. */
+  saveDeltaBody(): string {
+    return this.buildSave(true);
+  }
+
+  protected buildSave(omitDeltaState: boolean): string {
     let story = "";
     try {
-      story = this._story.state.toJson();
+      story = omitDeltaState
+        ? this._story.state.ToJsonWithoutCounts()
+        : this._story.state.toJson();
     } catch (e: any) {
       this.Error(e.message, ErrorType.Error);
     }
-    const runtime = this._runtimeState.toJSON();
+    const runtime = omitDeltaState
+      ? this._runtimeState.toJSONWithoutCollections()
+      : this._runtimeState.toJSON();
     const saveData: SaveData = {
       modules: {},
       context: {},

--- a/packages/spark-engine/src/game/core/classes/RuntimeState.ts
+++ b/packages/spark-engine/src/game/core/classes/RuntimeState.ts
@@ -12,6 +12,15 @@ export interface SerializableRuntimeState {
   }[];
 }
 
+/** Per-beat delta of the runtime collections (incremental checkpoints). */
+export interface RuntimeDelta {
+  // Paths executed this beat, in recency order (delete-then-add semantics).
+  pe: string[];
+  // Choices / conditions appended this beat.
+  ce: { options: string[]; selected: number }[];
+  cde: { selected: boolean }[];
+}
+
 export class RuntimeState {
   pathsExecutedThisFrame: Set<string> = new Set();
 
@@ -24,11 +33,27 @@ export class RuntimeState {
     selected: boolean;
   }[] = [];
 
+  // --- Incremental-checkpoint delta tracking ---
+  //
+  // `pathsExecutedThisFrame` grows ~1 entry/beat and re-orders on revisit
+  // (delete+add), so a full copy per checkpoint is O(n^2). We mirror the
+  // per-beat executions into `executedSinceCheckpoint` (same delete+add recency
+  // semantics) and drain it at each checkpoint — its rewind-safety is handled by
+  // Game's lookahead snapshot (which already copies `pathsExecutedThisFrame`).
+  // `choicesEncountered` / `conditionsEncountered` are append-only and never
+  // truncated below the last checkpoint, so a slice from a drain mark is exact
+  // and needs no snapshot/restore.
+  executedSinceCheckpoint: Set<string> = new Set();
+  protected _choiceDrainMark = 0;
+  protected _conditionDrainMark = 0;
+
   recordExecution(path: string) {
     if (!path.startsWith("global ")) {
       // Delete before adding so that last item in set is always the most recently executed
       this.pathsExecutedThisFrame.delete(path);
       this.pathsExecutedThisFrame.add(path);
+      this.executedSinceCheckpoint.delete(path);
+      this.executedSinceCheckpoint.add(path);
     }
   }
 
@@ -49,6 +74,38 @@ export class RuntimeState {
     return JSON.stringify(this.toSerializable());
   }
 
+  /** Like `toJSON()` but with the three unbounded collections emptied. The
+   *  CheckpointStore stores this constant body for delta beats and re-injects
+   *  the (delta-reconstructed) collections to rebuild a byte-identical save. */
+  toJSONWithoutCollections() {
+    return JSON.stringify({
+      pathsExecutedThisFrame: [],
+      choicesEncountered: [],
+      conditionsEncountered: [],
+    });
+  }
+
+  /** Full ordered snapshot of all three collections (seeds a delta keyframe). */
+  snapshotFull(): RuntimeDelta {
+    return {
+      pe: Array.from(this.pathsExecutedThisFrame),
+      ce: this.choicesEncountered.slice(),
+      cde: this.conditionsEncountered.slice(),
+    };
+  }
+
+  /** The collection changes committed since the last drain, and advance the
+   *  drain marks. Called once per captured beat. */
+  drainDeltas(): RuntimeDelta {
+    const pe = Array.from(this.executedSinceCheckpoint);
+    this.executedSinceCheckpoint.clear();
+    const ce = this.choicesEncountered.slice(this._choiceDrainMark);
+    this._choiceDrainMark = this.choicesEncountered.length;
+    const cde = this.conditionsEncountered.slice(this._conditionDrainMark);
+    this._conditionDrainMark = this.conditionsEncountered.length;
+    return { pe, ce, cde };
+  }
+
   protected toSerializable(): SerializableRuntimeState {
     return {
       pathsExecutedThisFrame: Array.from(this.pathsExecutedThisFrame),
@@ -61,6 +118,11 @@ export class RuntimeState {
     this.pathsExecutedThisFrame = new Set(serializable.pathsExecutedThisFrame);
     this.choicesEncountered = serializable.choicesEncountered;
     this.conditionsEncountered = serializable.conditionsEncountered;
+    // A freshly-loaded state is the new delta baseline — no pending changes,
+    // marks sit at the loaded collection lengths.
+    this.executedSinceCheckpoint = new Set();
+    this._choiceDrainMark = this.choicesEncountered.length;
+    this._conditionDrainMark = this.conditionsEncountered.length;
     return;
   }
 

--- a/packages/spark-engine/src/game/core/types/GameConfiguration.ts
+++ b/packages/spark-engine/src/game/core/types/GameConfiguration.ts
@@ -6,4 +6,14 @@ export interface GameConfiguration {
   breakpoints?: { file: string; line: number }[];
   functionBreakpoints?: { name: string }[];
   dataBreakpoints?: { dataId: string }[];
+  /** Store per-beat checkpoints as periodic full keyframes + deltas instead of
+   *  full saves (eliminates the O(n^2) cost of HMR route simulation). Default
+   *  off — a settled-on kill switch. */
+  incrementalCheckpoints?: boolean;
+  /** When incremental checkpoints are on, assert every delta reconstructs
+   *  byte-identically to a full save and fall back to a full keyframe on any
+   *  mismatch. Default on (correctness guard). */
+  verifyCheckpoints?: boolean;
+  /** Beats between full keyframes in incremental mode. Default 50. */
+  checkpointBaseInterval?: number;
 }

--- a/packages/spark-engine/src/tests/core/checkpointDelta.test.ts
+++ b/packages/spark-engine/src/tests/core/checkpointDelta.test.ts
@@ -1,0 +1,196 @@
+// Delta-checkpoint-specific tests. The characterization net
+// (checkpointSimulation.test.ts) proves observable behavior is identical with
+// the flag OFF and ON. These tests additionally prove the DELTA PATH IS REALLY
+// EXERCISED (not silently falling back to full keyframes) and that EVERY stored
+// checkpoint — not just the last — reconstructs byte-identically to the
+// full-save baseline.
+
+import { describe, expect, test } from "vitest";
+import { SparkdownCompiler } from "@impower/sparkdown/src/compiler/classes/SparkdownCompiler";
+import { Game } from "../../game/core/classes/Game";
+
+const URI = "inmemory:///main.sd";
+
+function compileSrc(src: string) {
+  const compiler = new SparkdownCompiler();
+  compiler.configure({
+    useBuiltinsPrelude: true,
+    files: [
+      { uri: URI, type: "script", name: "main", ext: "sd", text: src, version: 1, languageId: "sparkdown" },
+    ],
+  });
+  const result = compiler.compile({ textDocument: { uri: URI }, countAllVisits: true });
+  if (!result.program.compiled) {
+    throw new Error("delta fixture failed to compile");
+  }
+  return result.program;
+}
+
+function newGame(program: unknown, config: Record<string, unknown>) {
+  return new Game({
+    program: program as any,
+    now: () => 0,
+    setTimeout: ((fn: Function, _ms?: number, ...a: any[]) => {
+      fn(...a);
+      return 0;
+    }) as any,
+    ...config,
+  } as any);
+}
+
+function planTo(game: Game, program: any, line: number) {
+  game.setStartFrom({ file: URI, line });
+  const toPath = (game as any).startPath as string;
+  const fromPath = Game.getSimulateFromPath(toPath);
+  return Game.planRoute(game.story, program, fromPath, toPath);
+}
+
+/** Simulate to `line` and return the final checkpoint, every reconstructed
+ *  checkpoint, and the store's storage stats. */
+function simulateAll(program: any, line: number, config: Record<string, unknown>) {
+  const game = newGame(program, config);
+  const cp = game.patchAndSimulateRoute(planTo(game, program, line));
+  const store: any = game.checkpoints;
+  const all: (string | null)[] = [];
+  for (let i = 0; i < store.length; i++) {
+    all.push(store.getJson(i));
+  }
+  return { cp, all, stats: store.stats, length: store.length };
+}
+
+// A long-ish linear scene: enough display beats that the store spans many
+// keyframe/delta cycles, with globals mutated between beats so the per-beat
+// state genuinely differs (the delta isn't trivially empty).
+function buildLinearScene(lines: number): { src: string; lastLine: number } {
+  const head = ["store n = 0", "", "-> start", "", "scene start"];
+  const body: string[] = [];
+  for (let i = 0; i < lines; i++) {
+    body.push(`  Line number ${i} here.`);
+    body.push(`  & n = ${i + 1}`);
+  }
+  const all = [...head, ...body, "end", ""];
+  // Last display line is the second-to-last body entry pair's text line.
+  const lastTextLineIndex = head.length + (lines - 1) * 2; // 0-based line of last "Line number" text
+  return { src: all.join("\n"), lastLine: lastTextLineIndex };
+}
+
+const OFF = {};
+const ON = {
+  incrementalCheckpoints: true,
+  verifyCheckpoints: true,
+  checkpointBaseInterval: 4,
+};
+const ON_NO_VERIFY = {
+  incrementalCheckpoints: true,
+  verifyCheckpoints: false,
+  checkpointBaseInterval: 4,
+};
+
+// Each game seeds story RNG from wall-clock time, so two independent runs are not
+// comparable byte-for-byte. The seed-STABLE proof is a load→re-save round-trip:
+// a reconstructed checkpoint must load into a fresh game and re-save identically.
+// This also exercises the delta reconstruction INDEPENDENTLY of the capture-time
+// self-check (load/save never touch the CheckpointStore).
+function assertEveryCheckpointRoundTrips(program: any, all: (string | null)[]) {
+  expect(all.length).toBeGreaterThan(0);
+  for (let i = 0; i < all.length; i++) {
+    const cp = all[i];
+    expect(typeof cp, `checkpoint ${i} reconstructs to a string`).toBe("string");
+    const g2 = newGame(program, OFF);
+    expect(g2.load(cp as string), `load checkpoint ${i}`).toBe(true);
+    expect(g2.save(), `byte-identical re-save of checkpoint ${i}`).toBe(cp);
+  }
+}
+
+describe("delta checkpoints actually reconstruct byte-identically", () => {
+  test("every reconstructed checkpoint loads + re-saves identically (verify ON)", () => {
+    const { src, lastLine } = buildLinearScene(24);
+    const program = compileSrc(src);
+    const on = simulateAll(program, lastLine, ON);
+
+    // The route produced enough beats to span multiple keyframe/delta cycles.
+    expect(on.length).toBeGreaterThan(ON.checkpointBaseInterval);
+    assertEveryCheckpointRoundTrips(program, on.all);
+  });
+
+  test("the delta path is exercised and never falls back", () => {
+    const { src, lastLine } = buildLinearScene(24);
+    const program = compileSrc(src);
+    const on = simulateAll(program, lastLine, ON);
+
+    // Real deltas were stored (not all keyframes), and not one of them failed
+    // the byte-identical self-check (no fallback to a full keyframe).
+    expect(on.stats.deltas).toBeGreaterThan(0);
+    expect(on.stats.keyframes).toBeGreaterThan(0);
+    expect(on.stats.fallbacks).toBe(0);
+    expect(on.stats.total).toBe(on.length);
+  });
+
+  test("disabling verify still reconstructs byte-identically (pure delta path)", () => {
+    const { src, lastLine } = buildLinearScene(24);
+    const program = compileSrc(src);
+    // verify OFF: no per-beat full save() self-check at all — pure delta path.
+    const on = simulateAll(program, lastLine, ON_NO_VERIFY);
+
+    expect(on.stats.deltas).toBeGreaterThan(0);
+    expect(on.stats.fallbacks).toBe(0);
+    assertEveryCheckpointRoundTrips(program, on.all);
+  });
+
+  // A scene the route simulator must drive through several forced conditionals
+  // (each a lookahead try/rewind) before reaching the target — exercises the
+  // runtime executedSinceCheckpoint / count-delta tracking across rewinds, in
+  // the pure-delta path (verify OFF) so a rewind-leak would corrupt rather than
+  // silently fall back.
+  const REWIND = `store a = false
+store b = false
+store c = false
+store out = "none"
+
+-> start
+
+scene start
+  Intro line.
+  & a = true
+  if a then
+    & out = "a-open"
+    A opens.
+  else
+    & out = "a-shut"
+    A shut.
+  end
+  & b = true
+  if b then
+    & out = "b-open"
+    B opens.
+  else
+    & out = "b-shut"
+    B shut.
+  end
+  & c = true
+  if c then
+    & out = "c-open"
+    C opens.
+  else
+    & out = "c-shut"
+    C shut.
+  end
+  Final line.
+end
+`;
+  const REWIND_LAST_LINE = 33; // "Final line."
+
+  test("rewind-heavy conditional route reconstructs byte-identically (verify OFF)", () => {
+    const program = compileSrc(REWIND);
+    const diags = (program as any).diagnostics?.[URI] ?? [];
+    expect(diags.filter((d: any) => d?.severity === 1)).toEqual([]);
+
+    const off = simulateAll(program, REWIND_LAST_LINE, OFF);
+    const on = simulateAll(program, REWIND_LAST_LINE, ON_NO_VERIFY);
+
+    expect(on.length).toBe(off.length);
+    expect(on.stats.deltas).toBeGreaterThan(0);
+    expect(on.stats.fallbacks).toBe(0);
+    assertEveryCheckpointRoundTrips(program, on.all);
+  });
+});

--- a/packages/spark-engine/src/tests/core/checkpointSimulation.test.ts
+++ b/packages/spark-engine/src/tests/core/checkpointSimulation.test.ts
@@ -12,11 +12,31 @@
 // not match natural execution — e.g. a forced branch can leave a variable at a
 // value the natural branch wouldn't).
 
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import { SparkdownCompiler } from "@impower/sparkdown/src/compiler/classes/SparkdownCompiler";
 import { Game } from "../../game/core/classes/Game";
 
 const URI = "inmemory:///main.sd";
+
+// The same net runs under both checkpoint storage modes. The delta refactor must
+// be behavior-invariant: full-save mode (OFF) is the legacy baseline; delta mode
+// (ON) stores periodic keyframes + per-beat deltas and must reconstruct
+// byte-identically (a small baseInterval forces many delta beats between
+// keyframes so the delta path is actually exercised).
+const CHECKPOINT_MODES: { label: string; config: Record<string, unknown> }[] = [
+  { label: "full-save checkpoints (flag OFF)", config: {} },
+  {
+    label: "incremental delta checkpoints (flag ON)",
+    config: {
+      incrementalCheckpoints: true,
+      verifyCheckpoints: true,
+      checkpointBaseInterval: 3,
+    },
+  },
+];
+
+// Set by the outer describe.each iteration; folded into every Game created below.
+let ACTIVE_CHECKPOINT_CONFIG: Record<string, unknown> = {};
 
 function compileSrc(src: string) {
   const compiler = new SparkdownCompiler();
@@ -41,6 +61,7 @@ function newGame(program: unknown) {
       fn(...a);
       return 0;
     }) as any,
+    ...ACTIVE_CHECKPOINT_CONFIG,
   } as any);
 }
 
@@ -83,6 +104,14 @@ end
 `;
 const LINEAR_T = { first: 6, second: 8, third: 10, fourth: 12 };
 const LINEAR_VARS = ["score", "flag"];
+
+// Run the entire net once per checkpoint storage mode. `beforeEach` installs the
+// mode's Game config (read by `newGame`) at execution time — not collection time
+// — so each test sees its own mode.
+describe.each(CHECKPOINT_MODES)("$label", (mode) => {
+  beforeEach(() => {
+    ACTIVE_CHECKPOINT_CONFIG = mode.config;
+  });
 
 describe("save / load / simulate (linear)", () => {
   test("simulate() to the last line mutates globals through that point", () => {
@@ -252,3 +281,5 @@ describe("checkpoint round-trip through variable-driven IF routes", () => {
     expect(game2.save()).toBe(cp);
   });
 });
+
+}); // describe.each(CHECKPOINT_MODES)

--- a/packages/spark-web-player/src/main/workers/workspace.worker.ts
+++ b/packages/spark-web-player/src/main/workers/workspace.worker.ts
@@ -23,12 +23,14 @@ compilerState.compiler.addEventListener("compiler/didCompile", (params) => {
       ...gameState.systemConfiguration,
       // This is the live-preview / HMR route-simulation game: it saves a
       // checkpoint at every beat while replaying to the edited line, which is
-      // the O(n^2) cost incremental checkpoints exist to remove. Phase 1 keeps
-      // the byte-identical self-check on (default) — correctness first, memory
-      // win now. Phase 2: once this has been watched running stably, add
-      // `verifyCheckpoints: false` here to drop the per-beat full-save check and
-      // claim the full time win.
+      // the O(n^2) cost incremental checkpoints exist to remove. Deltas store
+      // periodic full keyframes + per-beat deltas; `verifyCheckpoints: false`
+      // drops the per-beat full-save self-check so capture is bounded per beat
+      // (the full time win). The delta reconstruction is covered by the
+      // byte-identical round-trip tests (incl. the pure-delta path); flip verify
+      // back on if a regression ever needs the self-check's fall-back-to-full.
       incrementalCheckpoints: true,
+      verifyCheckpoints: false,
     });
     profile("end", compilerState.compiler.profilerId + " " + "game/create");
   } else {

--- a/packages/spark-web-player/src/main/workers/workspace.worker.ts
+++ b/packages/spark-web-player/src/main/workers/workspace.worker.ts
@@ -21,6 +21,14 @@ compilerState.compiler.addEventListener("compiler/didCompile", (params) => {
       program: params.program,
       story: params.story,
       ...gameState.systemConfiguration,
+      // This is the live-preview / HMR route-simulation game: it saves a
+      // checkpoint at every beat while replaying to the edited line, which is
+      // the O(n^2) cost incremental checkpoints exist to remove. Phase 1 keeps
+      // the byte-identical self-check on (default) — correctness first, memory
+      // win now. Phase 2: once this has been watched running stably, add
+      // `verifyCheckpoints: false` here to drop the per-beat full-save check and
+      // claim the full time win.
+      incrementalCheckpoints: true,
     });
     profile("end", compilerState.compiler.profilerId + " " + "game/create");
   } else {

--- a/packages/sparkdown/src/inkjs/engine/StoryState.ts
+++ b/packages/sparkdown/src/inkjs/engine/StoryState.ts
@@ -43,6 +43,81 @@ export class StoryState {
     return this.ToJson(indented);
   }
 
+  // --- Delta-checkpoint support (spark-engine incremental checkpoints) ---
+  //
+  // These are ADDITIVE hooks for spark-engine's incremental/delta checkpoint
+  // store. They do not change any existing serialization or runtime behavior:
+  // `ToJsonWithoutCounts` is a strict variant of `ToJson` that writes the two
+  // unbounded count maps as empty objects (the store splices the real maps back
+  // in on reconstruction), and the `_changed*` sets are a passive dirty-key log
+  // recorded at the (only) three sites that commit count mutations.
+
+  // When true, WriteJson emits empty visitCounts/turnIndices objects. The
+  // delta-checkpoint store stores this bounded body per beat and re-injects the
+  // (delta-reconstructed) count maps to rebuild a byte-identical full save.
+  private _omitCountsForDelta = false;
+
+  // Dirty-key logs: container paths whose visit count / turn index were
+  // COMMITTED since the last drain. Shared by reference across
+  // CopyAndStartPatching copies (like the count maps themselves), so a drain
+  // from whichever StoryState is current at a beat boundary sees every commit.
+  // Speculative lookahead writes go through the patch and never touch these —
+  // they're only recorded when the patch is applied (ApplyCountChanges) or on
+  // the direct (no-patch) path.
+  private _changedVisitCounts: Set<string> = new Set();
+  private _changedTurnIndices: Set<string> = new Set();
+
+  // Shared immutable empty map used by ToJsonWithoutCounts (never mutated).
+  private static _emptyCounts: Map<string, number> = new Map();
+
+  public ToJsonWithoutCounts(): string {
+    this._omitCountsForDelta = true;
+    try {
+      return this.ToJson();
+    } finally {
+      this._omitCountsForDelta = false;
+    }
+  }
+
+  /** Full ordered snapshot of the visit-count map (Map insertion order). Used
+   *  to seed a delta-checkpoint keyframe. */
+  public GetVisitCountEntries(): [string, number][] {
+    return Array.from(this._visitCounts);
+  }
+
+  /** Full ordered snapshot of the turn-index map. */
+  public GetTurnIndexEntries(): [string, number][] {
+    return Array.from(this._turnIndices);
+  }
+
+  /** Drain the visit-count keys changed since the last drain, returning each
+   *  with its current value (in first-touch order), and clear the log. */
+  public DrainVisitCountDeltas(): [string, number][] {
+    const out: [string, number][] = [];
+    for (const key of this._changedVisitCounts) {
+      out.push([key, this._visitCounts.get(key) ?? 0]);
+    }
+    this._changedVisitCounts.clear();
+    return out;
+  }
+
+  /** Drain the turn-index keys changed since the last drain. */
+  public DrainTurnIndexDeltas(): [string, number][] {
+    const out: [string, number][] = [];
+    for (const key of this._changedTurnIndices) {
+      out.push([key, this._turnIndices.get(key) ?? 0]);
+    }
+    this._changedTurnIndices.clear();
+    return out;
+  }
+
+  /** Discard any pending dirty-key logs (e.g. after a load, where the loaded
+   *  state is the new baseline and there are no pending deltas). */
+  public ResetCountDeltaTracking(): void {
+    this._changedVisitCounts.clear();
+    this._changedTurnIndices.clear();
+  }
+
   public LoadJson(json: string) {
     let jObject = SimpleJson.TextToDictionary(json);
     this.LoadJsonObj(jObject);
@@ -113,6 +188,7 @@ export class StoryState {
     } else {
       this._visitCounts.set(containerPathStr, 1);
     }
+    this._changedVisitCounts.add(containerPathStr);
   }
 
   public RecordTurnIndexVisitToContainer(container: Container) {
@@ -123,6 +199,7 @@ export class StoryState {
 
     let containerPathStr = container.path.toString();
     this._turnIndices.set(containerPathStr, this.currentTurnIndex);
+    this._changedTurnIndices.add(containerPathStr);
   }
 
   public TurnsSinceForContainer(container: Container) {
@@ -613,6 +690,12 @@ export class StoryState {
     copy._visitCounts = this._visitCounts;
     copy._turnIndices = this._turnIndices;
 
+    // Share the delta dirty-key logs by reference alongside the maps they
+    // track, so a checkpoint drain from whichever copy is current sees every
+    // committed mutation regardless of which copy performed it.
+    copy._changedVisitCounts = this._changedVisitCounts;
+    copy._changedTurnIndices = this._changedTurnIndices;
+
     copy.currentTurnIndex = this.currentTurnIndex;
     copy.storySeed = this.storySeed;
     copy.previousRandom = this.previousRandom;
@@ -647,7 +730,9 @@ export class StoryState {
     isVisit: boolean,
   ) {
     let counts = isVisit ? this._visitCounts : this._turnIndices;
-    counts.set(container.path.toString(), newCount);
+    const pathStr = container.path.toString();
+    counts.set(pathStr, newCount);
+    (isVisit ? this._changedVisitCounts : this._changedTurnIndices).add(pathStr);
   }
 
   public WriteJson(writer: SimpleJson.Writer) {
@@ -693,11 +778,21 @@ export class StoryState {
       );
     }
 
+    // Delta-checkpoint bodies write the unbounded count maps as empty objects;
+    // the store re-injects the (delta-reconstructed) maps to rebuild a
+    // byte-identical full save. A normal save writes them in full.
+    const emptyCounts: Map<string, number> = StoryState._emptyCounts;
     writer.WriteProperty("visitCounts", (w) =>
-      JsonSerialisation.WriteIntDictionary(w, this._visitCounts),
+      JsonSerialisation.WriteIntDictionary(
+        w,
+        this._omitCountsForDelta ? emptyCounts : this._visitCounts,
+      ),
     );
     writer.WriteProperty("turnIndices", (w) =>
-      JsonSerialisation.WriteIntDictionary(w, this._turnIndices),
+      JsonSerialisation.WriteIntDictionary(
+        w,
+        this._omitCountsForDelta ? emptyCounts : this._turnIndices,
+      ),
     );
 
     writer.WriteIntProperty("turnIdx", this.currentTurnIndex);
@@ -821,6 +916,9 @@ export class StoryState {
     this.currentTurnIndex = parseInt(jObject["turnIdx"]);
     this.storySeed = parseInt(jObject["storySeed"]);
     this.previousRandom = parseInt(jObject["previousRandom"]);
+
+    // The freshly-loaded state is the new delta baseline — no pending changes.
+    this.ResetCountDeltaTracking();
   }
 
   public ResetErrors() {


### PR DESCRIPTION
## What

Eliminates the O(n²) time + memory cost of live-preview / HMR route simulation, where the engine saves a checkpoint at **every** beat while replaying to the edited line. Each checkpoint was a full `save()` whose dominant payload (the ink `visitCounts`/`turnIndices` maps and the runtime executed-paths/choices/conditions) grows with the number of beats — N checkpoints × O(N) state = O(n²).

A flag-gated `CheckpointStore` stores periodic full **keyframes** (every K beats) plus per-beat **deltas**, reconstructing full save strings lazily. The integer `step.checkpoint` index contract and the `game.checkpoints.at(-1)` contract are preserved.

## How

Deltas capture only the unbounded, per-beat-growing collections; the bounded rest (callstack, output stream, pointer, RNG, modules) is full-copied per beat.

- **Story count maps** — `StoryState` records changed visit/turn keys at the three commit sites (shared across `CopyAndStartPatching` copies), drained per beat; `ToJsonWithoutCounts` emits a bounded body.
- **Runtime collections** — `RuntimeState` mirrors per-beat executions into `executedSinceCheckpoint` (snapshot/restored with the lookahead so rewinds don't leak) plus append-only drain marks for choices/conditions.
- Reconstruction replays deltas onto the nearest keyframe and is **byte-identical**, reusing the same `JSON.stringify` shapes the engine serializers produce.

## Safety

- Default **OFF** — a settled kill switch (`incrementalCheckpoints`).
- When ON, `verifyCheckpoints` asserts every delta is byte-identical to a real `save()` and **falls back to a full keyframe on any mismatch** — a delta bug degrades to "stored a full save", never a silent corruption.
- The HMR simulation worker enables it and, now that the byte-identical round-trip tests cover the pure-delta path, sets `verifyCheckpoints: false` for the full time win.

## Verification

- `checkpointSimulation.test.ts` — the 9-test characterization net runs under **both flag states** (18 tests).
- `checkpointDelta.test.ts` — proves the delta path is exercised with **zero fallbacks**, every reconstructed checkpoint loads + re-saves **byte-identically**, including the **pure-delta (verify OFF)** path and a **rewind-heavy** conditional route.
- Full suites green: spark-engine 143 · spark-web-player 31 · sparkdown serialization 26.
- Live smoke test: pasted a 1,715-line script into the editor; clicking a line ~1,700 deep rendered the correct beat through the delta checkpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
