### PR TITLE
ci(vscode): run-number versioning, no commit-back to protected main

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -1,9 +1,14 @@
 name: Publish VS Code Extension
 
-# Auto-publishes the Sparkdown VS Code extension to the Microsoft Marketplace
-# whenever a push to main touches the extension or one of the packages it
-# bundles. Each run auto-bumps the patch version (the Marketplace rejects
-# republishing an existing version), publishes, then commits the bump back.
+# Auto-publishes the Sparkdown VS Code extension (impowergames.sparkdown) to the
+# Microsoft Marketplace whenever a push to main touches the extension or one of
+# the packages it bundles.
+#
+# Versioning: the Marketplace rejects republishing an existing version, so each
+# run publishes <major>.<minor>.<run_number>, computed at build time. The patch
+# is the workflow run number (always increasing), so versions never collide and
+# nothing is committed back to the (protected) main branch. Bump major/minor by
+# editing version in vscode-sparkdown/package.json; the patch is CI-derived.
 #
 # Setup required (one-time):
 #   - Repo secret VSCE_PAT: an Azure DevOps Personal Access Token for the
@@ -18,13 +23,14 @@ on:
       - "packages/**"
       - ".github/workflows/publish-vscode-extension.yml"
 
-# Never let two publishes overlap or race the version-bump push-back.
+# Never let two publishes overlap.
 concurrency:
   group: publish-vscode-extension
   cancel-in-progress: false
 
+# Read-only: this workflow never writes back to the repo.
 permissions:
-  contents: write # needed to push the version-bump commit back to main
+  contents: read
 
 jobs:
   publish:
@@ -32,9 +38,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          # Full history so the bump commit can be pushed back on top of main.
-          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -47,13 +50,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Bump patch version
-        id: bump
+      # Patch = workflow run number (monotonic), so published versions are
+      # always unique and increasing without committing anything back to main.
+      - name: Compute version
+        id: ver
         run: |
-          npm version patch --no-git-tag-version -w vscode-sparkdown
-          version=$(node -p "require('./vscode-sparkdown/package.json').version")
+          base=$(node -p "require('./vscode-sparkdown/package.json').version")
+          major_minor=$(echo "$base" | cut -d. -f1,2)
+          version="${major_minor}.${{ github.run_number }}"
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Bumped vscode-sparkdown to $version"
+          echo "Publishing $version"
+
+      # Set the version in-place for the build only (not committed).
+      - name: Set version
+        run: npm version "${{ steps.ver.outputs.version }}" --no-git-tag-version --allow-same-version -w vscode-sparkdown
 
       # vsce publish runs the extension's vscode:prepublish script, which does
       # the full production build (npm run package). --no-dependencies skips
@@ -64,17 +74,3 @@ jobs:
         run: npx --yes @vscode/vsce@^3 publish --no-dependencies
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-
-      # Only reached if the publish above succeeded. Pushing with the default
-      # GITHUB_TOKEN does not re-trigger workflows, and [skip ci] is a second
-      # guard against a publish loop.
-      - name: Commit version bump
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add vscode-sparkdown/package.json package-lock.json
-          git commit -m "chore(vscode): release v${{ steps.bump.outputs.version }} [skip ci]"
-          # --autostash sets aside any stray working-tree changes (e.g. npm
-          # version normalizing a nested workspace) so the rebase can proceed.
-          git pull --rebase --autostash origin main
-          git push


### PR DESCRIPTION
## What

The previous run **published 2.1.1 successfully** ✅ — it only failed on the final step, committing the version bump back to `main`, which `main`'s branch protection rejected:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
! [remote rejected] main -> main (protected branch hook declined)
```

Since the bump never persisted, the next run would re-bump `2.1.0 → 2.1.1` and the Marketplace would reject the duplicate. This removes the dependency on pushing to `main` entirely.

## The change

Publish `<major>.<minor>.<github.run_number>`, computed at build time and set in-place (not committed):
- Patch = workflow run number → always unique and increasing, so no collisions.
- No commit-back → no push to protected `main`, and `permissions` drops to `contents: read`.
- Bump major/minor anytime by editing `version` in `vscode-sparkdown/package.json`; the patch stays CI-derived.

Also removed now-unneeded `fetch-depth: 0`, the `[skip ci]` loop guard, and the commit step.

## After merge

Merging this touches the workflow file (a trigger path), so it re-runs and publishes `2.1.<run_number>` (well above the live 2.1.1). That run should be **fully green, end to end** — the first complete success of the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
