### PR TITLE
chore: one-command dev launcher + footgun-proof preview handshake

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# Working in this repo
+
+## Running the live editor / game preview
+
+To see a change in the running editor or game preview, launch BOTH dev servers
+with one command from the repo root:
+
+```sh
+npm run web:dev                # same-origin (default)
+npm run web:dev:cross-origin   # separate-origin iframe
+```
+
+It auto-picks free ports (never colliding with another worktree's servers),
+wires every cross-referencing env var consistently, waits for readiness, and
+prints the editor URL. `Ctrl+C` stops both. Override ports with `EDITOR_PORT` /
+`PLAYER_PORT` / `HMR_PORT` if needed. Same-origin mode (the default) lets you
+inspect the live game DOM from the editor page via `window.__preview`.
+
+**Do NOT hand-launch the editor (`impower-dev`) and player (`sparkdown-player-app`)
+separately** unless you fully understand the handshake below — it's a footgun.
+
+### Failure signature & why it happens
+
+The editor embeds the player as an `<iframe>` and they connect over a
+postMessage + MessageChannel handshake. The wiring that must agree:
+
+- Editor needs `VITE_SPARKDOWN_PLAYER_ORIGIN` = the player's real origin (it's
+  the iframe `src`), plus a unique `HMR_PORT` (the default collides when another
+  editor is already running → its Vite HMR websocket fails → the page reloads in
+  a loop).
+- Player needs `VITE_SPARKDOWN_EDITOR_ORIGIN` = the editor's origin so its
+  handshake replies `postMessage` to the right place. (On `localhost` the player
+  now relaxes this — it learns the editor's origin from the first message — but
+  prod stays strict.)
+
+These are **build-time** Vite vars baked into each bundle, so a page reload
+won't fix a wrong value — you must restart the server. Get any of them wrong and
+the **Game Preview is fully black, even on PLAY** (the editor never completes
+`connect`/`Initialize`, so the game never runs); the editor pane itself looks
+fine. `npm run dev:preview` exists precisely so you never have to get this right
+by hand.
+
+OPFS project storage is **per-origin**, so a project saved at one editor port is
+invisible at another — use the URL the launcher prints.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,45 @@
 # Impower
 
+Monorepo for **Sparkdown** — a markup language for writing screenplays and
+games — and the tools around it: the [impower.dev](./impower-dev) web editor, the
+[VS Code extension](./vscode-sparkdown), the language server, the game engine,
+and the player.
+
 ## Recommended Workspace Setup
 
 1. Install IDE: [Visual Studio Code](https://code.visualstudio.com/)
 2. In VSCode, install all [Workspace Recommended Extensions](https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions).
+
+## Local development
+
+This is an npm-workspaces monorepo. **Install once from the repo root**, then use
+the root launch scripts below — they are the supported way to run things and they
+keep the multi-process wiring correct.
+
+```sh
+npm install        # once, at the repo root — sets up every workspace
+```
+
+| To work on… | Run (from the repo root) | What it does |
+| --- | --- | --- |
+| The **web editor** ([impower-dev](./impower-dev)) | `npm run web:dev` | Launches the editor **and** the game-preview player together, on auto-picked free ports, and prints the editor URL. `Ctrl+C` stops both. |
+| …forcing a separate-origin player iframe | `npm run web:dev:cross-origin` | Same, but cross-origin instead of the default same-origin proxy. (`web:dev:same-origin` is the explicit default.) |
+| The **VS Code extension** ([vscode-sparkdown](./vscode-sparkdown)) | `npm run vscode:dev` | Builds + watches the extension and everything it bundles; press **F5** in VS Code to open an Extension Development Host. |
+
+Override the web ports with the `EDITOR_PORT` / `PLAYER_PORT` / `HMR_PORT` env
+vars if you need fixed ports.
+
+### Why `web:dev` instead of launching the two servers yourself
+
+The editor embeds the game player as an `<iframe>` and the two connect over a
+postMessage/MessageChannel handshake. That handshake needs three things to agree:
+the editor's player-origin, the player's editor-origin, and a unique HMR port per
+editor. Get any of them wrong — or collide with another running checkout — and the
+**Game Preview silently stays black** even on PLAY (the editor never finishes
+connecting; the editor pane itself looks fine). The values are baked into each
+Vite bundle at startup, so a page reload won't fix a wrong one. `web:dev` removes
+the footgun entirely: it derives every value consistently and never collides
+(every port is chosen free at launch). Just run it and open the URL it prints.
+
+Same-origin mode (the default) additionally exposes `window.__preview` in the
+editor page so you can inspect the live game DOM from the console / devtools.

--- a/impower-dev/README.md
+++ b/impower-dev/README.md
@@ -11,28 +11,27 @@ The web app at **impower.dev** — the Sparkdown screenplay/game editor. A
 ## Quick start
 
 This package lives in an npm-workspaces monorepo. Install once from the **repo
-root** (not from here):
+root**, then start everything with the root launcher (also from the root):
 
 ```sh
-npm install            # at the monorepo root — sets up all workspaces
+npm install        # at the monorepo root — sets up all workspaces
+npm run web:dev    # at the monorepo root — starts BOTH servers, prints the URL
 ```
 
-Then run two dev servers in separate terminals:
+`web:dev` launches the editor **and** the game-preview player together, picks
+free ports, wires the editor↔player handshake consistently, waits for both to be
+ready, and prints the editor URL to open. `Ctrl+C` stops both. It defaults to
+**same-origin** mode (the editor proxies the player under its own origin, so the
+live game DOM is reachable from the editor page); use `npm run web:dev:cross-origin`
+for a separate-origin iframe. See the [root README](../README.md).
 
-```sh
-# Terminal 1 — the editor, on http://localhost:8080
-cd impower-dev
-npm run dev
-
-# Terminal 2 — the game player that the preview <iframe> loads, on http://localhost:5173
-cd sparkdown-player-app
-npm run dev
-```
-
-Open <http://localhost:8080>. You only need the player (terminal 2) if you want
-the **game preview** to render; editing works with just the editor. The two
-origins are wired by `.env.development` in each package (editor → player at
-`:5173`, player → editor at `:8080`), so no extra env vars are needed.
+> **Don't hand-launch the editor and player in two terminals** unless you fully
+> understand the handshake. The editor embeds the player as an `<iframe>` and the
+> two connect over a postMessage/MessageChannel handshake. If the
+> cross-referencing origins/ports don't agree — or collide with another running
+> checkout — the **Game Preview silently stays black** even on PLAY (the editor
+> never finishes connecting). `web:dev` exists precisely so you never have to get
+> this wiring right by hand.
 
 > Editing a **worker** (LSP, screenplay-PDF, OPFS) hot-reloads automatically —
 > the dev server runs each worker's esbuild in `--watch` mode and reloads the
@@ -42,7 +41,7 @@ origins are wired by `.env.development` in each package (editor → player at
 
 | Command | What it does |
 | --- | --- |
-| `npm run dev` | Dev server with HMR (`tsx ./build.ts --watch`). |
+| `npm run dev` | The editor server alone (`tsx ./build.ts --watch`). The root `web:dev` launches this **plus** the player with consistent config — prefer that. |
 | `npm run build` | Production build to `out/` (minified). |
 | `npm start` | Serve a built `out/` (`node ./out/api/index.js`) — what the Docker image runs. |
 | `npm test` | Run the vitest suite (`test/**/*.test.ts`). |

--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "impower-monorepo",
   "type": "module",
   "private": true,
+  "scripts": {
+    "web:dev": "node scripts/dev-preview.mjs --mode same-origin",
+    "web:dev:same-origin": "node scripts/dev-preview.mjs --mode same-origin",
+    "web:dev:cross-origin": "node scripts/dev-preview.mjs --mode cross-origin",
+    "vscode:dev": "npm --prefix vscode-sparkdown run watch"
+  },
   "workspaces": [
     "packages/*",
     "!packages/concept-generator",

--- a/scripts/dev-preview.mjs
+++ b/scripts/dev-preview.mjs
@@ -1,0 +1,219 @@
+// One-command launcher for the live editor + game-preview player dev servers.
+//
+//   npm run web:dev               # same-origin (default)
+//   npm run web:dev:same-origin
+//   npm run web:dev:cross-origin
+//
+// The editor (impower-dev) and player (sparkdown-player-app) are two separate
+// Vite dev servers that talk over a postMessage/MessageChannel handshake. Wiring
+// them by hand is a footgun: the editor needs to know the player's real port,
+// the player needs to know the editor's origin to reply, and each editor needs a
+// unique HMR_PORT — get any of these wrong (or collide with another worktree's
+// servers) and the Game Preview silently stays BLACK. This script removes the
+// footgun: it grabs free ports, derives every cross-referencing env var
+// consistently for the chosen mode, launches both, waits for readiness, and
+// prints the URL. It never collides with other running worktrees because every
+// port is chosen free at launch time.
+//
+// Env overrides (optional): EDITOR_PORT, PLAYER_PORT, HMR_PORT force specific
+// ports instead of auto-picking free ones.
+
+import { spawn } from "node:child_process";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const IS_WIN = process.platform === "win32";
+
+// Ask the OS for a free TCP port by binding to :0 and reading the assignment.
+// There's an unavoidable tiny TOCTOU window between close() and the child
+// binding; we pass --strictPort to the player and pick the editor port last to
+// keep it small. Good enough for a dev launcher.
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+async function pickPort(envName) {
+  const forced = process.env[envName];
+  if (forced) return Number(forced);
+  return findFreePort();
+}
+
+// Poll an http URL until it answers (any status) or we give up.
+async function waitForHttp(url, { timeoutMs = 180_000, intervalMs = 500 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(url, { redirect: "manual" });
+      return true;
+    } catch {
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+  }
+  return false;
+}
+
+// Stream a child's output with a short prefix so both servers' logs interleave
+// readably in one terminal.
+function pipePrefixed(child, label) {
+  const prefix = `[${label}] `;
+  for (const stream of [child.stdout, child.stderr]) {
+    let buf = "";
+    stream?.on("data", (chunk) => {
+      buf += chunk.toString();
+      const lines = buf.split(/\r?\n/);
+      buf = lines.pop() ?? "";
+      for (const line of lines) process.stdout.write(prefix + line + "\n");
+    });
+  }
+}
+
+const children = [];
+
+function spawnServer(label, cwd, args, env) {
+  // `shell: true` is required on Windows so `npm` resolves to `npm.cmd` (Node 23
+  // refuses to spawn a `.cmd` directly) and is harmless on POSIX. Our args are
+  // all simple tokens (no spaces/quoting), so shell word-splitting is safe.
+  const child = spawn("npm", args, {
+    cwd: join(ROOT, cwd),
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: true,
+    windowsHide: true,
+  });
+  pipePrefixed(child, label);
+  child.on("exit", (code) => {
+    process.stdout.write(`[${label}] exited (code ${code})\n`);
+    shutdown(code ?? 0);
+  });
+  children.push(child);
+  return child;
+}
+
+let shuttingDown = false;
+function shutdown(code) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const child of children) {
+    if (child.pid == null || child.killed) continue;
+    if (IS_WIN) {
+      // npm.cmd spawns a node grandchild (vite/tsx) that a plain kill orphans —
+      // taskkill /T tears down the whole tree.
+      spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+        stdio: "ignore",
+      });
+    } else {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+  setTimeout(() => process.exit(code), 500);
+}
+
+process.on("SIGINT", () => shutdown(0));
+process.on("SIGTERM", () => shutdown(0));
+
+// Preview mode:
+//   same-origin  — the editor reverse-proxies the player under its OWN origin at
+//                  /__player/, so the live game DOM is reachable from the editor
+//                  page (window.__preview, devtools). Default.
+//   cross-origin — the editor embeds the player as a separate-origin iframe.
+// Both wire up identically from the user's side; they differ only in env. The
+// handshake works in both because the player learns the editor's origin
+// dynamically on localhost (sparkdown-player-app/src/main.ts).
+function parseMode() {
+  const i = process.argv.indexOf("--mode");
+  const mode = i >= 0 ? process.argv[i + 1] : "same-origin";
+  if (mode !== "same-origin" && mode !== "cross-origin") {
+    process.stderr.write(
+      `Unknown --mode "${mode}" (expected "same-origin" or "cross-origin").\n`,
+    );
+    process.exit(1);
+  }
+  return mode;
+}
+
+async function main() {
+  const mode = parseMode();
+  const editorPort = await pickPort("EDITOR_PORT");
+  const playerPort = await pickPort("PLAYER_PORT");
+  const hmrPort = await pickPort("HMR_PORT");
+
+  const editorOrigin = `http://localhost:${editorPort}`;
+  const playerOrigin = `http://localhost:${playerPort}`;
+
+  process.stdout.write(
+    `\nLaunching live preview (${mode}):\n` +
+      `  editor  ${editorOrigin}  (HMR ${hmrPort})\n` +
+      `  player  ${playerOrigin}\n\n`,
+  );
+
+  // Player. Both modes pass VITE_SPARKDOWN_EDITOR_ORIGIN so its handshake replies
+  // target the editor precisely (the localhost relaxation in main.ts is the
+  // safety net for hand-launches, not a substitute here).
+  if (mode === "same-origin") {
+    // Served under base "/__player/"; the editor proxies to it. The vite config
+    // reads SPARKDOWN_PLAYER_PORT (and pins hmr.clientPort to it); --strictPort
+    // makes a stolen port fail loudly instead of silently drifting.
+    spawnServer("player", "sparkdown-player-app", ["run", "dev", "--", "--strictPort"], {
+      VITE_SAME_ORIGIN_PREVIEW: "1",
+      SPARKDOWN_PLAYER_PORT: String(playerPort),
+      VITE_SPARKDOWN_EDITOR_ORIGIN: editorOrigin,
+    });
+  } else {
+    spawnServer("player", "sparkdown-player-app", ["run", "dev", "--", "--port", String(playerPort), "--strictPort"], {
+      VITE_SPARKDOWN_EDITOR_ORIGIN: editorOrigin,
+    });
+  }
+
+  // Editor.
+  if (mode === "same-origin") {
+    spawnServer("editor", "impower-dev", ["run", "dev"], {
+      PORT: String(editorPort),
+      HMR_PORT: String(hmrPort),
+      VITE_SAME_ORIGIN_PREVIEW: "1",
+      SPARKDOWN_PLAYER_DEV_ORIGIN: playerOrigin,
+      VITE_SPARKDOWN_EDITOR_ORIGIN: editorOrigin,
+    });
+  } else {
+    spawnServer("editor", "impower-dev", ["run", "dev"], {
+      PORT: String(editorPort),
+      HMR_PORT: String(hmrPort),
+      VITE_SPARKDOWN_PLAYER_ORIGIN: playerOrigin,
+      VITE_SPARKDOWN_EDITOR_ORIGIN: editorOrigin,
+    });
+  }
+
+  const ready = await waitForHttp(editorOrigin + "/");
+  if (ready) {
+    process.stdout.write(
+      `\n  ✓ Live preview ready → ${editorOrigin}\n` +
+        `    mode: ${mode}` +
+        (mode === "same-origin"
+          ? " (game DOM reachable via window.__preview)\n"
+          : "\n") +
+        `    (Ctrl+C stops both servers.)\n\n`,
+    );
+  } else {
+    process.stdout.write(
+      `\n  ! Editor did not become ready within the timeout — check the logs above.\n\n`,
+    );
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(String(err?.stack || err) + "\n");
+  shutdown(1);
+});

--- a/sparkdown-player-app/src/main.ts
+++ b/sparkdown-player-app/src/main.ts
@@ -17,6 +17,42 @@ import "./style.css";
 
 const SPARKDOWN_EDITOR_ORIGIN = import.meta.env.VITE_SPARKDOWN_EDITOR_ORIGIN;
 
+// Are we running on a local dev host? The editor's dev port varies per worktree,
+// so the build-time `VITE_SPARKDOWN_EDITOR_ORIGIN` is fragile in dev: if it's
+// unset or drifts from the editor's real port, EVERY handshake reply below posts
+// to the wrong (or `undefined` → throwing) targetOrigin and the Game Preview
+// silently stays BLACK — the editor never completes its connect/Initialize. On
+// localhost there's no cross-site security boundary to protect, so we relax:
+// accept the editor's connect from ANY origin and reply to the origin it
+// actually contacted us from (`replyTargetOrigin`, captured below), defaulting
+// to "*". Production (any non-localhost host) keeps the strict, build-time origin
+// so a hostile cross-site framer can never drive the player.
+const IS_LOCALHOST = ["localhost", "127.0.0.1", "[::1]"].includes(
+  window.location.hostname,
+);
+
+// The targetOrigin our postMessage replies go to. In prod it's the pinned
+// build-time origin. On localhost it starts permissive ("*") and is upgraded to
+// the editor's REAL origin as soon as the editor's first message arrives — so
+// even a missing/wrong VITE_SPARKDOWN_EDITOR_ORIGIN can't black-screen the
+// preview. The capture listener is registered BEFORE `connection.listen()` so the
+// value is resolved before the connection sends any reply.
+let replyTargetOrigin: string | undefined = IS_LOCALHOST
+  ? SPARKDOWN_EDITOR_ORIGIN || "*"
+  : SPARKDOWN_EDITOR_ORIGIN;
+if (IS_LOCALHOST) {
+  window.addEventListener("message", (e) => {
+    if (
+      e.source === window.parent &&
+      typeof e.origin === "string" &&
+      e.origin &&
+      e.origin !== "null"
+    ) {
+      replyTargetOrigin = e.origin;
+    }
+  });
+}
+
 // DEV-ONLY same-origin preview: when the editor proxies this app under its own
 // origin (see impower-dev/build.ts + vite base "/__player/"), our origin equals
 // the editor's. The postMessage handshake then matches exactly with no origin
@@ -38,8 +74,12 @@ const SAME_ORIGIN_PROXY = import.meta.env.BASE_URL.startsWith("/__player");
 
 const connection = new Port2MessageConnection(
   (message: any, transfer?: Transferable[]) =>
-    window.parent.postMessage(message, SPARKDOWN_EDITOR_ORIGIN, transfer),
-  SPARKDOWN_EDITOR_ORIGIN,
+    // `replyTargetOrigin || "*"` guards against an unset value ever reaching
+    // postMessage as `undefined` (which throws "Invalid target origin").
+    window.parent.postMessage(message, replyTargetOrigin || "*", transfer),
+  // Incoming-origin filter (Port2MessageConnection.canConnect): strict in prod,
+  // permissive on localhost dev so a drifted editor port can't reject connects.
+  IS_LOCALHOST ? undefined : SPARKDOWN_EDITOR_ORIGIN,
 );
 connection.listen();
 

--- a/vscode-sparkdown/README.md
+++ b/vscode-sparkdown/README.md
@@ -37,6 +37,31 @@ This extension contributes the following settings:
 
 > You can modify the look of your exported screenplays from `File > Preferences > Settings > Extensions > Sparkdown > Sparkdown Export`
 
+# Development
+
+> For contributors building the extension from source (not installing it from the
+> Marketplace).
+
+This package lives in an npm-workspaces monorepo. Install once from the **repo
+root**, then start the extension's dev build loop with the root launcher:
+
+```sh
+npm install        # at the monorepo root — sets up all workspaces
+npm run vscode:dev # at the monorepo root — builds + watches the extension
+```
+
+`vscode:dev` runs this package's `watch` (`npm-run-all -p watch:*`), which builds
+and watches everything the extension bundles: the language server, the
+spark-web-player, the screenplay-PDF exporter, and the screenplay / game / screen
+/ inspector webviews, plus the extension host code itself.
+
+With that watcher running, press **F5** in VS Code (the _Run Extension_ launch
+config) to open an Extension Development Host with the extension loaded; rebuilds
+from the watcher are picked up on reload.
+
+> Working on the **web app** instead of the extension? Use `npm run web:dev` from
+> the root — see the [root README](../README.md).
+
 # Known Issues
 
 [Issue Tracker](https://github.com/ImpowerGames/impower/labels/vscode)


### PR DESCRIPTION
## Problem

Running the editor (`impower-dev`) and game-preview player (`sparkdown-player-app`) by hand is a footgun. The editor embeds the player as an `<iframe>` and they connect over a postMessage/MessageChannel handshake that needs three things to agree:

- the editor's `VITE_SPARKDOWN_PLAYER_ORIGIN` → the player's real port,
- the player's `VITE_SPARKDOWN_EDITOR_ORIGIN` → the editor's origin (so its replies land), and
- a **unique** `HMR_PORT` per editor.

Get any wrong — or collide with another running checkout — and the **Game Preview silently stays black** even on PLAY (the editor never finishes connecting; the editor pane itself looks fine). These are build-time Vite vars, so a reload won't fix a wrong one. This bites both humans and agents.

## Changes

**1. One-command launcher** — `scripts/dev-preview.mjs`, exposed from the repo root:

| Command | Mode |
|---|---|
| `npm run web:dev` | same-origin (default) |
| `npm run web:dev:same-origin` | same-origin (explicit) |
| `npm run web:dev:cross-origin` | separate-origin iframe |
| `npm run vscode:dev` | extension build-watch (`vscode-sparkdown`) |

It picks **free** ports (never colliding with another worktree), derives every cross-referencing env var consistently for the chosen mode, launches both servers, waits for readiness, and prints the URL. `Ctrl+C` stops both. No new dependencies (`node:net` + `child_process`). Override ports with `EDITOR_PORT` / `PLAYER_PORT` / `HMR_PORT`.

**2. Footgun-proof the handshake** — `sparkdown-player-app/src/main.ts`. On `localhost` the player now accepts the editor's connect from any origin and replies to the origin it was actually contacted from (captured from the first message; fallback `"*"`), instead of depending on the build-time `VITE_SPARKDOWN_EDITOR_ORIGIN`. A missing/wrong editor-origin can no longer black-screen the preview in dev. **Production (non-localhost) stays strict.**

**3. Docs** — root `README.md` + `CLAUDE.md` (for agents), `impower-dev/README.md`, and `vscode-sparkdown/README.md` now describe the `web:dev` / `vscode:dev` flow and the black-screen failure signature, replacing the old "run two servers in two terminals" instructions that silently break on non-default ports.

## Verification (live, in-browser)

- `npm run web:dev` (same-origin) → editor + player come up on auto-picked free ports; game preview renders text; `window.__preview` confirms same-origin.
- **Hardening:** launched the player **without** `VITE_SPARKDOWN_EDITOR_ORIGIN` (the exact config that black-screened this work earlier) → the preview now renders ("The handshake works with no editor-origin var.").
- Launcher never collided with the several other worktree servers already running.

> Note: this branch is off `main`, which doesn't yet have the trailing-glue fix (#204), so glue joins aren't exercised here — this PR is purely dev tooling + the player handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)