### PR TITLE
feat(sparkdown): display flipped portraits via `with flip`

### DIFF
--- a/packages/spark-dom/src/classes/AnimationPlayer.ts
+++ b/packages/spark-dom/src/classes/AnimationPlayer.ts
@@ -27,7 +27,16 @@ export default class AnimationPlayer {
       // Convert engine animations to dom animations
       animations.forEach((animation) => {
         const convertedKeyframes: Keyframe[] = [];
-        animation.keyframes.forEach((keyframe) => {
+        // A single keyframe authored as `keyframes = { transform = ... }`
+        // compiles to an object, not an array — and an object has no `.forEach`,
+        // so this used to throw and the animation never played. Normalize a lone
+        // keyframe object into a one-element array.
+        const keyframes = Array.isArray(animation.keyframes)
+          ? animation.keyframes
+          : animation.keyframes
+            ? [animation.keyframes]
+            : [];
+        keyframes.forEach((keyframe) => {
           if (keyframe) {
             const convertedKeyframe: Keyframe = {};
             for (const [k, v] of Object.entries(keyframe)) {

--- a/packages/spark-dom/src/utils/getAnimationContent.ts
+++ b/packages/spark-dom/src/utils/getAnimationContent.ts
@@ -8,11 +8,21 @@ export const getAnimationContent = (
   let textContent = "";
   Object.entries(animations).forEach(([name, animation]) => {
     let animationContent = "";
-    if (animation.keyframes) {
-      for (let i = 0; i < animation.keyframes.length; i++) {
-        const max = animation.keyframes.length - 1;
+    // A single keyframe authored as `keyframes = { transform = ... }` compiles
+    // to an object, not an array — and an object's `length` is `undefined`, so
+    // the loop below used to run zero times and silently emit no `@keyframes`
+    // (the animation then did nothing). Normalize a lone keyframe object into a
+    // one-element array so it still produces a `to { … }` keyframe.
+    const keyframes = Array.isArray(animation.keyframes)
+      ? animation.keyframes
+      : animation.keyframes
+        ? [animation.keyframes]
+        : [];
+    if (keyframes.length) {
+      for (let i = 0; i < keyframes.length; i++) {
+        const max = keyframes.length - 1;
         const offset = max === 0 ? "to" : `${(i / max) * 100}%`;
-        const engineKeyframe = animation.keyframes[i];
+        const engineKeyframe = keyframes[i];
         const domKeyframe: Record<string, any> = {};
         if (engineKeyframe) {
           for (const [k, v] of Object.entries(engineKeyframe)) {

--- a/packages/spark-engine/src/game/modules/ui/classes/UIModule.ts
+++ b/packages/spark-engine/src/game/modules/ui/classes/UIModule.ts
@@ -796,7 +796,13 @@ export class UIModule extends Module<UIState, UIMessageMap, UIBuiltins> {
       const duration = durationOverride ?? animation?.timing?.duration ?? "0s";
       const iterations = loopOverride ?? animation?.timing?.iterations ?? 1;
       const easing = easingOverride ?? animation?.timing?.easing ?? "ease";
-      const fill = animation?.timing?.fill ?? "none";
+      // Default to "both" to match `default_animation` and every builtin
+      // animation (all use fill "both"); the other fallbacks here already
+      // mirror `default_animation`. Defaulting to "none" instead made any
+      // animation authored without an explicit `timing` (e.g. a `flip` that is
+      // just `keyframes = { transform = "scaleX(-1)" }`) apply its end state for
+      // a frame and then revert, so a persistent transform never showed.
+      const fill = animation?.timing?.fill ?? "both";
       const direction = animation?.timing?.direction ?? "normal";
       const keyframes = animation?.keyframes;
       const timing = {

--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -2127,11 +2127,19 @@ export class SparkdownCompiler {
         const annotations = this.documents.annotations(uri);
         const cur = annotations.implicits.iter();
         while (cur.value) {
-          const text = doc.read(cur.from, cur.to);
+          // Trim the read text AND each `~`-separated part: when an asset
+          // command is followed by a clause (e.g. `[[hero~a~b with flip]]`),
+          // the `AssetCommandName` node greedily includes the trailing space
+          // before the clause, so the last filter would otherwise be `"b "`.
+          // That produced a filtered_image keyed `hero~a~b ` (with a space),
+          // which never matched the reference's clean `sortFilteredName` key —
+          // so the image "could not be found" whenever a `with`/`over`/etc.
+          // clause was present.
+          const text = doc.read(cur.from, cur.to).trim();
           if (!resolvedImplicits.has(text)) {
             resolvedImplicits.add(text);
             const type = cur.value.type;
-            const parts = text.split("~");
+            const parts = text.split("~").map((part) => part.trim());
             const [fileName, ...filterNames] = parts;
             const sortedFilterNames = filterNames.sort();
             const name = [fileName, ...sortedFilterNames].join("~");

--- a/packages/sparkdown/src/tests/runtime/ImplicitFilteredImageClause.test.ts
+++ b/packages/sparkdown/src/tests/runtime/ImplicitFilteredImageClause.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+
+const compile = (text: string) => {
+  const compiler = new SparkdownCompiler();
+  compiler.configure({
+    files: [
+      {
+        uri: "inmemory:///main.sd",
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text,
+        version: 1,
+        languageId: "sparkdown",
+      } as any,
+    ],
+  });
+  return compiler.compile({ textDocument: { uri: "inmemory:///main.sd" } });
+};
+
+const SORTED = "bunny_suspicious~look_left~phone";
+
+describe("implicit filtered_image is created regardless of a trailing clause", () => {
+  test("a filtered asset with NO clause creates the implicit filtered_image", () => {
+    const result = compile(`-> main
+
+scene main
+  [[bunny_suspicious~phone~look_left]]
+  done
+end
+`);
+    const images = result.program.context?.["filtered_image"] ?? {};
+    expect(Object.keys(images)).toContain(SORTED);
+  });
+
+  test("a filtered asset WITH a `with` clause still creates the SAME clean key", () => {
+    // Regression: the `AssetCommandName` node greedily includes the trailing
+    // space before the clause, so the last filter used to become "look_left ",
+    // producing a mismatched `bunny_suspicious~look_left ~phone` key (note the
+    // space) that never matched the reference's `sortFilteredName` key — the
+    // image "could not be found" whenever a clause like `with flip` followed.
+    const result = compile(`-> main
+
+define flip as animation with
+  keyframes = {
+    transform = "scaleX(-1)"
+  }
+end
+
+scene main
+  [[bunny_suspicious~phone~look_left with flip]]
+  done
+end
+`);
+    const images = result.program.context?.["filtered_image"] ?? {};
+    const bunnyKeys = Object.keys(images).filter((k) =>
+      k.startsWith("bunny_suspicious"),
+    );
+    // Exactly the clean, space-free key — and no spaced variant.
+    expect(bunnyKeys).toEqual([SORTED]);
+    expect(bunnyKeys.some((k) => k.includes(" "))).toBe(false);
+  });
+});


### PR DESCRIPTION
Makes `[[portrait~filters with flip]]` display a portrait mirrored (and stay mirrored) in the preview. Getting there required fixing four distinct bugs across the pipeline; each is a separate, self-contained commit.

1. Compiler -- filtered image + a trailing clause could not resolve. `[[hero~a~b with flip]]` warned "Cannot find image named hero~a~b" while `[[hero~a~b]]` worked. The grammar AssetCommandName node greedily includes the trailing space before the clause, so the last filter parsed as "b " (with a space); populateImplicitDefs then keyed the implicit filtered_image as "hero~a~b " which never matched the reference side's clean sortFilteredName key. Fixed by trimming the text and each tilde-part.

2. spark-dom getAnimationContent -- a single keyframe authored as an object (keyframes = { transform = "scaleX(-1)" }) produced no @keyframes rule at all, because the loop used keyframes.length (undefined on an object). Normalized a lone keyframe object into a one-element array.

3. spark-dom AnimationPlayer -- the same object threw on keyframes.forEach when applying the animation via the Web Animations API. Same normalization.

4. spark-engine getAnimation -- an unspecified timing.fill defaulted to "none", while default_animation, the animation $default, and every builtin all use "both" (and every other fallback in getAnimation already mirrors default_animation). So an animation authored without an explicit timing applied its end state for one frame and then reverted -- the flip never visibly stuck. Defaulted fill to "both" to match the rest of the engine; builtins set fill explicitly so they are unaffected.

Verification: the compiler fix has a regression test and the full sparkdown suite passes (1515). The three runtime fixes were verified live in the editor preview (screenshot + DOM): the affected portrait now renders with computed transform matrix(-1,0,0,1,0,0) and stays mirrored on a clean reload.

Note on authoring: with these fixes a persistent flip can be written simply as `define flip as animation with keyframes = { transform = "scaleX(-1)" } end`; a single keyframe object is accepted, and it persists by default.

Generated with Claude Code.