### PR TITLE
fix(player): play character voices/sfx in the live preview

### DIFF
--- a/packages/spark-web-player/src/GamePlayerController.ts
+++ b/packages/spark-web-player/src/GamePlayerController.ts
@@ -173,6 +173,10 @@ export class GamePlayerController {
     window.addEventListener("contextmenu", this.handleContextMenu, true);
     window.addEventListener("dragstart", this.handleDragStart);
     window.addEventListener("resize", this.handleResize);
+    // Unlock/adopt the shared AudioContext on the first user interaction with the
+    // preview so voices start playing immediately (browsers require a gesture).
+    window.addEventListener("pointerdown", this.handleUserInteraction, true);
+    window.addEventListener("keydown", this.handleUserInteraction, true);
     this.refs.playButton?.addEventListener("click", this.handleClickPlayButton);
     this.refs.toolbar?.addEventListener(
       "pointerdown",
@@ -212,6 +216,8 @@ export class GamePlayerController {
     window.removeEventListener("contextmenu", this.handleContextMenu);
     window.removeEventListener("dragstart", this.handleDragStart);
     window.removeEventListener("resize", this.handleResize);
+    window.removeEventListener("pointerdown", this.handleUserInteraction, true);
+    window.removeEventListener("keydown", this.handleUserInteraction, true);
     this.refs.playButton?.removeEventListener(
       "click",
       this.handleClickPlayButton,
@@ -499,13 +505,32 @@ export class GamePlayerController {
     (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
   };
 
-  protected handleClickPlayButton = async () => {
-    if (!this._audioContext || this._audioContext.state !== "running") {
-      const audioContext = new AudioContext();
-      if (audioContext.state === "running") {
-        this._audioContext = audioContext;
-      }
+  // Create ONE shared AudioContext (cached on the controller) and resume it once
+  // the user has interacted with the page — browsers gate audio behind a user
+  // gesture. It is reused for every Application built afterward (including the
+  // preview reconstructions that happen on every edit), so no new context is
+  // minted per edit. Applied to the live app immediately once running, so
+  // preview audio (character voices, sfx) starts on the first interaction.
+  ensureAudioContext = async (): Promise<void> => {
+    if (!this._audioContext) {
+      this._audioContext = new AudioContext();
     }
+    if (this._audioContext.state !== "running") {
+      try {
+        await this._audioContext.resume();
+      } catch {}
+    }
+    if (this._audioContext.state === "running") {
+      this._app?.setAudioContext(this._audioContext);
+    }
+  };
+
+  protected handleUserInteraction = () => {
+    void this.ensureAudioContext();
+  };
+
+  protected handleClickPlayButton = async () => {
+    await this.ensureAudioContext();
     await this.startGameAndApp();
     this.hidePlayButton();
     sendProtocolMessage(GameStartedMessage.type.notification({}), this.host);
@@ -1157,6 +1182,10 @@ export class GamePlayerController {
       profile("end", "app/destroy");
     }
     this.updateExecutionLabels();
+    // Ensure the single shared AudioContext exists (and is resumed if the user
+    // has already interacted) so it can be handed to this Application — this is
+    // what lets preview reconstructions keep audio without minting a new context.
+    await this.ensureAudioContext();
     profile("start", "app/create");
     this._app = new Application(
       game,

--- a/packages/spark-web-player/src/app/Application.ts
+++ b/packages/spark-web-player/src/app/Application.ts
@@ -202,8 +202,19 @@ export class Application implements IApplication {
       resolution: window.devicePixelRatio,
     };
 
-    if (!this._game.context.system.previewing) {
-      this._audioContext = audioContext || new AudioContext();
+    // Use the shared AudioContext the controller owns (passed in via
+    // `audioContext`) — including in preview mode, so preview audio (character
+    // voices, sfx) plays. We must NOT create a new context per Application in
+    // preview: the Application is re-created on every edit, so minting one each
+    // time would exhaust the browser's per-page context limit (the reason
+    // preview mode used to skip this entirely). The controller creates a single
+    // shared context once and reuses it; here we only adopt it. Outside preview
+    // (e.g. the standalone player), fall back to creating one if none was passed.
+    const sharedAudioContext =
+      audioContext ||
+      (this._game.context.system.previewing ? undefined : new AudioContext());
+    if (sharedAudioContext) {
+      this._audioContext = sharedAudioContext;
       if (this._audioContext.state !== "running") {
         this._audioContext = undefined;
       } else {


### PR DESCRIPTION
Fixes character voice beeps (and other synth/sfx audio) being silent in the editor's live preview.

Root cause: the player's Application is re-created on every edit, and in preview mode it never had an AudioContext. AudioManager gates all playback on the app audio context, so with no context the synth voices are never built. This traces to commit eebe0549 (Don't create AudioContext in preview mode), which correctly stopped a NEW context being minted per preview reconstruction (that would exhaust the browser per-page context limit), but left preview with no context at all -- and nothing populated a reusable shared one (the only setter, handleClickPlayButton, is the standalone player button and is not used by the editor preview; a running Application that made its own context never shared it back). Instrumentation showed the Application reconstructed ~6 times per load in preview, every time with no context.

Fix: GamePlayerController now owns a single shared AudioContext. ensureAudioContext lazily creates it once (cached on the controller) and resumes it once the user has interacted (browsers gate audio behind a gesture); it is wired to the first pointerdown/keydown and to buildApp, and applied to the live app immediately. Every Application, including every preview reconstruction, now adopts this one shared context instead of minting its own -- so no new context is created per edit (honoring the original intent), but preview once again has a context to play through. Application.ts now adopts the passed-in context in preview mode too.

Verification: verified deterministically in the running editor with temporary logging (I cannot hear audio) -- after the fix every preview Application receives a running context and reuses the one shared context across all reconstructions, where before it had none. Please confirm the beeps are audible on your end: voices should start on the first click or keypress in the preview and keep playing as you edit.

Generated with Claude Code.