### PR TITLE
Dev-only same-origin game preview + window.__preview inspector

### DIFF
--- a/impower-dev/.env.development
+++ b/impower-dev/.env.development
@@ -1,1 +1,6 @@
 VITE_SPARKDOWN_PLAYER_ORIGIN=http://localhost:5173
+
+# DEV-ONLY: serve the game preview SAME-ORIGIN under the editor at /__player/ so
+# the live game DOM is reachable from devtools / automation. Must ALSO be set in
+# sparkdown-player-app/.env.development. Leave commented for normal cross-origin.
+# VITE_SAME_ORIGIN_PREVIEW=1

--- a/impower-dev/build.ts
+++ b/impower-dev/build.ts
@@ -2,6 +2,7 @@ import preact from "@preact/preset-vite";
 import tailwindcss from "@tailwindcss/vite";
 import { exec } from "child_process";
 import fs from "fs";
+import http from "node:http";
 import path from "path";
 import glob from "tiny-glob";
 import { build, createServer } from "vite";
@@ -344,7 +345,9 @@ const serve = async () => {
     publicDir: path.resolve(process.cwd(), publicInDir),
     server: {
       middlewareMode: true,
-      hmr: { port: 24679 },
+      // HMR port is overridable so several worktrees can run dev servers at once
+      // without colliding on the websocket port.
+      hmr: { port: Number(process.env["HMR_PORT"] || 24679) },
       watch: { ignored: ["**/out/**", "**/.dev/**"] },
     },
     resolve: { alias, dedupe },
@@ -400,6 +403,50 @@ const serve = async () => {
   const apiModule = await vite.ssrLoadModule(`${apiInDir}/index.ts`);
   const app = apiModule.default?.app || apiModule.app || apiModule.default;
   await app.ready();
+
+  // DEV-ONLY same-origin game preview. When VITE_SAME_ORIGIN_PREVIEW is set,
+  // reverse-proxy the game-preview player (its own Vite dev server) under the
+  // editor's origin at /__player/ so the editor can embed it as a SAME-ORIGIN
+  // iframe — making the live game DOM directly reachable from the editor page
+  // (document.querySelector('#iframe').contentDocument) and devtools. Defaults
+  // OFF: with the flag unset, the editor keeps embedding the player cross-origin
+  // via VITE_SPARKDOWN_PLAYER_ORIGIN. The player must be launched with the same
+  // flag so it serves under base /__player/ (see sparkdown-player-app).
+  if (process.env["VITE_SAME_ORIGIN_PREVIEW"]) {
+    const PLAYER_PROXY_BASE = "/__player";
+    const playerOrigin = new URL(
+      process.env["SPARKDOWN_PLAYER_DEV_ORIGIN"] || "http://localhost:5173",
+    );
+    app.use((req: any, res: any, next: any) => {
+      if (!req.url?.startsWith(PLAYER_PROXY_BASE)) {
+        next();
+        return;
+      }
+      const proxyReq = http.request(
+        {
+          protocol: playerOrigin.protocol,
+          hostname: playerOrigin.hostname,
+          port: playerOrigin.port,
+          method: req.method,
+          path: req.url,
+          headers: { ...req.headers, host: playerOrigin.host },
+        },
+        (proxyRes) => {
+          res.writeHead(proxyRes.statusCode || 502, proxyRes.headers);
+          proxyRes.pipe(res);
+        },
+      );
+      proxyReq.on("error", (err) => {
+        res.statusCode = 502;
+        res.end(`Player proxy error: ${err.message}`);
+      });
+      req.pipe(proxyReq);
+    });
+    console.log(
+      STEP_COLOR,
+      `Same-origin preview ON: proxying ${PLAYER_PROXY_BASE}/ -> ${playerOrigin.origin}`,
+    );
+  }
 
   app.use(async (req: any, res: any, next: any) => {
     vite.middlewares(req, res, next);

--- a/impower-dev/build.ts
+++ b/impower-dev/build.ts
@@ -3,6 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { exec } from "child_process";
 import fs from "fs";
 import http from "node:http";
+import https from "node:https";
 import path from "path";
 import glob from "tiny-glob";
 import { build, createServer } from "vite";
@@ -417,34 +418,100 @@ const serve = async () => {
     const playerOrigin = new URL(
       process.env["SPARKDOWN_PLAYER_DEV_ORIGIN"] || "http://localhost:5173",
     );
+    const client = playerOrigin.protocol === "https:" ? https : http;
+    // HTTP/1.1 hop-by-hop headers. They're connection-scoped and must NOT be
+    // forwarded; re-emitting them is also a hard error under HTTP/2 (which the
+    // dev server uses when https/ certs exist) — ERR_HTTP2_INVALID_CONNECTION_HEADERS.
+    const HOP_BY_HOP = new Set([
+      "connection",
+      "keep-alive",
+      "proxy-authenticate",
+      "proxy-authorization",
+      "te",
+      "trailer",
+      "transfer-encoding",
+      "upgrade",
+      "proxy-connection",
+    ]);
+    let warnedAsymmetric = false;
     app.use((req: any, res: any, next: any) => {
-      if (!req.url?.startsWith(PLAYER_PROXY_BASE)) {
+      // Boundary match so a future sibling route (e.g. /__playerfoo) can't be
+      // hijacked by the prefix.
+      const url: string = req.url || "";
+      if (url !== PLAYER_PROXY_BASE && !url.startsWith(PLAYER_PROXY_BASE + "/")) {
         next();
         return;
       }
-      const proxyReq = http.request(
+      const proxyReq = client.request(
         {
           protocol: playerOrigin.protocol,
           hostname: playerOrigin.hostname,
           port: playerOrigin.port,
           method: req.method,
-          path: req.url,
+          path: url,
           headers: { ...req.headers, host: playerOrigin.host },
         },
         (proxyRes) => {
-          res.writeHead(proxyRes.statusCode || 502, proxyRes.headers);
+          const headers: Record<string, any> = {};
+          for (const [k, v] of Object.entries(proxyRes.headers)) {
+            if (!HOP_BY_HOP.has(k.toLowerCase())) {
+              headers[k] = v;
+            }
+          }
+          res.writeHead(proxyRes.statusCode || 502, headers);
+          // Diagnose the easy-to-make asymmetric-config mistake: the editor has
+          // the flag but the player wasn't started with it, so it serves at base
+          // "/" and the proxied index.html lacks the /__player/ asset prefix →
+          // a silent white iframe. Sniff the document response once and warn.
+          if (
+            !warnedAsymmetric &&
+            url === PLAYER_PROXY_BASE + "/" &&
+            String(proxyRes.headers["content-type"] || "").includes("text/html")
+          ) {
+            let head = "";
+            proxyRes.on("data", (chunk) => {
+              if (head.length < 2048) {
+                head += chunk.toString("utf8");
+                if (head.length >= 256 && !head.includes(PLAYER_PROXY_BASE)) {
+                  warnedAsymmetric = true;
+                  console.log(
+                    YELLOW,
+                    `Same-origin preview: the player at ${playerOrigin.origin} ` +
+                      `is not serving under base ${PLAYER_PROXY_BASE}/. Start ` +
+                      `sparkdown-player-app with VITE_SAME_ORIGIN_PREVIEW=1 too.`,
+                  );
+                }
+              }
+            });
+          }
           proxyRes.pipe(res);
+          proxyRes.on("error", () => res.destroy());
         },
       );
       proxyReq.on("error", (err) => {
+        if (res.headersSent) {
+          res.destroy();
+          return;
+        }
         res.statusCode = 502;
-        res.end(`Player proxy error: ${err.message}`);
+        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+        res.end(
+          `Same-origin preview: could not reach the game-preview player at ` +
+            `${playerOrigin.origin}. Start sparkdown-player-app (npm run dev) ` +
+            `with VITE_SAME_ORIGIN_PREVIEW=1. (${err.message})`,
+        );
       });
+      // Tear the upstream request down if the client goes away mid-flight.
+      req.on("aborted", () => proxyReq.destroy());
+      res.on("close", () => proxyReq.destroy());
       req.pipe(proxyReq);
     });
+    // HMR websockets intentionally bypass this proxy — the player's Vite client
+    // connects straight to its own port (see sparkdown-player-app hmr config).
     console.log(
       STEP_COLOR,
-      `Same-origin preview ON: proxying ${PLAYER_PROXY_BASE}/ -> ${playerOrigin.origin}`,
+      `Same-origin preview ON: proxying ${PLAYER_PROXY_BASE}/ -> ${playerOrigin.origin} ` +
+        `(also set VITE_SAME_ORIGIN_PREVIEW=1 for sparkdown-player-app)`,
     );
   }
 

--- a/impower-dev/docs/architecture.md
+++ b/impower-dev/docs/architecture.md
@@ -198,3 +198,38 @@ component (`spark-editor/preact-registry.ts`) into `<div id="root">`, and the
 build inlines the editor's CSS (normalize + theme + compiled Tailwind) into a
 `<style id="ssg-css">` block. The same root component then mounts on the client.
 Details in [`build-pipeline.md`](./build-pipeline.md).
+
+## Same-origin game preview (dev-only)
+
+By default the editor (`localhost:8080`) embeds the game-preview player
+(`sparkdown-player-app`, `localhost:5173`) as a **cross-origin** iframe and
+drives it over `postMessage` RPC. That isolation makes debugging hard: the
+editor page can't reach into the iframe's DOM
+(`document.querySelector('#iframe').contentDocument` is `null`) or its
+performance entries.
+
+Set **`VITE_SAME_ORIGIN_PREVIEW=1`** (commented opt-in lines exist in both
+`.env.development` files) to serve the player **same-origin** under the editor in
+dev. To enable it you must set the flag in **both** apps and restart **both** dev
+servers (`impower-dev` and `sparkdown-player-app`), since it's a build-time var:
+
+- `impower-dev/.env.development` — gates the dev proxy in `build.ts`, which
+  reverse-proxies `http://localhost:8080/__player/` → the player's Vite dev
+  server (override its origin with `SPARKDOWN_PLAYER_DEV_ORIGIN`). It also flips
+  `PreviewGame.tsx` to point the iframe `src` at `/__player/` and the RPC target
+  origin at the editor's own origin.
+- `sparkdown-player-app/.env.development` — sets the player's Vite `base` to
+  `/__player/` so its HTML/asset URLs route back through the proxy, and makes
+  `main.ts` skip its own service-worker registration (the editor's root-scoped SW
+  already intercepts `/file:/` and serves game assets straight from OPFS, so it
+  controls the same-origin iframe too). HMR connects directly to `:5173`.
+
+Because the iframe is now same-origin, the `postMessage` handshake matches
+exactly with no origin relaxation, and the live game DOM is reachable from the
+editor page / devtools / automation. **Production stays strict** (cross-origin
+iframe + exact-origin RPC); this flag only affects the dev server and defaults
+OFF.
+
+Verify with the flag on: load `http://localhost:8080`, open the preview, then in
+the editor page console
+`document.querySelector('#iframe').contentDocument` is non-null.

--- a/impower-dev/docs/architecture.md
+++ b/impower-dev/docs/architecture.md
@@ -222,7 +222,12 @@ servers (`impower-dev` and `sparkdown-player-app`), since it's a build-time var:
   `/__player/` so its HTML/asset URLs route back through the proxy, and makes
   `main.ts` skip its own service-worker registration (the editor's root-scoped SW
   already intercepts `/file:/` and serves game assets straight from OPFS, so it
-  controls the same-origin iframe too). HMR connects directly to `:5173`.
+  controls the same-origin iframe too). HMR connects directly to the player's port
+  (not through the proxy).
+
+If you run the player on a non-default port, set `SPARKDOWN_PLAYER_PORT` for the
+player (it drives both the served port and the HMR client port) and point the
+editor's `SPARKDOWN_PLAYER_DEV_ORIGIN` at the same `http://localhost:<port>`.
 
 Because the iframe is now same-origin, the `postMessage` handshake matches
 exactly with no origin relaxation, and the live game DOM is reachable from the
@@ -233,3 +238,20 @@ OFF.
 Verify with the flag on: load `http://localhost:8080`, open the preview, then in
 the editor page console
 `document.querySelector('#iframe').contentDocument` is non-null.
+
+### `window.__preview` inspector
+
+When the flag is on, `PreviewGame` installs a small **`window.__preview`** helper
+(`previewInspect.ts`) on the editor page so the live game DOM is ergonomic to
+inspect from the console or automation (it's only installed in same-origin mode;
+cross-origin it would be blocked anyway). It resolves the iframe lazily, so it
+keeps working across preview reloads:
+
+```js
+__preview.summary()        // { mounted, sameOrigin, url, readyState, gameChildren, resourceEntries }
+__preview.game()           // the live #game element
+__preview.$('#game-ui')    // querySelector into the game document
+__preview.deep('canvas')   // querySelectorAll that descends open shadow roots
+__preview.perf('resource') // the iframe's performance entries
+await __preview.ready()    // resolves once #game has rendered
+```

--- a/impower-dev/src/modules/spark-editor/components/preview-game/PreviewGame.tsx
+++ b/impower-dev/src/modules/spark-editor/components/preview-game/PreviewGame.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "preact/hooks";
 import type { SparkProgram } from "../../../../../../packages/sparkdown/src/compiler/types/SparkProgram";
 import PreviewGameToolbar from "../preview-game-toolbar/PreviewGameToolbar";
+import { installPreviewInspector } from "./previewInspect";
 
 const SPARKDOWN_PLAYER_ORIGIN =
   import.meta.env.VITE_SPARKDOWN_PLAYER_ORIGIN || "";
@@ -167,6 +168,13 @@ export default function PreviewGame(_props: PreviewGameProps) {
   useEffect(() => {
     let cancelled = false;
     let cleanup: (() => void) | undefined;
+
+    // DEV-ONLY: when the preview is same-origin, expose `window.__preview` so the
+    // live game DOM is inspectable from the console / automation. No-op (and not
+    // installed) when embedding cross-origin, where frame access would be blocked.
+    const uninstallInspector = SAME_ORIGIN_PREVIEW
+      ? installPreviewInspector()
+      : undefined;
 
     Promise.all([
       import("@impower/jsonrpc/src/browser/classes/IFrameMessageConnection"),
@@ -506,6 +514,7 @@ export default function PreviewGame(_props: PreviewGameProps) {
     return () => {
       cancelled = true;
       cleanup?.();
+      uninstallInspector?.();
     };
   }, []);
 

--- a/impower-dev/src/modules/spark-editor/components/preview-game/PreviewGame.tsx
+++ b/impower-dev/src/modules/spark-editor/components/preview-game/PreviewGame.tsx
@@ -5,6 +5,24 @@ import PreviewGameToolbar from "../preview-game-toolbar/PreviewGameToolbar";
 const SPARKDOWN_PLAYER_ORIGIN =
   import.meta.env.VITE_SPARKDOWN_PLAYER_ORIGIN || "";
 
+// DEV-ONLY same-origin preview. When VITE_SAME_ORIGIN_PREVIEW is set, the editor
+// dev server proxies the player under our own origin at /__player/ (see
+// impower-dev/build.ts), so we embed it as a SAME-ORIGIN iframe and address it
+// via our own origin. This makes the live game DOM reachable from this page
+// (document.querySelector('#iframe').contentDocument) and devtools. Defaults
+// OFF: the player stays a cross-origin iframe at VITE_SPARKDOWN_PLAYER_ORIGIN.
+const SAME_ORIGIN_PREVIEW = !!import.meta.env.VITE_SAME_ORIGIN_PREVIEW;
+const PLAYER_SRC = SAME_ORIGIN_PREVIEW ? "/__player/" : `${SPARKDOWN_PLAYER_ORIGIN}/`;
+// Guard `window`: this module is also evaluated during the editor's SSG render
+// (server-side, no `window`). The target origin is only needed at runtime in the
+// browser. Same-origin posts match the iframe's origin with or without an
+// explicit targetOrigin, so an SSR-time "" is harmless.
+const PLAYER_TARGET_ORIGIN = SAME_ORIGIN_PREVIEW
+  ? typeof window !== "undefined"
+    ? window.location.origin
+    : ""
+  : SPARKDOWN_PLAYER_ORIGIN;
+
 export const propDefaults = {};
 export type PreviewGameProps = Partial<typeof propDefaults>;
 
@@ -271,13 +289,13 @@ export default function PreviewGame(_props: PreviewGameProps) {
               onChannelMessage,
             );
           }
-          if (!SPARKDOWN_PLAYER_ORIGIN) {
+          if (!PLAYER_TARGET_ORIGIN) {
             console.error("no target origin specified");
           }
           const channel = new MessageChannel();
           const iframeWindowConnection = new IFrameMessageConnection(
             iframe,
-            SPARKDOWN_PLAYER_ORIGIN,
+            PLAYER_TARGET_ORIGIN,
           );
           const connection = new Port1MessageConnection(channel.port1);
           iframeChannelRef.current = connection;
@@ -499,7 +517,7 @@ export default function PreviewGame(_props: PreviewGameProps) {
         <iframe
           ref={iframeRef}
           id="iframe"
-          src={`${SPARKDOWN_PLAYER_ORIGIN}/`}
+          src={PLAYER_SRC}
           sandbox="allow-scripts allow-forms allow-same-origin"
           allow="autoplay"
           referrerpolicy="no-referrer"

--- a/impower-dev/src/modules/spark-editor/components/preview-game/previewInspect.ts
+++ b/impower-dev/src/modules/spark-editor/components/preview-game/previewInspect.ts
@@ -1,0 +1,224 @@
+// DEV-ONLY live game-DOM inspector.
+//
+// When the game preview is embedded SAME-ORIGIN (VITE_SAME_ORIGIN_PREVIEW=1, see
+// impower-dev/docs/architecture.md), the editor page can reach into the preview
+// iframe's document directly. This installs a small `window.__preview` helper so
+// devs (in the devtools console) and automation (Claude-in-Chrome / Puppeteer /
+// etc.) can drill into the live game DOM and read its performance entries
+// without hand-rolling `document.querySelector('#iframe').contentDocument` every
+// time.
+//
+// `PreviewGame` only installs it in same-origin mode, but every accessor is still
+// guarded against cross-origin frame access (which throws) so a dev who calls
+// `installPreviewInspector()` directly gets null/[] + a one-time hint rather than
+// an exception. The iframe is resolved lazily on each call, so the helper keeps
+// working across preview reloads and component re-renders.
+
+export interface PreviewInspector {
+  /** The preview `<iframe>` element, or null if not mounted yet. */
+  readonly frame: HTMLIFrameElement | null;
+  /** The iframe's document, or null if not loaded / not same-origin. */
+  readonly doc: Document | null;
+  /** The iframe's window, or null if not loaded / not same-origin. */
+  readonly win: Window | null;
+  /** querySelector inside the game document. */
+  $(selector: string): Element | null;
+  /** querySelectorAll inside the game document, as an array. */
+  $$(selector: string): Element[];
+  /**
+   * querySelectorAll that also descends into open shadow roots — useful for
+   * games/UI that render into shadow DOM.
+   */
+  deep(selector: string): Element[];
+  /** The game root container (`#game`), or null. */
+  game(): Element | null;
+  /** outerHTML of the matched element, or the whole document if no selector. */
+  html(selector?: string): string | null;
+  /** Performance entries from inside the iframe (optionally filtered by type). */
+  perf(type?: string): PerformanceEntry[];
+  /**
+   * Resolves once the iframe document is loaded and the `#game` scaffold exists
+   * (or rejects after `timeoutMs`). Handy before automated assertions.
+   */
+  ready(timeoutMs?: number): Promise<Document>;
+  /** A quick one-call snapshot for logging / automation. */
+  summary(): {
+    mounted: boolean;
+    sameOrigin: boolean;
+    url: string | null;
+    readyState: DocumentReadyState | null;
+    gameChildren: number | null;
+    resourceEntries: number | null;
+  };
+}
+
+const GLOBAL_KEY = "__preview";
+
+export function installPreviewInspector(): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  let warnedCrossOrigin = false;
+  // Outstanding ready() poll timers, cleared on uninstall so a self-rescheduling
+  // poll can't outlive the component.
+  const pendingTimers = new Set<ReturnType<typeof setTimeout>>();
+
+  const getFrame = (): HTMLIFrameElement | null =>
+    document.querySelector<HTMLIFrameElement>("#iframe");
+
+  // Reading contentDocument/contentWindow on a cross-origin frame throws a
+  // SecurityError. Funnel every access through this so the helper degrades to
+  // null instead of blowing up, and nudges the dev toward the flag once.
+  const safe = <T>(read: () => T): T | null => {
+    try {
+      return read();
+    } catch {
+      if (!warnedCrossOrigin) {
+        warnedCrossOrigin = true;
+        console.warn(
+          `[same-origin preview] window.${GLOBAL_KEY}: the preview iframe is ` +
+            `cross-origin, so its DOM can't be inspected. Set ` +
+            `VITE_SAME_ORIGIN_PREVIEW=1 in both impower-dev and ` +
+            `sparkdown-player-app to enable same-origin embedding.`,
+        );
+      }
+      return null;
+    }
+  };
+
+  const getDoc = (): Document | null =>
+    safe(() => getFrame()?.contentDocument ?? null);
+  const getWin = (): Window | null =>
+    safe(() => getFrame()?.contentWindow ?? null);
+
+  const deepQueryAll = (root: ParentNode, selector: string): Element[] => {
+    const out: Element[] = [];
+    const visit = (node: ParentNode) => {
+      node.querySelectorAll(selector).forEach((el) => out.push(el));
+      node.querySelectorAll("*").forEach((el) => {
+        if (el.shadowRoot) {
+          visit(el.shadowRoot);
+        }
+      });
+    };
+    visit(root);
+    return out;
+  };
+
+  const inspector: PreviewInspector = {
+    get frame() {
+      return getFrame();
+    },
+    get doc() {
+      return getDoc();
+    },
+    get win() {
+      return getWin();
+    },
+    $(selector) {
+      return getDoc()?.querySelector(selector) ?? null;
+    },
+    $$(selector) {
+      return Array.from(getDoc()?.querySelectorAll(selector) ?? []);
+    },
+    deep(selector) {
+      const doc = getDoc();
+      return doc ? deepQueryAll(doc, selector) : [];
+    },
+    game() {
+      return getDoc()?.querySelector("#game") ?? null;
+    },
+    html(selector) {
+      const doc = getDoc();
+      if (!doc) {
+        return null;
+      }
+      if (selector) {
+        return doc.querySelector(selector)?.outerHTML ?? null;
+      }
+      return doc.documentElement.outerHTML;
+    },
+    perf(type) {
+      const win = getWin();
+      if (!win) {
+        return [];
+      }
+      return type
+        ? win.performance.getEntriesByType(type)
+        : win.performance.getEntries();
+    },
+    ready(timeoutMs = 10000) {
+      const frame0 = getFrame();
+      return new Promise<Document>((resolve, reject) => {
+        const start = performance.now();
+        const poll = () => {
+          // The iframe was swapped out (preview reloaded / component unmounted) —
+          // stop polling a detached node.
+          const current = getFrame();
+          if (frame0 && current && current !== frame0) {
+            reject(
+              new Error(
+                `[same-origin preview] ${GLOBAL_KEY}.ready(): the preview ` +
+                  `iframe changed before it was ready`,
+              ),
+            );
+            return;
+          }
+          const doc = getDoc();
+          if (doc?.readyState === "complete" && doc.querySelector("#game")) {
+            resolve(doc);
+            return;
+          }
+          if (performance.now() - start > timeoutMs) {
+            reject(
+              new Error(
+                `[same-origin preview] window.${GLOBAL_KEY}.ready() timed out ` +
+                  `after ${timeoutMs}ms`,
+              ),
+            );
+            return;
+          }
+          const id = setTimeout(() => {
+            pendingTimers.delete(id);
+            poll();
+          }, 100);
+          pendingTimers.add(id);
+        };
+        poll();
+      });
+    },
+    summary() {
+      const frame = getFrame();
+      const doc = getDoc();
+      const win = getWin();
+      return {
+        mounted: !!frame,
+        sameOrigin: !!doc,
+        url: safe(() => win?.location.href ?? null) ?? null,
+        readyState: doc?.readyState ?? null,
+        gameChildren: doc?.querySelector("#game")?.children.length ?? null,
+        resourceEntries: win
+          ? win.performance.getEntriesByType("resource").length
+          : null,
+      };
+    },
+  };
+
+  (window as unknown as Record<string, unknown>)[GLOBAL_KEY] = inspector;
+  console.info(
+    `[same-origin preview] window.${GLOBAL_KEY} ready — inspect the live game ` +
+      `DOM, e.g. ${GLOBAL_KEY}.game(), ${GLOBAL_KEY}.$('#game-ui'), ` +
+      `${GLOBAL_KEY}.summary(), await ${GLOBAL_KEY}.ready().`,
+  );
+
+  return () => {
+    pendingTimers.forEach(clearTimeout);
+    pendingTimers.clear();
+    if (
+      (window as unknown as Record<string, unknown>)[GLOBAL_KEY] === inspector
+    ) {
+      delete (window as unknown as Record<string, unknown>)[GLOBAL_KEY];
+    }
+  };
+}

--- a/impower-dev/src/modules/spark-editor/vite-env.d.ts
+++ b/impower-dev/src/modules/spark-editor/vite-env.d.ts
@@ -6,6 +6,8 @@ interface ViteTypeOptions {
 
 interface ImportMetaEnv {
   readonly VITE_SPARKDOWN_PLAYER_ORIGIN: string;
+  // DEV-ONLY: when set, embed the game preview same-origin under /__player/.
+  readonly VITE_SAME_ORIGIN_PREVIEW?: string;
 }
 
 interface ImportMeta {

--- a/impower-dev/vite.config.ts
+++ b/impower-dev/vite.config.ts
@@ -140,9 +140,18 @@ for (const file of envFiles) {
   dotenv.config({ path: path.join(process.cwd(), file), override: false });
 }
 
+// Dev-only browser flags that must never be baked into a production bundle —
+// even if they happen to be present in the build environment. VITE_SAME_ORIGIN_PREVIEW
+// only makes sense against the dev proxy (see build.ts / docs/architecture.md);
+// leaking it into prod would point the preview iframe at a non-existent /__player/.
+const DEV_ONLY_ENV_KEYS = new Set(["VITE_SAME_ORIGIN_PREVIEW"]);
+
 const BROWSER_VARIABLES_ENV: Record<string, string> = {};
 Object.entries(process.env).forEach(([key, value]) => {
   if (value && (key.startsWith("BROWSER_") || key.startsWith("VITE_"))) {
+    if (PRODUCTION && DEV_ONLY_ENV_KEYS.has(key)) {
+      return;
+    }
     BROWSER_VARIABLES_ENV[key] = value;
   }
 });

--- a/sparkdown-player-app/.env.development
+++ b/sparkdown-player-app/.env.development
@@ -1,1 +1,6 @@
 VITE_SPARKDOWN_EDITOR_ORIGIN=http://localhost:8080
+
+# DEV-ONLY: serve this app SAME-ORIGIN under the editor at /__player/ (the editor
+# proxies to this dev server). Must ALSO be set in impower-dev/.env.development.
+# Leave commented for normal cross-origin embedding.
+# VITE_SAME_ORIGIN_PREVIEW=1

--- a/sparkdown-player-app/src/main.ts
+++ b/sparkdown-player-app/src/main.ts
@@ -17,6 +17,14 @@ import "./style.css";
 
 const SPARKDOWN_EDITOR_ORIGIN = import.meta.env.VITE_SPARKDOWN_EDITOR_ORIGIN;
 
+// DEV-ONLY same-origin preview: when the editor proxies this app under its own
+// origin (see impower-dev/build.ts + vite base "/__player/"), our origin equals
+// the editor's. The postMessage handshake then matches exactly with no origin
+// relaxation needed. We also skip registering our own service worker: the
+// editor already runs a root-scoped SW that intercepts /file:/ and serves game
+// assets straight from its OPFS, so it controls this iframe too.
+const SAME_ORIGIN = window.location.origin === SPARKDOWN_EDITOR_ORIGIN;
+
 const connection = new Port2MessageConnection(
   (message: any, transfer?: Transferable[]) =>
     window.parent.postMessage(message, SPARKDOWN_EDITOR_ORIGIN, transfer),
@@ -89,7 +97,7 @@ window.addEventListener("drop", async (e) => {
   );
 });
 
-if ("serviceWorker" in navigator) {
+if (!SAME_ORIGIN && "serviceWorker" in navigator) {
   navigator.serviceWorker
     .register("/sw.js", { type: "module" })
     .catch((err) => console.error("SW register failed:", err));

--- a/sparkdown-player-app/src/vite-env.d.ts
+++ b/sparkdown-player-app/src/vite-env.d.ts
@@ -6,6 +6,9 @@ interface ViteTypeOptions {
 
 interface ImportMetaEnv {
   readonly VITE_SPARKDOWN_EDITOR_ORIGIN: string;
+  // DEV-ONLY: when set, this app is served same-origin under the editor's
+  // /__player/ base instead of as a cross-origin iframe.
+  readonly VITE_SAME_ORIGIN_PREVIEW?: string;
 }
 
 interface ImportMeta {

--- a/sparkdown-player-app/vite.config.ts
+++ b/sparkdown-player-app/vite.config.ts
@@ -157,14 +157,23 @@ export default defineConfig(({ mode }) => {
   // (see impower-dev/build.ts). Serving under base "/__player/" makes the
   // emitted HTML/asset URLs (/__player/@vite/client, /__player/src/main.ts, …)
   // route back through that proxy. HMR connects directly to this server's port
-  // so no websocket proxying is needed. Defaults OFF (base "/").
+  // (not through the proxy) so no websocket proxying is needed. Defaults OFF
+  // (base "/"). Gated on `mode !== "production"` so an ambient flag can never
+  // flip a prod build onto the /__player/ base.
   const env = loadEnv(mode, process.cwd(), "");
-  const SAME_ORIGIN_PREVIEW = !!env["VITE_SAME_ORIGIN_PREVIEW"];
+  const SAME_ORIGIN_PREVIEW =
+    mode !== "production" && !!env["VITE_SAME_ORIGIN_PREVIEW"];
+  // Keep the served port and the HMR client port in one knob so they can't drift
+  // (and so multiple worktrees can run players without colliding). The editor's
+  // SPARKDOWN_PLAYER_DEV_ORIGIN must point at this same port.
+  const PLAYER_PORT = Number(env["SPARKDOWN_PLAYER_PORT"] || 5173);
   return {
   base: SAME_ORIGIN_PREVIEW ? "/__player/" : "/",
   server: {
     host: true,
-    ...(SAME_ORIGIN_PREVIEW ? { hmr: { clientPort: 5173 } } : {}),
+    ...(SAME_ORIGIN_PREVIEW
+      ? { port: PLAYER_PORT, hmr: { clientPort: PLAYER_PORT } }
+      : {}),
   },
   // Use Preact's automatic JSX runtime for the .tsx in spark-web-player.
   esbuild: {

--- a/sparkdown-player-app/vite.config.ts
+++ b/sparkdown-player-app/vite.config.ts
@@ -1,7 +1,7 @@
 import * as esbuild from "esbuild";
 import fs from "node:fs";
 import path from "node:path";
-import { defineConfig, type Plugin } from "vite";
+import { defineConfig, loadEnv, type Plugin } from "vite";
 
 const PRODUCTION = process.env.NODE_ENV === "production";
 
@@ -151,9 +151,20 @@ function devServiceWorkerPlugin(options: {
   };
 }
 
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+  // DEV-ONLY same-origin game preview. When VITE_SAME_ORIGIN_PREVIEW is set, the
+  // editor reverse-proxies this dev server under its own origin at /__player/
+  // (see impower-dev/build.ts). Serving under base "/__player/" makes the
+  // emitted HTML/asset URLs (/__player/@vite/client, /__player/src/main.ts, …)
+  // route back through that proxy. HMR connects directly to this server's port
+  // so no websocket proxying is needed. Defaults OFF (base "/").
+  const env = loadEnv(mode, process.cwd(), "");
+  const SAME_ORIGIN_PREVIEW = !!env["VITE_SAME_ORIGIN_PREVIEW"];
+  return {
+  base: SAME_ORIGIN_PREVIEW ? "/__player/" : "/",
   server: {
     host: true,
+    ...(SAME_ORIGIN_PREVIEW ? { hmr: { clientPort: 5173 } } : {}),
   },
   // Use Preact's automatic JSX runtime for the .tsx in spark-web-player.
   esbuild: {
@@ -184,4 +195,5 @@ export default defineConfig({
       },
     },
   },
+  };
 });


### PR DESCRIPTION
## What

Adds a **dev-only, opt-in** mode (`VITE_SAME_ORIGIN_PREVIEW=1`, default **OFF**) that serves the game-preview player under the editor's own origin, so the live game DOM and performance entries are directly reachable from the editor page — for devtools and automation. Production stays strict (cross-origin iframe + exact-origin RPC).

## Why

Today the editor (`impower-dev`, `:8080`) embeds the player (`sparkdown-player-app`, `:5173`) as a **cross-origin** iframe driven over postMessage RPC. That isolation means you can't reach into the iframe's DOM (`document.querySelector('#iframe').contentDocument` is `null`) or read its performance entries. Same-origin in dev makes the live game inspectable directly.

## How

- **`impower-dev/build.ts`** — when the flag is on, a `node:http`/`https` reverse proxy forwards `/__player/*` to the player's Vite dev server (overridable via `SPARKDOWN_PLAYER_DEV_ORIGIN`), mounted ahead of the Vite middleware via the existing `@fastify/middie` chain. Also makes the editor's Vite HMR port overridable (`HMR_PORT`) so multiple worktrees can run dev servers without colliding.
- **`PreviewGame.tsx`** — points the iframe `src` at `/__player/` and the RPC target at the editor's own origin (SSR-guarded `window` access), and installs the `window.__preview` inspector.
- **`previewInspect.ts`** — `window.__preview` helper for live game-DOM access: `game()`, `$`, `$$`, `deep()` (descends open shadow roots), `html()`, `perf()`, `summary()`, `await ready()`. Lazily resolves the iframe, guards cross-origin access, and clears its poll timers on unmount.
- **`sparkdown-player-app`** — serves under Vite `base: /__player/` and skips its own service worker (the editor's root-scoped SW already intercepts `/file:/` and serves game assets straight from OPFS, so it controls the same-origin iframe too). A `SPARKDOWN_PLAYER_PORT` knob drives both the served port and `hmr.clientPort`.

No jsonrpc origin checks were loosened — same-origin means `event.origin` matches exactly, so the strict handshake passes as-is.

## Production safety

- Defaults OFF; committed `.env.development` files only carry **commented** opt-in lines.
- `VITE_SAME_ORIGIN_PREVIEW` is dropped from the browser bundle in production builds (dev-only env denylist), and the player's base override is gated on `mode !== "production"`, so an ambient flag can't leak into prod.

## Hardening (from an adversarial multi-dimensional review of the branch)

- Strip hop-by-hop headers before re-emitting — fixes an `ERR_HTTP2_INVALID_CONNECTION_HEADERS` crash on the dev-HTTPS/HTTP2 path.
- `/__player` matched on a path boundary (not a loose prefix); upstream/abort error handling + no double-write; actionable `502`; a warning when the player isn't serving under `/__player/` (the asymmetric-flag mistake).

## Verification (browser, flag on)

- iframe is same-origin (`contentWindow.location.origin === editor origin`); `contentDocument` non-null; 250 performance entries readable.
- RPC handshake renders the game DOM (`#game > #game-background / #game-view / #game-ui`).
- Every `window.__preview` method works against the live game DOM.
- Proxy strips `transfer-encoding`; `/__playerfoo` is **not** hijacked (404, handled by the editor).

How to enable: uncomment `VITE_SAME_ORIGIN_PREVIEW=1` in **both** `.env.development` files and restart both dev servers (build-time var). Documented in `impower-dev/docs/architecture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
