### PR TITLE
fix(dev): stop same-origin preview service-worker reload loop

### DIFF
--- a/impower-dev/src/pages/index.ts
+++ b/impower-dev/src/pages/index.ts
@@ -34,14 +34,29 @@ if ("serviceWorker" in navigator) {
   );
   // TODO: Handle service worker refresh with Approach #4 instead of Approach #2:
   // https://redfin.engineering/how-to-fix-the-refresh-button-when-using-service-workers-a8e27af6df68
-  let refreshing = false;
-  navigator.serviceWorker.addEventListener("controllerchange", () => {
-    if (refreshing) {
-      return;
-    }
-    refreshing = true;
-    window.location.reload();
-  });
+  // Reload to pick up a NEW worker version (so the PWA auto-updates to the latest
+  // engine code without the user clicking "update") — but ONLY in PRODUCTION, and
+  // only when this page was already controlled by a previous worker (a genuine
+  // update). Two reasons to skip this in dev:
+  //   1. The dev SW only intercepts /file:/ OPFS (sw.ts gates everything else on
+  //      production), so there is never a dev "update" worth reloading for.
+  //   2. Reloading on controllerchange in dev spins into an endless loop whenever
+  //      a second worker keeps claiming the origin — e.g. the same-origin preview
+  //      iframe mistakenly registering a competing /sw.js (fixed in the player's
+  //      main.ts; this gate is the belt-and-suspenders).
+  // On an UNCONTROLLED load the controller goes null→worker (the initial claim);
+  // reloading on THAT also loops (the reload fires before the new worker persists
+  // as the saved controller), so we additionally require an existing controller.
+  if (import.meta.env.PROD && navigator.serviceWorker.controller) {
+    let refreshing = false;
+    navigator.serviceWorker.addEventListener("controllerchange", () => {
+      if (refreshing) {
+        return;
+      }
+      refreshing = true;
+      window.location.reload();
+    });
+  }
 } else {
   console.error("Service workers are not supported.");
 }

--- a/sparkdown-player-app/src/main.ts
+++ b/sparkdown-player-app/src/main.ts
@@ -20,10 +20,21 @@ const SPARKDOWN_EDITOR_ORIGIN = import.meta.env.VITE_SPARKDOWN_EDITOR_ORIGIN;
 // DEV-ONLY same-origin preview: when the editor proxies this app under its own
 // origin (see impower-dev/build.ts + vite base "/__player/"), our origin equals
 // the editor's. The postMessage handshake then matches exactly with no origin
-// relaxation needed. We also skip registering our own service worker: the
-// editor already runs a root-scoped SW that intercepts /file:/ and serves game
-// assets straight from its OPFS, so it controls this iframe too.
+// relaxation needed.
 const SAME_ORIGIN = window.location.origin === SPARKDOWN_EDITOR_ORIGIN;
+
+// Whether the editor is proxying us same-origin under "/__player/". Derived from
+// the BUILD BASE (vite.config sets base "/__player/" iff same-origin preview is
+// on), NOT the port-fragile baked VITE_SPARKDOWN_EDITOR_ORIGIN: that env can
+// drift from the editor's real port (per-worktree dev ports), and when it does
+// the origin compare above goes wrongly false. We use this robust signal ONLY to
+// gate service-worker registration (below): registering our own /sw.js while the
+// editor already controls this origin mints a SECOND, competing root-scoped SW
+// at the editor's scope, whose install→claim fires `controllerchange` in the
+// editor top frame → its reload handler → endless reload loop. The editor's
+// root-scoped SW already intercepts /file:/ and serves game assets from its OPFS,
+// so under the proxy we must NOT register our own.
+const SAME_ORIGIN_PROXY = import.meta.env.BASE_URL.startsWith("/__player");
 
 const connection = new Port2MessageConnection(
   (message: any, transfer?: Transferable[]) =>
@@ -97,7 +108,12 @@ window.addEventListener("drop", async (e) => {
   );
 });
 
-if (!SAME_ORIGIN && "serviceWorker" in navigator) {
+// Register our own SW only when we are genuinely a SEPARATE origin from the
+// editor: neither the (prod-correct) origin compare nor the (dev-proxy-robust)
+// build-base signal says same-origin. Skipping when EITHER is true keeps the
+// production same-origin behavior intact while fixing the dev case where a
+// stale baked editor origin made `SAME_ORIGIN` wrongly false.
+if (!SAME_ORIGIN && !SAME_ORIGIN_PROXY && "serviceWorker" in navigator) {
   navigator.serviceWorker
     .register("/sw.js", { type: "module" })
     .catch((err) => console.error("SW register failed:", err));


### PR DESCRIPTION
## Problem

In **same-origin preview** mode (`VITE_SAME_ORIGIN_PREVIEW=1`), the editor reverse-proxies the player at `/__player/` and already runs a root-scoped service worker. Running the editor would churn in an **endless page-reload loop** (intermittent, ~every few seconds).

## Root cause

A **competing-service-worker claim war** at the editor origin scope `/`:

1. The player's `main.ts` gated its own SW registration on `SAME_ORIGIN = window.location.origin === VITE_SPARKDOWN_EDITOR_ORIGIN`.
2. That baked editor origin is **port-fragile** — it drifts from the editor's real port (each worktree runs its own dev ports, e.g. `:8084`, while the baked value may be `:8082`). When it drifts, `SAME_ORIGIN` is wrongly **false**.
3. So the proxied iframe ran `navigator.serviceWorker.register("/sw.js", {type:"module"})` — registering the **editor's** `/sw.js` at scope `/` as a *second, competing* worker (the editor page already registered it).
4. Each install → `skipWaiting()` + `clients.claim()` fired `controllerchange` in the editor top frame, whose handler called `window.location.reload()` → re-register → **loop**.

Cross-origin worktrees never hit this: the player SW lands on the *player* origin (a different scope), so there's no competing registration. That's why the loop appeared "branch-specific" — it was really "same-origin-preview-specific."

## Fix

- **Player (`sparkdown-player-app/src/main.ts`)** — gate SW registration on a **port-proof** signal, `import.meta.env.BASE_URL.startsWith("/__player")` (vite sets the base to `/__player/` iff same-origin preview is on), in addition to the origin compare. The proxied iframe can no longer mint a competing SW. The RPC origin-relaxation path is untouched.
- **Editor (`impower-dev/src/pages/index.ts`)** — gate the `controllerchange → window.location.reload()` on `import.meta.env.PROD` (keeping the existing-controller guard). The dev SW only serves `/file:/` OPFS, so there's never a dev update worth reloading for; **production keeps PWA auto-update**. Belt-and-suspenders even if a rogue SW ever lingers.

## Verification

- Root cause confirmed in the live served bundle: the player's `import.meta.env` showed `BASE_URL: "/__player/"` **and** the stale `VITE_SPARKDOWN_EDITOR_ORIGIN: "http://localhost:8082"` against an editor running on `:8084` — the exact mismatch.
- After the fix, restarting the editor/player pair and hard-reloading the editor: **no reload loop**, and the game preview renders.

> Note: a separate fix for the dead dev/prod **SW version+resource injection** (currently a constant via the `viteBannerPlugin` banner; should move to a Vite `define`) is a follow-up — it's entangled with the `devPreviewProxy` refactor and is a distinct prod-auto-update concern, kept out of this PR to keep it minimal and focused on the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
