### PR TITLE
chore(impower-dev): dev-only Clear OPFS sidebar button

### DIFF
--- a/impower-dev/src/modules/spark-editor/components/account/Account.tsx
+++ b/impower-dev/src/modules/spark-editor/components/account/Account.tsx
@@ -3,6 +3,7 @@ import {
   Download,
   Logout,
   Ripple,
+  Trash,
   Upload,
 } from "@impower/impower-ui/components";
 import type { ComponentChildren, JSX } from "preact";
@@ -109,6 +110,30 @@ export default function Account(_p: AccountProps) {
       const name = Workspace.window.store.project.name;
       downloadFile(`${name}.zip`, "application/x-zip", zip);
     }
+  };
+
+  // DEV-ONLY: nuke the origin's OPFS (the local editor project) and reload.
+  // A replacement for the now-broken "OPFS Explorer" browser extension.
+  // Gated by `import.meta.env.DEV` at the render site below so it is tree-
+  // shaken out of production bundles.
+  const handleClearOpfs = async () => {
+    if (
+      !window.confirm(
+        "Clear OPFS? This permanently deletes the local editor project in this browser.",
+      )
+    )
+      return;
+    try {
+      const root = await navigator.storage.getDirectory();
+      const names: string[] = [];
+      for await (const [name] of root.entries()) names.push(name);
+      for (const name of names) {
+        await root.removeEntry(name, { recursive: true });
+      }
+    } catch (e) {
+      console.error("Failed to clear OPFS", e);
+    }
+    location.reload();
   };
 
   const handleSignIn = async () => {
@@ -275,6 +300,15 @@ export default function Account(_p: AccountProps) {
           </Row>
         </>
       )}
+      {/* DEV-ONLY utility: clear this origin's OPFS workspace and reload.
+          `import.meta.env.DEV` is Vite's build-time boolean — `false` in
+          production page builds, so this branch is tree-shaken out and the
+          button never ships. Replaces the broken "OPFS Explorer" extension. */}
+      {import.meta.env.DEV ? (
+        <Row icon={<Trash class="size-5" />} onClick={handleClearOpfs}>
+          Clear OPFS (dev)
+        </Row>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## What

Adds a **dev-only** "Clear OPFS (dev)" button to the editor's side-drawer (the menu/account panel opened from the hamburger). On click it confirms, then deletes every entry in this origin's OPFS — the local editor project — and reloads the page.

This is a replacement for the user's now-broken "OPFS Explorer" browser extension, giving a quick way to wipe the local workspace from inside the editor itself.

## Dev-only gating

The button is rendered inside an `import.meta.env.DEV` guard. `import.meta.env.DEV` is Vite's standard build-time boolean (`true` on the dev server, `false` in production page builds), so the branch is statically tree-shaken out of production bundles and the button never ships to prod. This matches how the project already reads build-time browser env via Vite `define` (see `vite.config.ts` / `PreviewGame.tsx`).

## Implementation notes

- Lives in `impower-dev/src/modules/spark-editor/components/account/Account.tsx`, the side-drawer panel that already hosts Import/Export Project.
- Reuses that file's existing local `Row` component and the `Trash` icon from `@impower/impower-ui/components`, matching the neighboring rows' imports, JSX, and styling exactly.
- Uses the standard OPFS clear sequence (`navigator.storage.getDirectory()` → iterate entries → `removeEntry(..., { recursive: true })`) wrapped in a confirm + try/catch + `location.reload()`.

Independent of other in-flight work; touches a single component file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)