### PR TITLE
fix(vscode): restore extension name to sparkdown (update existing listing)

### DIFF
--- a/vscode-sparkdown/package.json
+++ b/vscode-sparkdown/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vscode-sparkdown",
+  "name": "sparkdown",
   "displayName": "Sparkdown",
   "description": "Sparkdown autocomplete, syntax highlighting, and export to PDF",
   "galleryBanner": {


### PR DESCRIPTION
## What

Fixes the "This extension display name is taken" error from the publish workflow.

## Root cause

The published Marketplace extension is **`impowergames.sparkdown`** (display name "Sparkdown", v2.1.0). But the package's `name` field had drifted to **`vscode-sparkdown`** (likely when the folder was reorganized in the monorepo). Since the Marketplace extension ID is `publisher.name`, publishing as-is would create a **brand-new** `impowergames.vscode-sparkdown` extension — and its display name "Sparkdown" collides with the existing `impowergames.sparkdown` listing, which the Marketplace rejects.

(Confirmed: `impowergames.vscode-sparkdown` 404s; `impowergames.sparkdown` exists at v2.1.0.)

## The fix

Restore `name` to `sparkdown`. Now `vsce publish` updates the **existing** `impowergames.sparkdown` listing — preserving its install base, ratings, and version history — instead of creating a new extension.

### Why this is safe
- The package is referenced elsewhere only by **folder path** (`vscode-sparkdown/`), not by package name — verified no workspace/dependency references the `vscode-sparkdown` name.
- The workflow's `npm version patch -w vscode-sparkdown` still resolves the workspace by directory path, reads the bumped version directly from the file, and `vsce` publishes from the directory — all unaffected by the name change.
- The token/publisher are correct as-is; no token change needed.

## After merge

The merge re-triggers the publish workflow. Expect: bump `2.1.0 → 2.1.1` on `impowergames.sparkdown`, build, publish the update, and a `[skip ci]` bump commit pushed back to `main`. This should be the first successful auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
