### PR TITLE
fix(sparkdown): lower trailing `..` glue so lines join

### DIFF
--- a/packages/sparkdown/src/compiler/lower/lowerers/lowerDisplay.ts
+++ b/packages/sparkdown/src/compiler/lower/lowerers/lowerDisplay.ts
@@ -233,7 +233,8 @@ type BodySegment =
   | { kind: "expr"; node: SyntaxNode }
   | { kind: "divert"; node: SyntaxNode }
   | { kind: "inlineGluedAlt"; node: SyntaxNode }
-  | { kind: "tag"; node: SyntaxNode };
+  | { kind: "tag"; node: SyntaxNode }
+  | { kind: "glue" };
 
 const INLINE_GLUED_ALTERNATOR_NAMES = new Set([
   "LuauSparkdownInlineGluedSequentialAlternatorBlock",
@@ -290,6 +291,16 @@ function processDisplayBody(
       } else {
         if (text.length > 0) out.push(new Text(text));
       }
+    } else if (seg.kind === "glue") {
+      // A `..` glue marker sitting WITHIN display content (most commonly a
+      // TRAILING `text ..` at end of line, but also a mid-body `..`). The
+      // grammar already produces a `Glue` node (it's even syntax-
+      // highlighted); without this branch `collectBodySegments` would read
+      // its raw `..` characters as literal text and the lines would never
+      // join. Leading `..` is handled separately by the `leadingGlue` path
+      // (the glue is excluded from the body range there), so this only fires
+      // for non-leading glue. Emits the same runtime marker as `lowerGlue`.
+      out.push(new ParsedGlue(new RuntimeGlue()));
     } else if (seg.kind === "inlineGluedAlt") {
       // `Here is text .. queue|A|B|C .. and more` — inline-glued
       // alternator embedded in display content. The grammar matches
@@ -395,6 +406,8 @@ function collectBodySegments(
         out.push({ kind: "divert", node: next.node });
       } else if (next.kind === "tag") {
         out.push({ kind: "tag", node: next.node });
+      } else if (next.kind === "glue") {
+        out.push({ kind: "glue" });
       } else if (next.kind === "comment") {
         // Emit nothing — the comment is removed. Swallow the trailing
         // newline ONLY for a whole-line comment (nothing but indent before
@@ -429,7 +442,7 @@ function collectBodySegments(
 }
 
 interface BodyInjection {
-  kind: "expr" | "divert" | "inlineGluedAlt" | "tag" | "comment";
+  kind: "expr" | "divert" | "inlineGluedAlt" | "tag" | "comment" | "glue";
   node: SyntaxNode;
   from: number;
   to: number;
@@ -516,6 +529,24 @@ function collectTopLevelInjections(
       ) {
         if (node.from >= bodyStart && node.to <= bodyEnd) {
           out.push({ kind: "comment", node, from: node.from, to: node.to });
+        }
+        return;
+      }
+      // A `..` glue marker embedded in display content — a TRAILING
+      // `text ..` (or a mid-body `..`). The `Glue` grammar node spans its
+      // leading whitespace plus the `..` (`(?:ws)*(?:[.][.])`); the `..` is
+      // always the final two characters. Anchor the injection on the `..`
+      // itself (`node.to - 2`) rather than `node.from` so the whitespace
+      // before it stays in the preceding text segment — that single space
+      // is what separates the joined words (`shadows ..` + `and` →
+      // `shadows and`, mirroring the leading-glue form `shadows` + `.. and`).
+      // The opening/closing `..` of an inline-glued alternator are NOT
+      // reached here: the alternator branch above returns before descending,
+      // and its closing `Glue` (consumed into the alternator's range) is
+      // defensively skipped in `collectBodySegments`.
+      if (node.name === "Glue") {
+        if (node.from >= bodyStart && node.to <= bodyEnd) {
+          out.push({ kind: "glue", node, from: node.to - 2, to: node.to });
         }
         return;
       }
@@ -646,6 +677,57 @@ function hasLeadingGlue(nodeRef: SparkdownSyntaxNodeRef): boolean {
   return getDescendent("Glue", nodeRef.node) != null;
 }
 
+// Sibling node names that sit between two display constructs without being
+// content themselves — skipped when looking back for the preceding construct.
+const GLUE_SKIP_SIBLINGS: ReadonlySet<string> = new Set([
+  "Newline",
+  "Whitespace",
+  "ExtraWhitespace",
+  "OptionalWhitespace",
+  "RequiredWhitespace",
+]);
+
+// True when the immediately-preceding top-level sibling construct ends with a
+// TRAILING `..` glue marker (`text ..<eol>`). A trailing `..` means "join the
+// next line onto this one", so the FOLLOWING display construct must be lowered
+// as a leading-glue continuation (no line-type tag pair) — the symmetric twin
+// of the leading-`..` form. This is required, not cosmetic: the runtime
+// removes a pending Glue only when real text follows it with no intervening
+// control command (`StoryState.RemoveExistingGlue` stops at the first
+// `ControlCommand`). A line-type tag pair (`BeginTag`/`EndTag`) on the next
+// line sits exactly there, so without skipping it the previous line's Glue
+// lingers and later suppresses an unrelated newline (the same hazard the
+// `leadingGlue` branch documents). Mirroring the leading form keeps the join
+// clean and the trailing newline intact.
+function isPrecededByTrailingGlue(
+  nodeRef: SparkdownSyntaxNodeRef,
+  ctx: LowerContext,
+): boolean {
+  let sib: SyntaxNode | null = nodeRef.node.prevSibling;
+  while (sib && GLUE_SKIP_SIBLINGS.has(sib.name)) sib = sib.prevSibling;
+  if (!sib) return false;
+  return endsWithTrailingGlue(sib, ctx);
+}
+
+// True when `node`'s last visible content is a `..` glue marker — i.e. the
+// right-most `Glue` descendant ends exactly at the node's trailing-whitespace-
+// trimmed end. Mid-construct glues (followed by more text) don't count.
+function endsWithTrailingGlue(node: SyntaxNode, ctx: LowerContext): boolean {
+  const text = ctx.read(node.from, node.to);
+  const trimmedEnd = node.from + text.replace(/\s+$/, "").length;
+  let lastGlueEnd = -1;
+  const visit = (n: SyntaxNode): void => {
+    if (n.name === "Glue" && n.to > lastGlueEnd) lastGlueEnd = n.to;
+    let c = n.firstChild;
+    while (c) {
+      visit(c);
+      c = c.nextSibling;
+    }
+  };
+  visit(node);
+  return lastGlueEnd === trimmedEnd;
+}
+
 // For block forms, the body spans every line after the first newline. The
 // per-line indentation is stripped later by `processDisplayBody` in `block`
 // mode.
@@ -694,6 +776,10 @@ export function lowerImplicitAction(
   nodeRef: SparkdownSyntaxNodeRef,
   ctx: LowerContext,
 ): CompiledBlock {
+  // A line glued onto by the PREVIOUS line's trailing `..` is a continuation:
+  // emit it as leading-glue (no tag pair) so the join is clean. See
+  // `isPrecededByTrailingGlue`.
+  const leadingGlue = isPrecededByTrailingGlue(nodeRef, ctx);
   return wrapInWeave(
     buildDisplayContent(
       nodeRef.node,
@@ -703,6 +789,7 @@ export function lowerImplicitAction(
       "inline",
       "action",
       null,
+      { leadingGlue },
     ),
   );
 }
@@ -778,7 +865,11 @@ export function lowerInlineAction(
   ctx: LowerContext,
 ): CompiledBlock {
   const { from, to } = extractInlineBodyRange(nodeRef);
-  const leadingGlue = hasLeadingGlue(nodeRef);
+  // Either this line opens with `..` (its own leading glue) or it's a
+  // continuation glued onto by the previous line's trailing `..`. Both are
+  // lowered as leading-glue (no tag pair). See `isPrecededByTrailingGlue`.
+  const leadingGlue =
+    hasLeadingGlue(nodeRef) || isPrecededByTrailingGlue(nodeRef, ctx);
   return wrapInWeave(
     buildDisplayContent(nodeRef.node, from, to, ctx, "inline", "action", null, {
       leadingGlue,

--- a/packages/sparkdown/src/compiler/lower/lowerers/lowerDisplay.ts
+++ b/packages/sparkdown/src/compiler/lower/lowerers/lowerDisplay.ts
@@ -48,21 +48,29 @@ function buildDisplayContent(
   identifier: string | null,
   options: { leadingGlue?: boolean } = {},
 ): ParsedObject[] {
-  if (options.leadingGlue) {
-    // `..` glue marker — emitted first so the runtime's output-stream trim
-    // walks past the previous line's trailing newline. For glued lines we
-    // skip the line-type metadata tag pair: the tag's inner text ("action",
-    // etc.) is non-whitespace and would prevent the runtime from cleanly
-    // removing the existing Glue once real body text arrives, leaving the
-    // Glue in the stream and causing subsequent newlines to be dropped. The
-    // glued content conceptually inherits the previous line's type anyway.
-    // Glued content is never split at breaks (it's a continuation, not a
-    // standalone beat).
+  // A glued line is a continuation of the previous one. Two sources:
+  //   1. This line OPENS with `..` (its own leading glue — always an
+  //      `InlineAction` per the grammar). The space AFTER the `..` is the
+  //      word separator, so its leading whitespace is preserved.
+  //   2. The PREVIOUS line ended with a trailing `..` (`isNodePrecededBy
+  //      TrailingGlue`). The separator is the previous line's space BEFORE
+  //      its `..`, so this line's own leading whitespace (e.g. the space
+  //      after a `CHARACTER:` / `$:` routing colon) is trimmed to avoid a
+  //      doubled space.
+  // Both are lowered the same way: a single leading Glue, then the body with
+  // NO line-type tag pair / routing prefix, so the runtime joins this line's
+  // text onto the previous line's beat (inheriting its display target) and
+  // the pending Glue is cleanly removed. Glued content is never split at
+  // breaks (it's a continuation, not a standalone beat).
+  const ownLeadingGlue = options.leadingGlue ?? false;
+  const continuationGlue =
+    !ownLeadingGlue && isNodePrecededByTrailingGlue(parent, ctx);
+  if (ownLeadingGlue || continuationGlue) {
     const content: ParsedObject[] = [];
     content.push(new ParsedGlue(new RuntimeGlue()));
     content.push(
       ...processDisplayBody(parent, bodyStart, bodyEnd, ctx, mode, {
-        preserveLeadingWhitespace: true,
+        preserveLeadingWhitespace: ownLeadingGlue,
       }),
     );
     content.push(new Text("\n"));
@@ -253,11 +261,24 @@ function processDisplayBody(
 
   // Mode-specific text trimming.
   if (mode === "block") {
-    for (const seg of segments) {
+    for (let i = 0; i < segments.length; i++) {
+      const seg = segments[i]!;
       if (seg.kind === "text") {
+        // Strip each line's leading indentation (block body lines are
+        // indented under their heading/cue). EXCEPTION: when this text
+        // segment immediately follows a `..` glue marker, its first line's
+        // leading whitespace is the glue's word separator (the space after
+        // `.. ` in a mid-block leading-glue line), not indentation — keep it
+        // so the joined words don't fuse (`first` + `.. second` → `first
+        // second`, not `firstsecond`).
+        const followsGlue = i > 0 && segments[i - 1]!.kind === "glue";
         seg.raw = seg.raw
           .split(/\r?\n/)
-          .map((line) => line.replace(/^[ \t]+/, ""))
+          .map((line, lineIndex) =>
+            lineIndex === 0 && followsGlue
+              ? line
+              : line.replace(/^[ \t]+/, ""),
+          )
           .join("\n");
       }
     }
@@ -689,21 +710,24 @@ const GLUE_SKIP_SIBLINGS: ReadonlySet<string> = new Set([
 
 // True when the immediately-preceding top-level sibling construct ends with a
 // TRAILING `..` glue marker (`text ..<eol>`). A trailing `..` means "join the
-// next line onto this one", so the FOLLOWING display construct must be lowered
-// as a leading-glue continuation (no line-type tag pair) — the symmetric twin
-// of the leading-`..` form. This is required, not cosmetic: the runtime
-// removes a pending Glue only when real text follows it with no intervening
-// control command (`StoryState.RemoveExistingGlue` stops at the first
-// `ControlCommand`). A line-type tag pair (`BeginTag`/`EndTag`) on the next
-// line sits exactly there, so without skipping it the previous line's Glue
-// lingers and later suppresses an unrelated newline (the same hazard the
-// `leadingGlue` branch documents). Mirroring the leading form keeps the join
-// clean and the trailing newline intact.
-function isPrecededByTrailingGlue(
-  nodeRef: SparkdownSyntaxNodeRef,
+// next line onto this one", so the FOLLOWING display construct (of ANY type —
+// action, dialogue, heading, title, transitional, write) must be lowered as a
+// leading-glue continuation (no line-type tag pair / routing prefix) — the
+// symmetric twin of the leading-`..` form. This is required, not cosmetic: the
+// runtime removes a pending Glue only when real text follows it with no
+// intervening control command (`StoryState.RemoveExistingGlue` stops at the
+// first `ControlCommand`). A line-type tag pair (`BeginTag`/`EndTag`) on the
+// next line sits exactly there, so without skipping it the previous line's
+// Glue lingers and later suppresses an unrelated newline (the same hazard the
+// `leadingGlue` branch documents); the routing prefix (`ALICE:`, `$:`, …)
+// would also re-cue a fresh beat instead of continuing the previous one.
+// Mirroring the leading form keeps the join clean, the continuation routed to
+// the previous line's target, and the trailing newline intact.
+function isNodePrecededByTrailingGlue(
+  node: SyntaxNode,
   ctx: LowerContext,
 ): boolean {
-  let sib: SyntaxNode | null = nodeRef.node.prevSibling;
+  let sib: SyntaxNode | null = node.prevSibling;
   while (sib && GLUE_SKIP_SIBLINGS.has(sib.name)) sib = sib.prevSibling;
   if (!sib) return false;
   return endsWithTrailingGlue(sib, ctx);
@@ -714,7 +738,14 @@ function isPrecededByTrailingGlue(
 // trimmed end. Mid-construct glues (followed by more text) don't count.
 function endsWithTrailingGlue(node: SyntaxNode, ctx: LowerContext): boolean {
   const text = ctx.read(node.from, node.to);
-  const trimmedEnd = node.from + text.replace(/\s+$/, "").length;
+  const trimmed = text.replace(/\s+$/, "");
+  // Fast reject before the subtree walk: a trailing glue's last visible
+  // characters are always `..`. Most display lines don't end that way, so this
+  // skips the walk for them. (`...` ellipsis also passes this cheap check but
+  // is rejected below — it isn't a `Glue` node, so no descendant ends at
+  // `trimmedEnd`.)
+  if (!trimmed.endsWith("..")) return false;
+  const trimmedEnd = node.from + trimmed.length;
   let lastGlueEnd = -1;
   const visit = (n: SyntaxNode): void => {
     if (n.name === "Glue" && n.to > lastGlueEnd) lastGlueEnd = n.to;
@@ -776,10 +807,8 @@ export function lowerImplicitAction(
   nodeRef: SparkdownSyntaxNodeRef,
   ctx: LowerContext,
 ): CompiledBlock {
-  // A line glued onto by the PREVIOUS line's trailing `..` is a continuation:
-  // emit it as leading-glue (no tag pair) so the join is clean. See
-  // `isPrecededByTrailingGlue`.
-  const leadingGlue = isPrecededByTrailingGlue(nodeRef, ctx);
+  // Trailing-glue continuation (this line glued onto by the previous line's
+  // `..`) is detected centrally in `buildDisplayContent`.
   return wrapInWeave(
     buildDisplayContent(
       nodeRef.node,
@@ -789,7 +818,6 @@ export function lowerImplicitAction(
       "inline",
       "action",
       null,
-      { leadingGlue },
     ),
   );
 }
@@ -865,11 +893,9 @@ export function lowerInlineAction(
   ctx: LowerContext,
 ): CompiledBlock {
   const { from, to } = extractInlineBodyRange(nodeRef);
-  // Either this line opens with `..` (its own leading glue) or it's a
-  // continuation glued onto by the previous line's trailing `..`. Both are
-  // lowered as leading-glue (no tag pair). See `isPrecededByTrailingGlue`.
-  const leadingGlue =
-    hasLeadingGlue(nodeRef) || isPrecededByTrailingGlue(nodeRef, ctx);
+  // This line's OWN leading `..`. A trailing-glue continuation (previous line
+  // ended with `..`) is detected centrally in `buildDisplayContent`.
+  const leadingGlue = hasLeadingGlue(nodeRef);
   return wrapInWeave(
     buildDisplayContent(nodeRef.node, from, to, ctx, "inline", "action", null, {
       leadingGlue,

--- a/packages/sparkdown/src/tests/runtime/Glue.test.ts
+++ b/packages/sparkdown/src/tests/runtime/Glue.test.ts
@@ -23,6 +23,19 @@ describe("Glue (ported from inkjs)", () => {
     expect(runToEnd(ctx.story)).toBe("Some content with glue.\n");
   });
 
+  test("trailing glue across multiple lines", () => {
+    // The mirror of the leading-`..` fixture above: each line ends with a
+    // trailing ` ..` glue marker instead of opening with one. The grammar
+    // recognizes (and highlights) trailing `..` as a `Glue` node, but the
+    // display lowerer used to read its raw `..` characters as literal text,
+    // so the lines never joined. Both forms must produce the same joined
+    // output, with the single space before `..` preserved as the word
+    // separator (`Some ..` + `content` → `Some content`).
+    const ctx = makeRuntimeStoryFromFile("glue", "trailing-glue");
+    expect(ctx.errorMessages).toEqual([]);
+    expect(runToEnd(ctx.story)).toBe("Some content with glue.\n");
+  });
+
   test("multi-line content inside `if cond then ... end` (left-right glue)", () => {
     // Ink fixture wraps text in `{ f(): Another line. }` — sparkdown
     // maps the inline `{cond: text}` shorthand to the block form

--- a/packages/sparkdown/src/tests/runtime/Glue.test.ts
+++ b/packages/sparkdown/src/tests/runtime/Glue.test.ts
@@ -9,7 +9,21 @@
 // divergence flagged in `Newlines.test.ts` and `CallStack.test.ts`.
 
 import { describe, expect, test } from "vitest";
-import { makeRuntimeStoryFromFile, runToEnd } from "./runtimeTestHarness";
+import {
+  makeRuntimeStoryFromFile,
+  makeRuntimeStoryFromSource,
+  runToEnd,
+} from "./runtimeTestHarness";
+import { Story as RuntimeStory } from "../../inkjs/engine/Story";
+
+// Drive `Continue()` one beat at a time. A correctly-glued continuation
+// joins onto the previous line's beat, so the whole join is a SINGLE
+// `Continue()` boundary (mirrors `ChainedDialogueBreak.test.ts`).
+function continueBeats(story: RuntimeStory): string[] {
+  const beats: string[] = [];
+  while (story.canContinue) beats.push(story.Continue() ?? "");
+  return beats;
+}
 
 describe("Glue (ported from inkjs)", () => {
   test("simple glue across multiple lines", () => {
@@ -87,6 +101,78 @@ describe("Glue — ported from ink fixture rewrites", () => {
     );
     expect(ctx.errorMessages).toEqual([]);
     expect(ctx.story.ContinueMaximally()).toBe("A\nX\n");
+  });
+});
+
+// Glue is not action-only: a `..` marker joins consecutive display lines of
+// EVERY type (action, dialogue, heading, title, transitional, write), in both
+// the leading (`.. text`) and trailing (`text ..`) positions. A correct join
+// collapses the two lines into a SINGLE `Continue()` beat whose routing
+// prefix appears ONCE — the continuation inherits the first line's display
+// target. The raw beat text still carries the prefix (`ALICE:`, `$:`, …)
+// because the prefix-stripping interpreter is a separate layer; the runtime
+// concern here is the join + single beat + intact trailing newline.
+describe("Glue — across all display statement types", () => {
+  // [label, first-line text incl. prefix, raw joined beat]. The second line
+  // re-uses the same prefix; the join drops it.
+  const TYPES: { label: string; prefix: string; joined: string }[] = [
+    { label: "action", prefix: "", joined: "first second.\n" },
+    { label: "dialogue", prefix: "ALICE:", joined: "ALICE: first second.\n" },
+    { label: "heading", prefix: "$:", joined: "$: first second.\n" },
+    { label: "title", prefix: "^:", joined: "^: first second.\n" },
+    { label: "transitional", prefix: "%:", joined: "%: first second.\n" },
+    { label: "write", prefix: "@hud:", joined: "@hud: first second.\n" },
+  ];
+
+  for (const { label, prefix, joined } of TYPES) {
+    const p = prefix ? `${prefix} ` : "";
+
+    test(`trailing \`..\` joins two ${label} lines into one beat`, () => {
+      const ctx = makeRuntimeStoryFromSource(`${p}first ..\n${p}second.\n`);
+      expect(ctx.errorMessages).toEqual([]);
+      const beats = continueBeats(ctx.story);
+      expect(beats).toEqual([joined]);
+    });
+
+    test(`leading \`..\` joins a continuation onto a ${label} line`, () => {
+      // The continuation `.. second.` carries no prefix of its own (a
+      // leading-`..` line is always parsed as a bare continuation) and
+      // inherits the previous line's display target.
+      const ctx = makeRuntimeStoryFromSource(`${p}first\n.. second.\n`);
+      expect(ctx.errorMessages).toEqual([]);
+      const beats = continueBeats(ctx.story);
+      expect(beats).toEqual([joined]);
+    });
+  }
+
+  test("a chain of trailing `..` joins three dialogue lines into one beat", () => {
+    const ctx = makeRuntimeStoryFromSource(
+      "ALICE: a ..\nALICE: b ..\nALICE: c.\n",
+    );
+    expect(ctx.errorMessages).toEqual([]);
+    expect(continueBeats(ctx.story)).toEqual(["ALICE: a b c.\n"]);
+  });
+
+  test("trailing `..` joins mid-body lines within a block dialogue", () => {
+    const ctx = makeRuntimeStoryFromSource("ALICE:\n  first ..\n  second.\n");
+    expect(ctx.errorMessages).toEqual([]);
+    expect(continueBeats(ctx.story)).toEqual(["ALICE: first second.\n"]);
+  });
+
+  test("leading `..` joins mid-body lines within a block dialogue", () => {
+    // The separator space (after `.. `) must survive block-mode indentation
+    // stripping, so the words don't fuse into `firstsecond`.
+    const ctx = makeRuntimeStoryFromSource("ALICE:\n  first\n  .. second.\n");
+    expect(ctx.errorMessages).toEqual([]);
+    expect(continueBeats(ctx.story)).toEqual(["ALICE: first second.\n"]);
+  });
+
+  test("a non-glued multi-line block dialogue still keeps its line breaks", () => {
+    // Guard the block-mode fix: without a `..`, body lines stay on separate
+    // lines (one beat, newline preserved between them).
+    const ctx = makeRuntimeStoryFromSource("ALICE:\n  one.\n  two.\n");
+    expect(ctx.errorMessages).toEqual([]);
+    expect(continueBeats(ctx.story)).toEqual(["ALICE: one.\ntwo.\n"]);
   });
 });
 

--- a/packages/sparkdown/src/tests/runtime/fixtures/glue/trailing-glue.sd
+++ b/packages/sparkdown/src/tests/runtime/fixtures/glue/trailing-glue.sd
@@ -1,0 +1,3 @@
+Some ..
+content ..
+with glue.


### PR DESCRIPTION
## Problem

A **trailing** `..` glue marker was recognized and syntax-highlighted by the grammar as a `Glue` node, but the display lowerer silently dropped it — so it rendered as literal text instead of joining the lines:

```
A goblin leaps from the shadows ..
and then screams.
```

- **Before:** `"A goblin leaps from the shadows ..\nand then screams.\n"` (the `..` survives as text, lines not joined)
- **After:** `"A goblin leaps from the shadows and then screams.\n"` (joined — identical to the leading-`..` form)

The leading form (`.. and then screams.`) already worked, because it goes through a dedicated `InlineAction` + `leadingGlue` path where the glue is excluded from the body range. The gap was between grammar *recognition* and *lowering*.

## Root cause

`collectTopLevelInjections` in `lowerDisplay.ts` recognized expr / divert / alternator / tag / comment nodes but **not** `Glue` nodes, so `collectBodySegments` read the marker's `..` characters as literal text.

## Fix (in the lowerer — the grammar already emits the `Glue` node correctly)

1. Recognize a `Glue` node embedded in display content as a glue segment and emit the same runtime `Glue` marker as `lowerGlue`, anchored on the `..` so the space before it stays in the preceding text (the word separator).
2. A trailing `..` means "join the next line on", so the **following** display construct is now lowered as a leading-glue continuation (no line-type tag pair) — the symmetric twin of the existing leading-`..` path. This is required, not cosmetic: the runtime only removes a pending `Glue` when text follows with no intervening control command, and the next line's tag pair (`BeginTag`/`EndTag`) would otherwise block removal, leaving a lingering glue that drops a later newline.

## Not regressed

- Leading `..` glue, dialogue glue, the `>` break marker — verified by the full runtime suite.
- Luau `..` string concatenation (`a..b` between non-whitespace operands) stays concatenation (`{ Greeting..Name }` → `"hiBob"`); only whitespace-flanked `..` is glue.
- Within-block trailing `..`, no-glue plain lines, and trailing `..` at EOF all behave correctly.

## Tests

- New runtime fixture `fixtures/glue/trailing-glue.sd` mirroring `simple-glue.sd`, asserting the joined output.
- Full sparkdown runtime suite (276 pass / 24 pre-existing skips) and compiler snapshot suite (128 pass) green. The 2 formatter failures in `deltaFormatEquivalence.test.ts` ("screen element (bad attr spacing)") are pre-existing on `main` and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)