### PR TITLE
fix(compiler): eliminate incremental-vs-cold drift (dataLocations cache + scene/end validation)

### DIFF
--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -31,6 +31,11 @@ import { Weave } from "../../inkjs/compiler/Parser/ParsedHierarchy/Weave";
 import { ControlCommand } from "../../inkjs/engine/ControlCommand";
 import { DebugMetadata } from "../../inkjs/engine/DebugMetadata";
 import { SourceMetadata } from "../../inkjs/engine/Error";
+import {
+  validateScene,
+  validateBranch,
+} from "../lower/utils/validateSceneBranchScope";
+import { LowerContext } from "../lower/context";
 import { InkObject } from "../../inkjs/engine/Object";
 import { SimpleJson } from "../../inkjs/engine/SimpleJson";
 import { Story as RuntimeStory } from "../../inkjs/engine/Story";
@@ -1120,6 +1125,14 @@ export class SparkdownCompiler {
       cur.next();
     }
 
+    // Scene/`end` (and branch) pairing validation. This is a CROSS-CHUNK
+    // structural check — a scene's validity depends on a LATER root-level `end`
+    // sibling — so it runs fresh over the whole parse tree each compile rather
+    // than per-chunk during lowering. A per-chunk check would go stale when only
+    // the matching `end` chunk is edited (the earlier scene chunk isn't
+    // re-lowered), silently dropping the "missing `end`" diagnostic incrementally.
+    this.validateSceneStructure(uri, onDiagnostic);
+
     // Auto-terminate non-function scenes / branches whose body doesn't end
     // with an explicit terminator. Sparkdown narrative flows (`scene` /
     // `branch`) are story content — running off the end without a
@@ -1385,6 +1398,50 @@ export class SparkdownCompiler {
   // Path components match `Object.path`: a child with a valid name uses its
   // name, otherwise its index within `content`. Paths are relative to
   // `mainContentContainer`, which is the serialized root and the path root.
+  // Whole-document scene/`end` + branch pairing validation. Walks the file's
+  // root-level Scene/Branch nodes and runs the same forward/backward `end`
+  // pairing checks the lowerer used to do per-chunk — but freshly, over the full
+  // tree, every compile. Because it never relies on a stale per-chunk result, an
+  // edit that breaks only the matching `end` keyword now correctly re-emits the
+  // "missing `end`" diagnostic incrementally. Source positions are absolute (the
+  // doc-level ctx returns document line/column directly), matching what the
+  // previous chunk-relative + lineNumberOffset path produced.
+  validateSceneStructure(
+    uri: string,
+    onDiagnostic: (
+      message: string,
+      type: ErrorType,
+      source: SourceMetadata | null,
+      tags?: number[],
+    ) => void,
+  ) {
+    const tree = this.documents.tree(uri);
+    const doc = this.documents.get(uri);
+    if (!tree || !doc) {
+      return;
+    }
+    const ctx = {
+      filePath: uri,
+      read: (from: number, to: number) => doc.read(from, to),
+      lineNumber: (pos: number) => doc.positionAt(pos).line,
+      characterNumber: (pos: number) => doc.positionAt(pos).character,
+    } as unknown as LowerContext;
+    const emit = (diags: ReturnType<typeof validateScene>) => {
+      for (const d of diags) {
+        onDiagnostic(d.message, d.severity, d.source ?? null);
+      }
+    };
+    let cur = tree.topNode.firstChild;
+    while (cur) {
+      if (cur.name === "Scene") {
+        emit(validateScene(cur, ctx));
+      } else if (cur.name === "Branch") {
+        emit(validateBranch(cur, ctx));
+      }
+      cur = cur.nextSibling;
+    }
+  }
+
   populateAllLocations(program: SparkProgram, story: RuntimeStory) {
     const root = story.mainContentContainer;
     if (!root) {

--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -1513,6 +1513,31 @@ export class SparkdownCompiler {
         }
         return Number.POSITIVE_INFINITY;
       };
+      // Reuse is only sound while the set of top-level flows is STABLE. A
+      // structural edit (a scene/knot header made/unmade, renamed, added or
+      // removed) can reflow content across flow boundaries and shift the
+      // document-global ownership of GLOBAL dataLocations (a `& global = …`
+      // entry is keyed by bare name and owned by the FIRST writer across all
+      // flows — not flow-local). The per-flow cache freezes that ownership, so
+      // when the flow set changes, fall back to a full recompute this compile.
+      // `_locCache` keys ARE the previous compile's named-flow set (every
+      // non-`global decl` flow is stored), so this is a free comparison.
+      let effPrevCache = prevCache;
+      if (prevCache) {
+        const curNames = flows.filter((f) => f.name !== "global decl");
+        let sameSet = curNames.length === prevCache.size;
+        if (sameSet) {
+          for (const f of curNames) {
+            if (!prevCache.has(f.name)) {
+              sameSet = false;
+              break;
+            }
+          }
+        }
+        if (!sameSet) {
+          effPrevCache = undefined;
+        }
+      }
       for (const f of flows) {
         // `global decl`'s source is non-contiguous (scattered declarations), so
         // it never gets a span — always recompute it (it emits no pathLocations
@@ -1521,9 +1546,9 @@ export class SparkdownCompiler {
           f.container != null &&
           f.start0 >= 0 &&
           f.name !== "global decl" &&
-          prevCache != null;
+          effPrevCache != null;
         if (reusable) {
-          const cached = prevCache!.get(f.name);
+          const cached = effPrevCache!.get(f.name);
           if (cached) {
             const end0 = spanEndOf(f.start0);
             const guardStart = f.start0 - 1;

--- a/packages/sparkdown/src/compiler/lower/lowerers/lowerBranch.ts
+++ b/packages/sparkdown/src/compiler/lower/lowerers/lowerBranch.ts
@@ -5,11 +5,12 @@ import { CompiledBlock } from "../../classes/annotators/CompilationAnnotator";
 import { SparkdownSyntaxNodeRef } from "../../types/SparkdownSyntaxNodeRef";
 import { LowerContext } from "../context";
 import { lowerArguments } from "../utils/lowerArguments";
-import { validateBranch } from "../utils/validateSceneBranchScope";
 
 // `Branch` is a boundary-only Scoped rule (see docs/compiler/GRAMMAR.md). The
-// body lives at root; the lowerer validates that the branch sits
-// inside an active scene AND has a matching `end` keyword later.
+// body lives at root. The inside-a-scene / matching-`end` checks depend on
+// other root-level siblings, so they run as a fresh whole-document pass each
+// compile (see `SparkdownCompiler.validateSceneStructure`), not here — per-chunk
+// lowering would go stale when only a sibling `end`/scene is edited.
 export function lowerBranch(
   nodeRef: SparkdownSyntaxNodeRef,
   ctx: LowerContext,
@@ -21,8 +22,5 @@ export function lowerBranch(
   const identifier = new Identifier(ctx.read(nameNode.from, nameNode.to));
   const args = lowerArguments(nodeRef.node, ctx);
   const stitch = new Stitch(identifier, [], args, false);
-  const diagnostics = validateBranch(nodeRef.node, ctx);
-  const block: CompiledBlock = { content: [stitch] };
-  if (diagnostics.length > 0) block.diagnostics = diagnostics;
-  return block;
+  return { content: [stitch] };
 }

--- a/packages/sparkdown/src/compiler/lower/lowerers/lowerScene.ts
+++ b/packages/sparkdown/src/compiler/lower/lowerers/lowerScene.ts
@@ -5,14 +5,14 @@ import { CompiledBlock } from "../../classes/annotators/CompilationAnnotator";
 import { SparkdownSyntaxNodeRef } from "../../types/SparkdownSyntaxNodeRef";
 import { LowerContext } from "../context";
 import { lowerArguments } from "../utils/lowerArguments";
-import { validateScene } from "../utils/validateSceneBranchScope";
 
 // `Scene` is a boundary-only Scoped rule (see docs/compiler/GRAMMAR.md) — it
 // covers the declaration line only. The scene's body lives at root,
-// so this lowerer just builds the Knot from the declaration and
-// validates that a matching `end` keyword appears later at root
-// level (the lowerer pairs declarations with their `LuauEndKeyword`
-// siblings — see `validateSceneBranchScope`).
+// so this lowerer just builds the Knot from the declaration. The
+// scene/`end` pairing check is NOT done here: it depends on LATER
+// root-level siblings (the matching `end`), so per-chunk lowering would
+// go stale when only the `end` chunk is edited. It runs as a fresh
+// whole-document pass each compile — see `SparkdownCompiler.validateSceneStructure`.
 export function lowerScene(
   nodeRef: SparkdownSyntaxNodeRef,
   ctx: LowerContext,
@@ -24,8 +24,5 @@ export function lowerScene(
   const identifier = new Identifier(ctx.read(nameNode.from, nameNode.to));
   const args = lowerArguments(nodeRef.node, ctx);
   const knot = new Knot(identifier, [], args, false);
-  const diagnostics = validateScene(nodeRef.node, ctx);
-  const block: CompiledBlock = { content: [knot] };
-  if (diagnostics.length > 0) block.diagnostics = diagnostics;
-  return block;
+  return { content: [knot] };
 }

--- a/packages/sparkdown/src/tests/compiler/incrementalEquivalence.test.ts
+++ b/packages/sparkdown/src/tests/compiler/incrementalEquivalence.test.ts
@@ -228,6 +228,50 @@ describe("compiler incremental equivalence", () => {
     }
   });
 
+  it("incremental == cold location maps when a structural edit changes the flow set", () => {
+    // Breaking the FIRST scene's header removes it from the flow set and shifts
+    // the document-global `dataLocations` ownership (the first `& trust =`, which
+    // is keyed by bare name and owned by the first writer across ALL flows). The
+    // per-flow location cache must detect the flow-set change and full-recompute,
+    // or it drops the entry. Compares the location-map fields only: malformed
+    // input also trips a separate pre-existing parser diagnostics drift.
+    const realWarn = console.warn;
+    const realError = console.error;
+    console.warn = () => {};
+    console.error = () => {};
+    try {
+      const base = coupledScreenplay();
+      const find = "scene scene_0";
+      const offset = base.indexOf(find);
+      expect(offset).toBeGreaterThanOrEqual(0);
+      const start = posAt(base, offset);
+      const end = posAt(base, offset + find.length);
+      const replace = "scen scene_0"; // break the `scene` keyword
+      const after = base.slice(0, offset) + replace + base.slice(offset + find.length);
+      const incr = new SparkdownCompiler();
+      incr.configure({
+        files: [{ uri: URI, type: "script", name: "main", ext: "sd", text: base, version: 1, languageId: "sparkdown" }],
+      });
+      incr.compile({ textDocument: { uri: URI } });
+      incr.updateDocument({
+        textDocument: { uri: URI, version: 2 },
+        contentChanges: [{ range: { start, end }, text: replace }],
+      });
+      const locOf = (p: any) => ({
+        pathLocations: p.pathLocations,
+        dataLocations: p.dataLocations,
+        pathLocationsOrder: p.pathLocationsOrder,
+        dataLocationsOrder: p.dataLocationsOrder,
+      });
+      const incrLoc = locOf(pick(incr.compile({ textDocument: { uri: URI } }).program));
+      const coldLoc = locOf(coldCompile(after));
+      expect(stable(incrLoc)).toBe(stable(coldLoc));
+    } finally {
+      console.warn = realWarn;
+      console.error = realError;
+    }
+  });
+
   it("incremental == cold under randomized single edits (fuzz, each from fresh)", () => {
     // Each random edit is applied as a SINGLE incremental update from a freshly
     // configured compiler (not cumulative), so it exercises the per-flow reuse

--- a/packages/sparkdown/src/tests/compiler/incrementalEquivalence.test.ts
+++ b/packages/sparkdown/src/tests/compiler/incrementalEquivalence.test.ts
@@ -272,11 +272,12 @@ describe("compiler incremental equivalence", () => {
     }
   });
 
-  it("incremental == cold under randomized single edits (fuzz, each from fresh)", () => {
-    // Each random edit is applied as a SINGLE incremental update from a freshly
-    // configured compiler (not cumulative), so it exercises the per-flow reuse
-    // path on a wide variety of edit sites/kinds without conflating it with the
-    // separate pre-existing cumulative-parser drift.
+  it("incremental == cold under randomized structural edits (fuzz, full surface)", () => {
+    // Each random edit (structural inserts AND mid-content deletions) is applied
+    // as a SINGLE incremental update from a freshly configured compiler and
+    // compared on the FULL program surface to a cold compile. This exercises the
+    // location/ToJson reuse paths AND the incremental parser+annotation+validation
+    // across a wide variety of edit sites/kinds.
     const realWarn = console.warn;
     const realError = console.error;
     console.warn = () => {};
@@ -289,20 +290,15 @@ describe("compiler incremental equivalence", () => {
         seed = (seed * 1103515245 + 12345) & 0x7fffffff;
         return seed / 0x7fffffff;
       };
-      // Plain-character inserts only, compared on the location-map fields
-      // (Design A's surface). Random STRUCTURAL inserts ("}", "{...}", "//...")
-      // or mid-content deletions at arbitrary offsets can still trip separate
-      // pre-existing incremental-PARSER divergences (compiled / diagnostics
-      // differ — not caused by the location cache); the deterministic edits above
-      // (incl. append, rename, read-count) compare the FULL program surface and
-      // pass. A failure HERE would implicate the caching, not the parser.
-      const inserts = ["x", " ", "1", "a", "Z", "."];
-      for (let n = 0; n < 60; n++) {
+      const inserts = ["x", "\n", " ", "1", "}", "{", "{trust}", "// c", "->", "end", ")", ""];
+      for (let n = 0; n < 120; n++) {
         const insert = inserts[Math.floor(rand() * inserts.length)]!;
+        const delLen = rand() < 0.4 ? Math.min(1 + Math.floor(rand() * 8), 14) : 0;
+        if (insert === "" && delLen === 0) continue;
         const offset = Math.floor(rand() * base.length);
         const start = posAt(base, offset);
-        const end = start;
-        const after = base.slice(0, offset) + insert + base.slice(offset);
+        const end = posAt(base, Math.min(offset + delLen, base.length));
+        const after = base.slice(0, offset) + insert + base.slice(offset + delLen);
 
         const incr = new SparkdownCompiler();
         incr.configure({
@@ -313,17 +309,12 @@ describe("compiler incremental equivalence", () => {
           textDocument: { uri: URI, version: 2 },
           contentChanges: [{ range: { start, end }, text: insert }],
         });
-        const locOf = (p: any) => ({
-          pathLocations: p.pathLocations,
-          dataLocations: p.dataLocations,
-          pathLocationsOrder: p.pathLocationsOrder,
-          dataLocationsOrder: p.dataLocationsOrder,
-        });
-        const incrLoc = locOf(pick(incr.compile({ textDocument: { uri: URI } }).program));
-        const coldLoc = locOf(coldCompile(after));
-        expect(stable(incrLoc), `after fuzz edit #${n} insert ${JSON.stringify(insert)} @${offset}`).toBe(
-          stable(coldLoc),
-        );
+        const incrProg = pick(incr.compile({ textDocument: { uri: URI } }).program);
+        const coldProg = coldCompile(after);
+        expect(
+          stable(incrProg),
+          `after fuzz edit #${n} insert ${JSON.stringify(insert)} del ${delLen} @${offset}`,
+        ).toBe(stable(coldProg));
       }
     } finally {
       console.warn = realWarn;


### PR DESCRIPTION
## Summary

Fixes the remaining **incremental-vs-cold divergences** in the Sparkdown compiler — cases where a persistent compiler (the editor's HMR path) drifts from a from-scratch compile of the same text. Follow-up to #193. All divergences here were **LSP-only** (`program.compiled` bytecode was already correct); they affected `dataLocations` (go-to-definition) and `diagnostics` (squiggles) in transient editing states.

Found by an incremental==cold fuzz that applies random structural inserts + deletions and compares the full program surface (compiled + every `*Locations` map + context + diagnostics + ui + colorAnnotations) against a cold compile. **Before: 10/386 random edits diverged across 9 distinct classes. After: 0/386.**

## Two root causes

**1. `dataLocations` — a Design A (location-cache) regression.** Global `dataLocations` (a `& global = …` reassignment, keyed by bare variable name) is owned by the *first* writer in document order across **all** flows — it isn't flow-local. The per-flow location cache froze that ownership, so a structural edit that shifted it to a different flow (whose cache predated the shift) dropped the entry. Fix: invalidate the location cache (full recompute) when the top-level flow-name set changes — a free comparison, since the cache's keys *are* the previous flow set. Pure within-flow content edits keep the flow set stable and still reuse.

**2. `diagnostics` — scene/`end` pairing validated per-chunk.** *"Scene is missing its closing `end` keyword"* (and the branch checks) were computed during a scene/branch chunk's lowering via a cross-chunk sibling walk for the matching `end`. That result depends on **later** root-level siblings, so an edit breaking only the `end` keyword re-lowered just the `end` chunk — never the earlier scene chunk — leaving the diagnostic stale. This was the single cause of all 7 diagnostics drift classes. Fix: move the pairing checks into a fresh **whole-document pass** (`validateSceneStructure`) that walks the file's root-level Scene/Branch nodes every compile. Source positions are computed from the document directly, matching the old chunk-relative + offset path — so emission order/positions are unchanged and **compileSnapshot stays byte-identical (no regeneration)**.

## Testing

- Re-broadened the incremental==cold oracle's fuzz to random **structural** inserts + deletions compared on the **full** program surface (was scoped to plain-char inserts + location fields to work around these bugs). Added a deterministic flow-set-change regression test.
- All gates green: incremental oracle (13), perfEquivalence, compileSnapshot (byte-identical), full compiler (423), runtime (275), luau-conformance (759).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
