### PR TITLE
test(dev): unit-test the same-origin preview proxy helpers

### DIFF
--- a/impower-dev/build.ts
+++ b/impower-dev/build.ts
@@ -9,6 +9,10 @@ import glob from "tiny-glob";
 import { build, createServer } from "vite";
 import staticallyRenderPage from "./src/build/staticallyRenderPage.js";
 import {
+  shouldProxyToPlayer,
+  stripHopByHopHeaders,
+} from "./src/build/devPreviewProxy.js";
+import {
   alias,
   apiInDir,
   apiOutDir,
@@ -419,26 +423,12 @@ const serve = async () => {
       process.env["SPARKDOWN_PLAYER_DEV_ORIGIN"] || "http://localhost:5173",
     );
     const client = playerOrigin.protocol === "https:" ? https : http;
-    // HTTP/1.1 hop-by-hop headers. They're connection-scoped and must NOT be
-    // forwarded; re-emitting them is also a hard error under HTTP/2 (which the
-    // dev server uses when https/ certs exist) — ERR_HTTP2_INVALID_CONNECTION_HEADERS.
-    const HOP_BY_HOP = new Set([
-      "connection",
-      "keep-alive",
-      "proxy-authenticate",
-      "proxy-authorization",
-      "te",
-      "trailer",
-      "transfer-encoding",
-      "upgrade",
-      "proxy-connection",
-    ]);
     let warnedAsymmetric = false;
     app.use((req: any, res: any, next: any) => {
-      // Boundary match so a future sibling route (e.g. /__playerfoo) can't be
-      // hijacked by the prefix.
       const url: string = req.url || "";
-      if (url !== PLAYER_PROXY_BASE && !url.startsWith(PLAYER_PROXY_BASE + "/")) {
+      // Boundary match so a future sibling route (e.g. /__playerfoo) can't be
+      // hijacked by the prefix (see src/build/devPreviewProxy.ts).
+      if (!shouldProxyToPlayer(url, PLAYER_PROXY_BASE)) {
         next();
         return;
       }
@@ -452,13 +442,11 @@ const serve = async () => {
           headers: { ...req.headers, host: playerOrigin.host },
         },
         (proxyRes) => {
-          const headers: Record<string, any> = {};
-          for (const [k, v] of Object.entries(proxyRes.headers)) {
-            if (!HOP_BY_HOP.has(k.toLowerCase())) {
-              headers[k] = v;
-            }
-          }
-          res.writeHead(proxyRes.statusCode || 502, headers);
+          // Drop hop-by-hop headers before re-emitting (required under HTTP/2).
+          res.writeHead(
+            proxyRes.statusCode || 502,
+            stripHopByHopHeaders(proxyRes.headers),
+          );
           // Diagnose the easy-to-make asymmetric-config mistake: the editor has
           // the flag but the player wasn't started with it, so it serves at base
           // "/" and the proxied index.html lacks the /__player/ asset prefix →

--- a/impower-dev/src/build/devPreviewProxy.ts
+++ b/impower-dev/src/build/devPreviewProxy.ts
@@ -1,0 +1,48 @@
+// Pure helpers for the DEV-ONLY same-origin game-preview reverse proxy in
+// build.ts. Kept side-effect-free so they can be unit-tested without importing
+// the build script itself (which runs serve()/the build pipeline on import).
+
+/**
+ * HTTP/1.1 hop-by-hop headers. They are connection-scoped and must NOT be
+ * forwarded by a proxy; re-emitting them is also a hard error under HTTP/2
+ * (ERR_HTTP2_INVALID_CONNECTION_HEADERS), which the dev server uses when the
+ * https/ certs exist.
+ */
+export const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "proxy-connection",
+]);
+
+/**
+ * Whether a request URL should be reverse-proxied to the player dev server.
+ * A boundary match on `base` (e.g. "/__player") — so the exact base and any
+ * path beneath it match, but a sibling path like "/__playerfoo" does NOT get
+ * hijacked by a loose prefix.
+ */
+export const shouldProxyToPlayer = (
+  url: string | undefined,
+  base: string,
+): boolean => !!url && (url === base || url.startsWith(base + "/"));
+
+/**
+ * A shallow copy of `headers` with hop-by-hop headers removed
+ * (case-insensitive). Used before re-emitting the upstream response.
+ */
+export const stripHopByHopHeaders = <T>(
+  headers: Record<string, T>,
+): Record<string, T> => {
+  const out: Record<string, T> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+      out[key] = value;
+    }
+  }
+  return out;
+};

--- a/impower-dev/test/build/devPreviewProxy.test.ts
+++ b/impower-dev/test/build/devPreviewProxy.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  HOP_BY_HOP_HEADERS,
+  shouldProxyToPlayer,
+  stripHopByHopHeaders,
+} from "../../src/build/devPreviewProxy";
+
+const BASE = "/__player";
+
+describe("shouldProxyToPlayer (boundary match)", () => {
+  it("matches the exact base (the iframe's bare request)", () => {
+    expect(shouldProxyToPlayer("/__player", BASE)).toBe(true);
+  });
+
+  it("matches the base with a trailing slash (the iframe src)", () => {
+    expect(shouldProxyToPlayer("/__player/", BASE)).toBe(true);
+  });
+
+  it("matches nested player assets", () => {
+    expect(shouldProxyToPlayer("/__player/@vite/client", BASE)).toBe(true);
+    expect(shouldProxyToPlayer("/__player/src/main.ts", BASE)).toBe(true);
+  });
+
+  it("does NOT hijack sibling paths sharing the prefix", () => {
+    expect(shouldProxyToPlayer("/__playerfoo", BASE)).toBe(false);
+    expect(shouldProxyToPlayer("/__player2/x", BASE)).toBe(false);
+    expect(shouldProxyToPlayer("/__player-stuff", BASE)).toBe(false);
+  });
+
+  it("does NOT match unrelated editor routes", () => {
+    expect(shouldProxyToPlayer("/", BASE)).toBe(false);
+    expect(shouldProxyToPlayer("/sw.js", BASE)).toBe(false);
+    expect(shouldProxyToPlayer("/@vite/client", BASE)).toBe(false);
+  });
+
+  it("handles a missing/empty url", () => {
+    expect(shouldProxyToPlayer(undefined, BASE)).toBe(false);
+    expect(shouldProxyToPlayer("", BASE)).toBe(false);
+  });
+});
+
+describe("stripHopByHopHeaders", () => {
+  it("removes hop-by-hop headers that break HTTP/2 re-emit", () => {
+    const out = stripHopByHopHeaders({
+      "content-type": "text/html",
+      "content-length": "420",
+      connection: "keep-alive",
+      "keep-alive": "timeout=5",
+      "transfer-encoding": "chunked",
+      etag: 'W/"abc"',
+    });
+    expect(out).toEqual({
+      "content-type": "text/html",
+      "content-length": "420",
+      etag: 'W/"abc"',
+    });
+    expect(out).not.toHaveProperty("connection");
+    expect(out).not.toHaveProperty("transfer-encoding");
+  });
+
+  it("is case-insensitive on header names", () => {
+    const out = stripHopByHopHeaders({
+      "Content-Type": "text/javascript",
+      Connection: "keep-alive",
+      "Transfer-Encoding": "chunked",
+      Upgrade: "h2c",
+    });
+    expect(out).toEqual({ "Content-Type": "text/javascript" });
+  });
+
+  it("strips every documented hop-by-hop header", () => {
+    const headers = Object.fromEntries(
+      [...HOP_BY_HOP_HEADERS].map((h) => [h, "x"]),
+    );
+    expect(stripHopByHopHeaders(headers)).toEqual({});
+  });
+
+  it("returns a copy and does not mutate the input", () => {
+    const input = { "content-type": "text/css", connection: "close" };
+    const out = stripHopByHopHeaders(input);
+    expect(out).not.toBe(input);
+    expect(input).toHaveProperty("connection", "close");
+  });
+
+  it("preserves array-valued headers (e.g. set-cookie)", () => {
+    const out = stripHopByHopHeaders({
+      "set-cookie": ["a=1", "b=2"],
+      connection: "keep-alive",
+    });
+    expect(out).toEqual({ "set-cookie": ["a=1", "b=2"] });
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #189 (already merged): adds a unit test for the dev-only same-origin preview proxy's pure logic.

## Changes

- Extracts the proxy's pure helpers into `impower-dev/src/build/devPreviewProxy.ts` (side-effect-free, so it's importable without running `build.ts`):
  - `shouldProxyToPlayer(url, base)` — the path-boundary match
  - `stripHopByHopHeaders(headers)` — the HTTP/2-safe header filter
- `build.ts` now uses these helpers (behavior unchanged; verified with a proxy smoke test).
- `impower-dev/test/build/devPreviewProxy.test.ts` — 11 vitest cases:
  - boundary guard hits `/__player`, `/__player/`, and nested assets but rejects siblings (`/__playerfoo`, `/__player2/x`), unrelated editor routes, and empty/undefined URLs;
  - header stripper drops `connection`/`transfer-encoding`/etc. case-insensitively, strips every documented hop-by-hop header, doesn't mutate its input, and preserves array-valued headers like `set-cookie`.

Runs under the existing `npm test` (vitest, single-fork config). All 11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
