### PR TITLE
fix(vscode): sync package-lock with sparkdown rename (unblock npm ci)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14443,6 +14443,10 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sparkdown": {
+      "resolved": "vscode-sparkdown",
+      "link": true
+    },
     "node_modules/sparkdown-player-app": {
       "resolved": "sparkdown-player-app",
       "link": true
@@ -17053,10 +17057,6 @@
       "integrity": "sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/vscode-sparkdown": {
-      "resolved": "vscode-sparkdown",
-      "link": true
     },
     "node_modules/vscode-sparkdown-build-tools": {
       "resolved": "vscode-sparkdown/scripts",
@@ -21548,6 +21548,7 @@
       }
     },
     "vscode-sparkdown": {
+      "name": "sparkdown",
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

Follow-up to #195. Renaming the extension package to `sparkdown` desynced the root `package-lock.json`, so the workflow's `npm ci` failed before it could build:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json ... are in sync.
npm error Missing: sparkdown@2.1.0 from lock file
```

## The fix

Regenerated the lockfile with `npm install --package-lock-only` (no `node_modules` write). Minimal diff: the workspace link entry `node_modules/vscode-sparkdown` becomes `node_modules/sparkdown`, and the workspace records `"name": "sparkdown"`. The path-keyed entries stay `vscode-sparkdown` (the folder didn't move).

## After merge

Re-triggers the workflow. With the lockfile in sync, `npm ci` passes, the build runs, and `vsce` publishes `2.1.1` as an update to the existing `impowergames.sparkdown` listing. This should be the first green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
