### PR TITLE
fix(dev): inject service-worker version via Vite define (revive PWA auto-update)

### DIFF
--- a/impower-dev/build.ts
+++ b/impower-dev/build.ts
@@ -19,7 +19,7 @@ import {
   browserEnvDefine,
   dedupe,
   externalWorkerPaths,
-  getServiceWorkerProcessEnvBanner,
+  getServiceWorkerDefine,
   impowerUiStyleCss,
   indir,
   MINIFY,
@@ -32,7 +32,6 @@ import {
   readEditorGlobalCss,
   serviceWorkerPaths,
   staticallyStylePage,
-  viteBannerPlugin,
   viteStaticallyRenderedPagesPlugin,
   WATCH,
 } from "./vite.config.js";
@@ -314,14 +313,11 @@ const buildWorkers = async () => {
   console.log("");
   await build({
     configFile: false,
-    plugins: [
-      viteBannerPlugin(
-        getServiceWorkerProcessEnvBanner({
-          swVersion: SW_VERSION,
-          swResources: SW_RESOURCES,
-        }),
-      ),
-    ],
+    define: getServiceWorkerDefine({
+      swVersion: SW_VERSION,
+      swResources: SW_RESOURCES,
+      production: PRODUCTION,
+    }),
     build: {
       outDir: publicOutDir,
       emptyOutDir: false,

--- a/impower-dev/docs/build-pipeline.md
+++ b/impower-dev/docs/build-pipeline.md
@@ -37,8 +37,12 @@ needs explicitly.
   `var process = {...}` banner.)
 - **`viteStaticallyRenderedPagesPlugin`** — the dev SSG middleware *and* dev
   worker hot-reload (below).
-- **`viteBannerPlugin`** — prepends the dynamic service-worker env banner
-  (`SW_VERSION` / `SW_RESOURCES`).
+- **`getServiceWorkerDefine()`** — Vite `define` that injects the service-worker
+  build values (`SW_VERSION` / `SW_RESOURCES` / `NODE_ENV`) as `SW_*_INJECTED`
+  token literals in `sw.ts`. Replaced a `renderChunk` banner that was dead code:
+  `process.env.SW_VERSION` folded to `{}.SW_VERSION` ("v1") before the banner
+  applied, so the SW looked unchanged every deploy and PWA auto-update never
+  fired. Tokens (not `process.env`) survive minification + dodge the fold.
 - **`readEditorGlobalCss()`** — reads `normalize.css` + `theme.css` to inline
   into the SSG `<style>` block.
 

--- a/impower-dev/src/workers/sw.ts
+++ b/impower-dev/src/workers/sw.ts
@@ -1,12 +1,25 @@
 export default null;
 declare var self: ServiceWorkerGlobalScope;
 
-const SW_VERSION: string = process?.env?.["SW_VERSION"] || "v1";
-const SW_CACHE_NAME: string =
-  process?.env?.["SW_CACHE_NAME"] || `cache-${SW_VERSION}`;
+// Build-time values injected via Vite `define` (see getServiceWorkerDefine).
+// Read through a `typeof` guard so (a) an un-injected build falls back safely
+// instead of throwing, and (b) — crucially — the value can't be folded away by
+// an ambient `process.env` → `{}` replacement. The old `process?.env?.[...]`
+// reads minified to `{}.SW_VERSION` → always "v1", so the SW looked byte-
+// identical on every deploy and PWA auto-update silently never fired.
+declare const SW_VERSION_INJECTED: string | undefined;
+declare const SW_RESOURCES_INJECTED: string | undefined;
+declare const SW_NODE_ENV_INJECTED: string | undefined;
+const SW_VERSION: string =
+  typeof SW_VERSION_INJECTED !== "undefined" ? SW_VERSION_INJECTED : "v1";
+const SW_CACHE_NAME: string = `cache-${SW_VERSION}`;
 const SW_RESOURCES: string[] = JSON.parse(
-  process?.env?.["SW_RESOURCES"] || "[]",
+  typeof SW_RESOURCES_INJECTED !== "undefined" ? SW_RESOURCES_INJECTED : "[]",
 );
+const SW_NODE_ENV: string =
+  typeof SW_NODE_ENV_INJECTED !== "undefined"
+    ? SW_NODE_ENV_INJECTED
+    : "development";
 const RESOURCE_PROTOCOL: string = "/file:/";
 
 const RESOURCE_URL_REGEX =
@@ -119,7 +132,7 @@ self.addEventListener("fetch", async (event) => {
     event.respondWith(handleLocalAssetRequest(url));
     return;
   }
-  if (process?.env?.["NODE_ENV"] === "production") {
+  if (SW_NODE_ENV === "production") {
     if (event.request.mode === "navigate") {
       // Fetching a page route
       event.respondWith(cacheThenNetwork("/"));

--- a/impower-dev/vite.config.ts
+++ b/impower-dev/vite.config.ts
@@ -177,20 +177,33 @@ const __dirname = path.dirname(__filename);
 process.env.NODE_ENV = process.env.NODE_ENV || '${PRODUCTION ? "production" : "development"}';
 `.trim();
 
-const getServiceWorkerProcessEnvBanner = (options?: {
+// Build-time `define` for the service-worker bundle: replaces the SW_*_INJECTED
+// tokens in sw.ts with string literals (esbuild/Vite define), which SURVIVE
+// minification. Replaces the old prepended-`var process` banner, which was dead
+// code: `process.env.SW_VERSION` folded to `{}.SW_VERSION` ("v1") before the
+// banner applied, so the SW looked byte-identical every deploy and PWA
+// auto-update never fired. Using non-`process` tokens avoids that ambient fold.
+const getServiceWorkerDefine = (options?: {
   swVersion?: string | number;
   swResources?: string[];
-}) =>
-  `
-var process = {
-  env: {
-    NODE_ENV: '${PRODUCTION ? "production" : "development"}',
-    SW_VERSION: ${options?.swVersion ? `'${options.swVersion}'` : "undefined"},
-    SW_CACHE_NAME: ${options?.swVersion ? `'cache-${options.swVersion}'` : "undefined"},
-    SW_RESOURCES: ${options?.swResources ? `'${JSON.stringify(options.swResources)}'` : "undefined"},
+  production?: boolean;
+}): Record<string, string> => {
+  const define: Record<string, string> = {};
+  if (options?.swVersion != null) {
+    define["SW_VERSION_INJECTED"] = JSON.stringify(String(options.swVersion));
   }
+  if (options?.swResources != null) {
+    // Double-encode: sw.ts does JSON.parse(SW_RESOURCES_INJECTED), so the token
+    // must replace to a JSON-string *literal* (e.g. `"[\"/\"]"`).
+    define["SW_RESOURCES_INJECTED"] = JSON.stringify(
+      JSON.stringify(options.swResources),
+    );
+  }
+  define["SW_NODE_ENV_INJECTED"] = JSON.stringify(
+    options?.production ? "production" : "development",
+  );
+  return define;
 };
-`.trim();
 
 // ----------------------------------------------------------------------------
 // Shared Utilities
@@ -217,15 +230,6 @@ const readEditorGlobalCss = (): string =>
 // ----------------------------------------------------------------------------
 // Vite Plugins
 // ----------------------------------------------------------------------------
-
-
-const viteBannerPlugin = (banner: string): Plugin => ({
-  name: "vite-banner-plugin",
-  renderChunk(code, chunk) {
-    if (chunk.fileName.endsWith(".js")) return banner + "\n" + code;
-    return null;
-  },
-});
 
 const viteStaticallyRenderedPagesPlugin = (): Plugin => ({
   name: "vite-statically-rendered-pages",
@@ -353,7 +357,11 @@ const viteStaticallyRenderedPagesPlugin = (): Plugin => ({
               return;
             }
           } else if (!isMap) {
-            const SW_VERSION = Date.now();
+            // Stable per dev-server (NOT Date.now()-per-request): the dev SW
+            // must not look "new" on every fetch, or the controllerchange→reload
+            // (src/pages/index.ts) would churn. Dev code updates ride Vite HMR /
+            // the worker chokidar reload; in dev the SW only serves OPFS.
+            const SW_VERSION = "dev";
             const swResourceSet = new Set(["/"]);
             // outDevDir is only created in the isExternal branch above. For
             // non-external service-worker requests it may not exist yet —
@@ -381,14 +389,11 @@ const viteStaticallyRenderedPagesPlugin = (): Plugin => ({
             console.log("");
             const result = await build({
               configFile: false,
-              plugins: [
-                viteBannerPlugin(
-                  getServiceWorkerProcessEnvBanner({
-                    swVersion: SW_VERSION,
-                    swResources: SW_RESOURCES,
-                  }),
-                ),
-              ],
+              define: getServiceWorkerDefine({
+                swVersion: SW_VERSION,
+                swResources: SW_RESOURCES,
+                production: false,
+              }),
               build: {
                 write: false,
                 rollupOptions: {
@@ -524,10 +529,9 @@ export {
   MINIFY,
   browserEnvDefine,
   PATH_RESOLUTION_BANNER,
-  getServiceWorkerProcessEnvBanner,
+  getServiceWorkerDefine,
   staticallyStylePage,
   readEditorGlobalCss,
-  viteBannerPlugin,
   viteStaticallyRenderedPagesPlugin,
 };
 


### PR DESCRIPTION
## Problem

Production **PWA auto-update is broken**: users never receive the latest engine code without manually clearing the service worker.

The dev/prod SW version + precache manifest were injected via a `process.env` banner (`viteBannerPlugin` + `getServiceWorkerProcessEnvBanner`). At minify time `process.env.SW_VERSION` collapsed to a constant, so the **production** service worker's bytes never changed across deploys → the browser never detected a "new" worker → no update.

## Fix

Replace the banner with Vite **`define`**, injecting typeof-guarded tokens (`SW_VERSION_INJECTED` / `SW_RESOURCES_INJECTED` / `SW_NODE_ENV_INJECTED`) that `sw.ts` reads with safe fallbacks:

- **Production** gets a real per-build version (`Date.now()`) → the SW changes each deploy → the browser picks it up (paired with the prod-gated `controllerchange → reload` in #201).
- **Dev** stays the constant `"dev"` so the dev SW doesn't look "new" on every fetch.

## Scope / safety

- 4 files: `build.ts`, `vite.config.ts`, `sw.ts`, `docs/build-pipeline.md`.
- **Independent of and complementary to #201** (no file overlap): #201 stops the dev reload *loop*; this restores prod auto-*update*.
- `build.ts` keeps main's `devPreviewProxy` refactor intact — only the SW worker build switches from `viteBannerPlugin(...)` to `define`.
- No remaining references to `viteBannerPlugin` / `getServiceWorkerProcessEnvBanner` anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
