### PR TITLE
fix(sparkdown): resolve filtered_image portraits defined with image = <ref>

### DIFF
--- a/packages/sparkdown/src/compiler/lower/lowerers/lowerLuauDefine.ts
+++ b/packages/sparkdown/src/compiler/lower/lowerers/lowerLuauDefine.ts
@@ -411,10 +411,29 @@ export function lowerLuauDefine(
       const struct: Record<string, unknown> = { $type: type, $name: name };
       const flat: Record<string, unknown> = {};
       for (const prop of properties) {
+        // A bare/dotted reference used as a SCALAR value (e.g. a
+        // `filtered_image`'s `image = bunny_realization`) is a struct
+        // reference, not a string — it must reach context as a
+        // `{ $type, $name }` object so the engine's spec system can resolve it
+        // (matching `schema_filtered_image`/`default_filtered_image`, the
+        // implicit filtered_image defs, references inside `{ … }` tables, and
+        // the legacy colon-form). `coerceScalarLiteral` would otherwise claim
+        // the bare identifier as a plain string, leaving `filterImage` unable
+        // to find the base image (its `image.$name` read yields `undefined`),
+        // so the filtered image silently renders nothing. Only a value that
+        // parses as a plain reference takes this path; engine value tokens like
+        // `surface-2` don't (they aren't a single/dotted VariableReference), so
+        // they still fall through to the raw-string scalar coercion below.
+        let value =
+          prop.expr instanceof VariableReference
+            ? expressionToContextValue(prop.expr)
+            : undefined;
         // Scalars (and engine value tokens like `surface-2`) come from the
         // raw source; tables/arrays/references fall back to the parsed
         // expression so a `layered_image`'s `assets = { … }` reaches context.
-        let value = coerceScalarLiteral(prop.rawValue);
+        if (value === undefined) {
+          value = coerceScalarLiteral(prop.rawValue);
+        }
         if (value === undefined) {
           value = expressionToContextValue(prop.expr);
         }

--- a/packages/sparkdown/src/tests/runtime/DefineNonScalarContext.test.ts
+++ b/packages/sparkdown/src/tests/runtime/DefineNonScalarContext.test.ts
@@ -116,4 +116,36 @@ end
     expect(errors).toEqual([]);
     expect(out).toContain("Hello.");
   });
+
+  test("a SCALAR bare reference emits a {$type,$name} object, not a string", () => {
+    // Regression: a `filtered_image`'s `image = bunny_realization` is a struct
+    // reference, but `coerceScalarLiteral` used to claim the bare identifier as
+    // a plain string "bunny_realization". The engine's `filterImage` reads
+    // `image.$name`, so a string left it unable to find the base image and the
+    // portrait silently rendered nothing. It must reach context as a reference
+    // object, matching `schema_filtered_image` / `default_filtered_image`.
+    const result = compile(`define bunny_angry as filtered_image with
+  image = bunny_realization
+  filters = {
+    face_angry,
+  }
+end
+`);
+    const fi = result.program.context?.["filtered_image"]?.["bunny_angry"];
+    expect(fi).toBeDefined();
+    expect(fi!["image"]).toEqual({ $type: "", $name: "bunny_realization" });
+    // Non-scalar table refs still compile to references too.
+    expect(fi!["filters"]).toEqual([{ $type: "", $name: "face_angry" }]);
+  });
+
+  test("a quoted string scalar stays a string (reference fix must not capture it)", () => {
+    const result = compile(`define panel as character with
+  name = "PANEL"
+  color = "surface"
+end
+`);
+    const c = result.program.context?.["character"]?.["panel"];
+    expect(c!["name"]).toBe("PANEL");
+    expect(c!["color"]).toBe("surface");
+  });
 });


### PR DESCRIPTION
Fixes filtered_image portraits defined with a scalar image reference (image = SomeName) rendering blank in the web preview.

Root cause: when an OOP define is emitted into program.context, a scalar property value goes through coerceScalarLiteral first, which returns a bare identifier as a raw string. But the engine treats a filtered image's image field as a reference object (type/name), and filterImage reads image.name -- on a string that is undefined, so the base image is never found and nothing renders. This affects every explicit filtered_image built on image = Name (implicit raw-SVG portraits still work, which is why only some portraits were blank).

Fix: in lowerLuauDefine, when a property value parses as a single or dotted reference, emit it as a type/name object instead of a raw string. Value tokens like surface-2 (which do not parse as a plain reference) and quoted strings/numbers/tables are unchanged.

Verification: verified live in the running web preview (the affected portrait now renders, and the compiled image field is now a reference object); full sparkdown test suite passes (1513 passed, 24 skipped, 0 failed); added regression tests to DefineNonScalarContext.test.ts.

Follow-up (not in this PR): a separate content issue in the sample project (a layered_image referencing a layer name that no longer matches the asset files) leaves that one backdrop blank -- a project-side reference fix, not an engine bug.

Generated with Claude Code.