### PR TITLE
fix(vscode): resolve vsce .vscodeignore/files conflict blocking publish

### DIFF
--- a/vscode-sparkdown/package.json
+++ b/vscode-sparkdown/package.json
@@ -1015,13 +1015,5 @@
     "url-browserify": "^1.3.0",
     "vscode-languageserver-protocol": "^3.17.5",
     "vscode-languageserver-textdocument": "^1.0.12"
-  },
-  "files": [
-    "out",
-    "package.json",
-    "icon-activitybar.png",
-    "icon-lang.png",
-    "icon.png",
-    "README.md"
-  ]
+  }
 }


### PR DESCRIPTION
## What

Fixes the first publish-workflow failure. The build itself succeeded in CI — the only blocker was a `vsce` packaging config conflict:

```
Both a .vscodeignore file and a "files" property in package.json were found.
VSCE does not support combining both strategies.
```

## Why it happened

`vscode-sparkdown` has **both** a `.vscodeignore` (denylist) and a `"files"` allowlist in `package.json`. Older `vsce` silently ignored `"files"` and only honored `.vscodeignore`, so 2.1.0 published fine. `vsce` 3.x (used by the new workflow) now reads both and errors on the conflict.

## The fix

Remove the `"files"` array; keep `.vscodeignore`. Two reasons:
1. `.vscodeignore` is what actually controlled packaging historically.
2. The `"files"` allowlist was **incomplete** — it omitted the `language/` folder, but `package.json` references `./language/sparkdown.language-grammar.json` (and the language-config/snippets) at runtime. `.vscodeignore` doesn't exclude `language/`, so the package stays correct and complete.

## After merge

The merge commit touches `vscode-sparkdown/package.json`, so it re-triggers the publish workflow. Expect: bump `2.1.0 → 2.1.1`, build, publish to the Marketplace, and a `[skip ci]` bump commit pushed back to `main`. No version has been published yet (both prior runs failed before publishing), so 2.1.1 will be the first live release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
