### PR TITLE
docs(vscode): refresh extension description (and trigger first publish)

### DIFF
--- a/vscode-sparkdown/package.json
+++ b/vscode-sparkdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sparkdown",
   "displayName": "Sparkdown",
-  "description": "Sparkdown autocomplete, syntax highlighting, and export to PDF",
+  "description": "Sparkdown language support, live previews, and export — syntax highlighting, autocomplete, diagnostics, live previews as screenplays or playable games, and export to PDF, HTML, or HTML5 games.",
   "galleryBanner": {
     "color": "#053155",
     "theme": "dark"


### PR DESCRIPTION
## What

Refreshes the outdated `description` in `vscode-sparkdown/package.json` to reflect the extension's current feature set, and serves as the `vscode-sparkdown/**` change that triggers the first publish run (the prior lockfile fix in #196 didn't match the trigger paths).

**Before:**
> Sparkdown autocomplete, syntax highlighting, and export to PDF

**After:**
> Sparkdown language support, live previews, and export — syntax highlighting, autocomplete, diagnostics, live previews as screenplays or playable games, and export to PDF, HTML, or HTML5 games.

## After merge

Triggers the publish workflow. With every prior blocker resolved (build script, `.vscodeignore`/`files` conflict, extension name, lockfile sync), this should be the first green run: bump `2.1.0 → 2.1.1`, build, publish the update to `impowergames.sparkdown`, and push back the `[skip ci]` bump commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
