### PR TITLE
Support color emoji in screenplay preview, PDF, and HTML export

### DIFF
--- a/impower-app/modules/impower-route-engine/utils/exportHtml.ts
+++ b/impower-app/modules/impower-route-engine/utils/exportHtml.ts
@@ -10,6 +10,7 @@ import bolditalic from "../../../public/fonts/courier-prime-bold-italic.ttf";
 import bold from "../../../public/fonts/courier-prime-bold.ttf";
 import italic from "../../../public/fonts/courier-prime-italic.ttf";
 import normal from "../../../public/fonts/courier-prime.ttf";
+import emoji from "../../../public/fonts/noto-color-emoji.ttf";
 import { SPARK_SCREENPLAY_CONFIG } from "../constants/SPARK_SCREENPLAY_CONFIG";
 import { downloadFile } from "./downloadFile";
 
@@ -35,6 +36,7 @@ export const exportHtml = async (
     bold: decodeBase64(bold),
     italic: decodeBase64(italic),
     bolditalic: decodeBase64(bolditalic),
+    emoji: decodeBase64(emoji),
   });
   downloadFile(`${name}.html`, "text/html", html);
 };

--- a/impower-app/modules/impower-route-engine/utils/exportPdf.ts
+++ b/impower-app/modules/impower-route-engine/utils/exportPdf.ts
@@ -12,6 +12,7 @@ import bolditalic from "../../../public/fonts/courier-prime-bold-italic.ttf";
 import bold from "../../../public/fonts/courier-prime-bold.ttf";
 import italic from "../../../public/fonts/courier-prime-italic.ttf";
 import normal from "../../../public/fonts/courier-prime.ttf";
+import emoji from "../../../public/fonts/noto-color-emoji.ttf";
 import { SPARK_SCREENPLAY_CONFIG } from "../constants/SPARK_SCREENPLAY_CONFIG";
 import { createPdfDocument } from "./createPdfDocument";
 import { downloadFile } from "./downloadFile";
@@ -38,6 +39,7 @@ export const exportPdf = async (
     bold: decodeBase64(bold),
     italic: decodeBase64(italic),
     bolditalic: decodeBase64(bolditalic),
+    emoji: decodeBase64(emoji),
   });
   const doc = createPdfDocument(pdfData);
   pdfGenerate(doc, pdfData);

--- a/impower-app/pages/_document.tsx
+++ b/impower-app/pages/_document.tsx
@@ -160,6 +160,11 @@ export default class MyDocument extends Document {
             as="font"
             crossOrigin="anonymous"
           />
+          <link
+            href="/fonts/noto-color-emoji.ttf"
+            as="font"
+            crossOrigin="anonymous"
+          />
 
           <link rel="stylesheet" href="/style.css" />
 

--- a/impower-app/public/style.css
+++ b/impower-app/public/style.css
@@ -92,6 +92,13 @@
     url("/fonts/courier-prime-sans-bold-italic.ttf") format("truetype");
 }
 
+@font-face {
+  font-family: "Noto Color Emoji";
+  font-display: block;
+  src: local(""),
+    url("/fonts/noto-color-emoji.ttf") format("truetype");
+}
+
 /* WARNING: webkit-scrollbar is not supported in Firefox and IE */
 *::-webkit-scrollbar {
   width: 8px;

--- a/impower-dev/src/modules/spark-editor/components/share-screenplay/ShareScreenplay.tsx
+++ b/impower-dev/src/modules/spark-editor/components/share-screenplay/ShareScreenplay.tsx
@@ -65,9 +65,11 @@ export default function ShareScreenplay(_props: ShareScreenplayProps) {
       const projectName = store.project?.name;
       if (!projectId || !projectName) return;
 
-      const programs = Object.values(
-        (await Workspace.ls.getPrograms()) || {},
-      );
+      // Screenplay export parses the raw .sd text (not the compiled program),
+      // so bundle the project's script files into the script list.
+      const scriptBundle =
+        await Workspace.fs.readProjectScriptBundle(projectId);
+      const programs = [scriptBundle];
       const onProgress = (value?: { percentage?: number }) => {
         const pct = (value?.percentage ?? 0) / 100;
         setProgress((p) => ({ ...p, [format]: pct }));

--- a/impower-dev/src/modules/spark-editor/workspace/WorkspacePrint.ts
+++ b/impower-dev/src/modules/spark-editor/workspace/WorkspacePrint.ts
@@ -3,10 +3,12 @@ import {
   ExportPDFMessage,
   ExportPDFParams,
 } from "@impower/spark-editor-protocol/src/protocols/workspace/ExportPDFMessage";
+import {
+  ExportHTMLMessage,
+  ExportHTMLParams,
+} from "@impower/spark-editor-protocol/src/protocols/workspace/ExportHTMLMessage";
 import { ProgressValue } from "@impower/spark-editor-protocol/src/types/base/ProgressValue";
-import ScreenplayParser from "../../../../../packages/sparkdown-screenplay/src/classes/ScreenplayParser";
 import { ScreenplayConfig } from "../../../../../packages/sparkdown-screenplay/src/types/ScreenplayConfig";
-import { generateScreenplayHtmlData } from "../../../../../packages/sparkdown-screenplay/src/utils/generateScreenplayHtmlData";
 
 export default class WorkspacePrint {
   protected _worker: Worker;
@@ -55,11 +57,16 @@ export default class WorkspacePrint {
       cache: "force-cache",
     });
     const bolditalic = await boldItalicResp.arrayBuffer();
+    const emojiResp = await fetch("/fonts/noto-color-emoji.ttf", {
+      cache: "force-cache",
+    });
+    const emoji = await emojiResp.arrayBuffer();
     return {
       normal,
       bold,
       italic,
       bolditalic,
+      emoji
     };
   }
 
@@ -97,7 +104,10 @@ export default class WorkspacePrint {
     return new Promise((resolve, reject) => {
       const request = type.request(params);
       this._messageQueue[request.id] = { resolve, reject };
-      if (type.method === "workspace/exportPDF") {
+      if (
+        type.method === "workspace/exportPDF" ||
+        type.method === "workspace/exportHTML"
+      ) {
         this._worker.postMessage(request, transfer);
       }
     });
@@ -118,6 +128,7 @@ export default class WorkspacePrint {
       params.fonts.bold,
       params.fonts.italic,
       params.fonts.bolditalic,
+      params.fonts.emoji,
     ]);
   }
 
@@ -125,9 +136,20 @@ export default class WorkspacePrint {
     scripts: string[],
     onProgress?: (value: ProgressValue) => void,
   ) {
+    // Runs in the worker (see sparkdown-screenplay-pdf.ts) so fontkit's Buffer
+    // shim is available to embed only the emoji this script uses as inline SVG.
     const fonts = await this.getFonts();
-    const parser = new ScreenplayParser();
-    const tokens = parser.parseAll(scripts);
-    return generateScreenplayHtmlData(tokens, this.config, fonts);
+    const params: ExportHTMLParams = { scripts, fonts, config: this.config };
+    if (onProgress) {
+      params.workDoneToken = ExportHTMLMessage.type.uuid();
+      this._progressQueue[params.workDoneToken] = onProgress;
+    }
+    return this.sendRequest(ExportHTMLMessage.type, params, [
+      params.fonts.normal,
+      params.fonts.bold,
+      params.fonts.italic,
+      params.fonts.bolditalic,
+      params.fonts.emoji,
+    ]);
   }
 }

--- a/impower-dev/src/public/document.css
+++ b/impower-dev/src/public/document.css
@@ -58,6 +58,13 @@
   src: url("/fonts/courier-prime-bold-italic.ttf") format("truetype");
 }
 
+@font-face {
+  font-family: "Noto Color Emoji";
+  font-display: block;
+  src: local(""),
+    url("/fonts/noto-color-emoji.ttf") format("truetype");
+}
+
 :root {
   color-scheme: dark;
   --screenplay-preview-texture: url("/noisetexture.png");

--- a/impower-dev/src/public/document.html
+++ b/impower-dev/src/public/document.html
@@ -16,6 +16,7 @@
   <link rel="preload" href="/fonts/courier-prime-sans-bold.ttf" as="font" type="font/ttf" crossorigin>
   <link rel="preload" href="/fonts/courier-prime-sans-italic.ttf" as="font" type="font/ttf" crossorigin>
   <link rel="preload" href="/fonts/courier-prime-sans-bold-italic.ttf" as="font" type="font/ttf" crossorigin>
+  <link rel="preload" href="/fonts/noto-color-emoji.ttf" as="font" type="font/ttf" crossorigin>
   <style>
     html {
       opacity: 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14949,6 +14949,15 @@
         "node": ">=20.11.1"
       }
     },
+    "node_modules/svg-to-pdfkit": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/svg-to-pdfkit/-/svg-to-pdfkit-0.1.8.tgz",
+      "integrity": "sha512-QItiGZBy5TstGy+q8mjQTMGRlDDOARXLxH+sgVm1n/LYeo0zFcQlcCh8m4zi8QxctrxB9Kue/lStc/RD5iLadQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pdfkit": ">=0.8.1"
+      }
+    },
     "node_modules/svgo": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
@@ -20151,6 +20160,7 @@
         "pdfkit": "^0.14.0",
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0",
+        "svg-to-pdfkit": "^0.1.8",
         "util": "^0.12.5"
       },
       "bin": {

--- a/packages/spark-editor-protocol/src/protocols/workspace/ExportHTMLMessage.ts
+++ b/packages/spark-editor-protocol/src/protocols/workspace/ExportHTMLMessage.ts
@@ -1,0 +1,26 @@
+import { ScreenplayConfig } from "../../../../sparkdown-screenplay/src/types/ScreenplayConfig";
+import { MessageProtocolRequestType } from "../MessageProtocolRequestType";
+
+export type ExportHTMLMethod = typeof ExportHTMLMessage.method;
+
+export interface ExportHTMLParams {
+  scripts: string[];
+  fonts: {
+    normal: ArrayBuffer;
+    bold: ArrayBuffer;
+    italic: ArrayBuffer;
+    bolditalic: ArrayBuffer;
+    [name: string]: ArrayBuffer;
+  };
+  config?: ScreenplayConfig;
+  workDoneToken?: string;
+}
+
+export class ExportHTMLMessage {
+  static readonly method = "workspace/exportHTML";
+  static readonly type = new MessageProtocolRequestType<
+    ExportHTMLMethod,
+    ExportHTMLParams,
+    string
+  >(ExportHTMLMessage.method);
+}

--- a/packages/sparkdown-document-views/src/modules/screenplay-preview/constants/PREVIEW_THEME.ts
+++ b/packages/sparkdown-document-views/src/modules/screenplay-preview/constants/PREVIEW_THEME.ts
@@ -13,7 +13,8 @@ const PREVIEW_THEME: {
     color: "#333",
   },
   "& .cm-scroller": {
-    fontFamily: "Courier Prime",
+    fontFamily:
+      '"Courier Prime", "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", monospace',
     fontSize: "1rem",
     overflow: "visible",
     position: "relative",

--- a/packages/sparkdown-document-views/src/modules/script-editor/ScriptEditorController.ts
+++ b/packages/sparkdown-document-views/src/modules/script-editor/ScriptEditorController.ts
@@ -872,6 +872,11 @@ export class ScriptEditorController {
         'url("/fonts/courier-prime-bold-italic.ttf") format("truetype")',
         { style: "italic", weight: "700", display: "block" },
       );
+      const notoColorEmoji = new FontFace(
+        '"Noto Color Emoji"',
+        'url("/fonts/noto-color-emoji.ttf") format("truetype")',
+        { style: "normal", weight: "normal", display: "block" },
+      );
       await Promise.all(
         [
           courierPrimeSans,
@@ -882,6 +887,7 @@ export class ScriptEditorController {
           courierPrimeBold,
           courierPrimeItalic,
           courierPrimeBoldItalic,
+          notoColorEmoji
         ].map(async (fontFace) => {
           if (
             "add" in document.fonts &&

--- a/packages/sparkdown-document-views/src/modules/script-editor/constants/EDITOR_THEME.ts
+++ b/packages/sparkdown-document-views/src/modules/script-editor/constants/EDITOR_THEME.ts
@@ -86,7 +86,8 @@ const EDITOR_THEME: {
     overscrollBehavior: "none",
   },
   "& .cm-line": {
-    fontFamily: "Courier Prime Sans",
+    fontFamily:
+      '"Courier Prime Sans", "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", monospace',
   },
   "& .cm-gutters": {
     fontFamily: "Courier Prime Sans",

--- a/packages/sparkdown-screenplay-pdf/package.json
+++ b/packages/sparkdown-screenplay-pdf/package.json
@@ -57,6 +57,7 @@
     "pdfkit": "^0.14.0",
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
+    "svg-to-pdfkit": "^0.1.8",
     "util": "^0.12.5"
   },
   "peerDependencies": {

--- a/packages/sparkdown-screenplay-pdf/src/buildPDF.ts
+++ b/packages/sparkdown-screenplay-pdf/src/buildPDF.ts
@@ -4,6 +4,8 @@ import type { ScreenplayConfig } from "@impower/sparkdown-screenplay/src/types/S
 import { generateScreenplayPrintData } from "@impower/sparkdown-screenplay/src/utils/generateScreenplayPrintData";
 import PdfWriteStream from "./classes/PdfWriteStream";
 import ScreenplayPrinter from "./classes/ScreenplayPrinter";
+import EmojiSvgProvider from "./emoji/EmojiSvgProvider";
+import { setEmojiProvider } from "./emoji/emojiText";
 
 export const buildPDF = async (
   scripts: string[],
@@ -13,6 +15,7 @@ export const buildPDF = async (
     bold: ArrayBuffer;
     italic: ArrayBuffer;
     bolditalic: ArrayBuffer;
+    emoji?: ArrayBuffer;
   },
   onProgress?: (value: {
     kind: string;
@@ -58,10 +61,26 @@ export const buildPDF = async (
   }
   if (fonts) {
     for (const [fontName, fontBuffer] of Object.entries(fonts)) {
+      // The color emoji font is never used as a pdfkit text font (its glyphs
+      // are empty outlines); it is drawn as vector SVG via EmojiSvgProvider.
+      if (fontName === "emoji" || !fontBuffer) {
+        continue;
+      }
       doc.registerFont(fontName, fontBuffer);
     }
     if (fonts.normal) {
       doc.font(fonts.normal);
+    }
+    if (fonts.emoji) {
+      try {
+        const provider = new EmojiSvgProvider(fonts.emoji);
+        if (provider.hasSvg) {
+          setEmojiProvider(doc, provider);
+        }
+      } catch (e) {
+        // If the emoji font can't be parsed, emoji simply fall back to text.
+        console.warn("Failed to initialize emoji SVG provider:", e);
+      }
     }
   }
   doc.fontSize(fontSize);

--- a/packages/sparkdown-screenplay-pdf/src/classes/ScreenplayPrinter.ts
+++ b/packages/sparkdown-screenplay-pdf/src/classes/ScreenplayPrinter.ts
@@ -13,6 +13,7 @@ import { getHeightOfTextbox } from "../textbox-for-pdfkit/src/utils/getHeightOfT
 import { getWidthOfTextbox } from "../textbox-for-pdfkit/src/utils/getWidthOfTextbox";
 import { printTextbox } from "../textbox-for-pdfkit/src/utils/printTextbox";
 import { wrapTextbox } from "../textbox-for-pdfkit/src/utils/wrapTextbox";
+import { splitEmojiRuns } from "../emoji/emojiText";
 
 // pdfkit accepts sizes in PDF points (72 per inch)
 // https://pdfkit.org/docs/getting_started.html
@@ -660,21 +661,28 @@ export default class ScreenplayPrinter {
     content: FormattedText[],
     options: TextOptions = {},
   ): FormattedText[] {
-    return content.map((c) => {
-      const augmented = {
+    return content.flatMap((c) => {
+      const base = {
         ...options,
         ...c,
       };
-      augmented.font =
-        augmented.font ??
-        (augmented.bold && augmented.italic
+      const font =
+        base.font ??
+        (base.bold && base.italic
           ? "bolditalic"
-          : augmented.bold
+          : base.bold
             ? "bold"
-            : augmented.italic
+            : base.italic
               ? "italic"
               : "normal");
-      return augmented;
+      // Split emoji clusters into their own chunks so they can be drawn from
+      // the SVG table instead of the (glyph-less) Courier fonts.
+      return splitEmojiRuns(base.text ?? "").map((run) => ({
+        ...base,
+        font,
+        text: run.text,
+        isEmoji: run.isEmoji || undefined,
+      }));
     });
   }
 

--- a/packages/sparkdown-screenplay-pdf/src/cli/buildPdfCli.ts
+++ b/packages/sparkdown-screenplay-pdf/src/cli/buildPdfCli.ts
@@ -61,6 +61,7 @@ const loadFontsFrom = (dir: string) => {
     bold: read("courier-prime-bold.ttf"),
     italic: read("courier-prime-italic.ttf"),
     bolditalic: read("courier-prime-bold-italic.ttf"),
+    emoji: read("noto-color-emoji.ttf"),
   };
 };
 

--- a/packages/sparkdown-screenplay-pdf/src/emoji/EmojiSvgProvider.ts
+++ b/packages/sparkdown-screenplay-pdf/src/emoji/EmojiSvgProvider.ts
@@ -1,0 +1,352 @@
+import { create, type Font, type GlyphRun } from "fontkit";
+
+/**
+ * Renders color emoji into a PDF as *vector* graphics by pulling each glyph's
+ * artwork out of the font's OpenType-SVG (`SVG `) table.
+ *
+ * PDFKit/fontkit only embed monochrome glyph outlines and ignore the color
+ * tables (`COLR`/`CPAL`/`SVG `), so registering a color emoji font as a text
+ * font produces blank glyphs. Noto Color Emoji, however, ships an `SVG ` table
+ * whose glyphs are plain `<path fill>` art (plus the occasional gradient). We
+ * extract the minimal self-contained SVG for a glyph and hand it to
+ * `svg-to-pdfkit`, which emits real PDF vector ops — crisp at any zoom, tiny on
+ * disk, and identical in Node and the browser worker (no canvas needed).
+ *
+ * Noto packs *all* glyphs of a range into a single shared SVG document with a
+ * common `<defs>`; each emoji is a `<g id="glyphN">` that `<use>`s shared paths
+ * (and sometimes gradients). So per glyph we must collect the transitive
+ * closure of the defs it references and assemble a standalone SVG.
+ */
+
+interface SvgRecord {
+  start: number;
+  end: number;
+  off: number;
+  len: number;
+}
+
+interface ParsedDoc {
+  doc: string;
+  /** id -> outer XML of a `<defs>` child (lazily built) */
+  defs: Map<string, string> | null;
+  /** gid -> `<g id="glyphN">…</g>` (lazily built, null if absent) */
+  groups: Map<number, string | null>;
+}
+
+export interface EmojiGlyph {
+  id: number;
+  /** advance width in font design units */
+  advanceWidth: number;
+}
+
+export interface EmojiRunGlyph extends EmojiGlyph {
+  /** minimal standalone SVG for this glyph, or null if the font has none */
+  svg: string | null;
+}
+
+export interface EmojiRun {
+  glyphs: EmojiRunGlyph[];
+  /** total advance of the run, in font design units */
+  advanceUnits: number;
+}
+
+const REF_REGEX = /(?:xlink:href|href)="#([^"]+)"|url\(#([^)]+)\)/g;
+
+export default class EmojiSvgProvider {
+  protected _font: Font;
+
+  protected _bytes: Uint8Array;
+
+  protected _dv: DataView;
+
+  protected _records: SvgRecord[] = [];
+
+  protected _docs = new Map<number, ParsedDoc>();
+
+  protected _svgCache = new Map<number, string | null>();
+
+  protected _runCache = new Map<string, EmojiRun>();
+
+  readonly unitsPerEm: number;
+
+  /** true when the font actually carries a usable `SVG ` table */
+  readonly hasSvg: boolean;
+
+  constructor(fontData: ArrayBuffer | Uint8Array) {
+    const bytes =
+      fontData instanceof Uint8Array ? fontData : new Uint8Array(fontData);
+    this._bytes = bytes;
+    this._dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    // fontkit wants a Node Buffer; Buffer is shimmed in the browser bundle.
+    this._font = create(Buffer.from(bytes) as Buffer) as Font;
+    this.unitsPerEm = this._font.unitsPerEm || 1000;
+    this.hasSvg = this.parseSvgTable();
+  }
+
+  /** Shape a string into glyphs, resolving ZWJ/skin-tone sequences via GSUB. */
+  layout(text: string): EmojiGlyph[] {
+    const run = this._font.layout(text) as GlyphRun;
+    return run.glyphs.map((g) => ({
+      id: g.id,
+      advanceWidth: g.advanceWidth,
+    }));
+  }
+
+  /**
+   * Shape + resolve a whole emoji cluster into its drawable glyphs (each with
+   * its SVG) plus the run's total advance. Cached per cluster string.
+   */
+  getEmojiRun(cluster: string): EmojiRun {
+    const cached = this._runCache.get(cluster);
+    if (cached) {
+      return cached;
+    }
+    const glyphs: EmojiRunGlyph[] = this.layout(cluster).map((g) => ({
+      ...g,
+      svg: this.getSvg(g.id),
+    }));
+    const advanceUnits = glyphs.reduce((sum, g) => sum + g.advanceWidth, 0);
+    const run: EmojiRun = { glyphs, advanceUnits };
+    this._runCache.set(cluster, run);
+    return run;
+  }
+
+  /** Minimal standalone SVG for a glyph id, or null if the font has none. */
+  getSvg(gid: number): string | null {
+    if (this._svgCache.has(gid)) {
+      return this._svgCache.get(gid)!;
+    }
+    let svg: string | null = null;
+    try {
+      svg = this.buildSvg(gid);
+    } catch {
+      svg = null;
+    }
+    this._svgCache.set(gid, svg);
+    return svg;
+  }
+
+  // ---- SVG table parsing -------------------------------------------------
+
+  protected parseSvgTable(): boolean {
+    const dv = this._dv;
+    const bytes = this._bytes;
+    const numTables = dv.getUint16(4);
+    let svgOff = -1;
+    for (let i = 0; i < numTables; i += 1) {
+      const rec = 12 + i * 16;
+      const tag = String.fromCharCode(
+        bytes[rec]!,
+        bytes[rec + 1]!,
+        bytes[rec + 2]!,
+        bytes[rec + 3]!,
+      );
+      if (tag === "SVG ") {
+        svgOff = dv.getUint32(rec + 8);
+        break;
+      }
+    }
+    if (svgOff < 0) {
+      return false;
+    }
+    const docListOff = svgOff + dv.getUint32(svgOff + 2);
+    const numDocs = dv.getUint16(docListOff);
+    for (let i = 0; i < numDocs; i += 1) {
+      const b = docListOff + 2 + i * 12;
+      this._records.push({
+        start: dv.getUint16(b),
+        end: dv.getUint16(b + 2),
+        off: docListOff + dv.getUint32(b + 4),
+        len: dv.getUint32(b + 8),
+      });
+    }
+    return this._records.length > 0;
+  }
+
+  protected recordIndexFor(gid: number): number {
+    // records are sorted by glyph id; linear scan is fine (≤ ~700 records)
+    for (let i = 0; i < this._records.length; i += 1) {
+      const r = this._records[i]!;
+      if (gid >= r.start && gid <= r.end) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  protected getParsedDoc(recIndex: number): ParsedDoc {
+    const cached = this._docs.get(recIndex);
+    if (cached) {
+      return cached;
+    }
+    const rec = this._records[recIndex]!;
+    let slice = this._bytes.subarray(rec.off, rec.off + rec.len);
+    // OpenType-SVG docs may be gzip-compressed (this font's are not).
+    if (slice[0] === 0x1f && slice[1] === 0x8b) {
+      slice = this.gunzip(slice);
+    }
+    const parsed: ParsedDoc = {
+      doc: new TextDecoder("utf-8").decode(slice),
+      defs: null,
+      groups: new Map(),
+    };
+    this._docs.set(recIndex, parsed);
+    return parsed;
+  }
+
+  protected gunzip(data: Uint8Array): Uint8Array {
+    // Only reached for gzip'd SVG docs. Kept synchronous + optional so the
+    // common (uncompressed) path never pulls in zlib.
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const zlib = require("zlib");
+      return zlib.gunzipSync(Buffer.from(data));
+    } catch {
+      return data;
+    }
+  }
+
+  // ---- per-glyph SVG assembly -------------------------------------------
+
+  protected buildSvg(gid: number): string | null {
+    const recIndex = this.recordIndexFor(gid);
+    if (recIndex < 0) {
+      return null;
+    }
+    const parsed = this.getParsedDoc(recIndex);
+    const group = this.getGlyphGroup(parsed, gid);
+    if (!group) {
+      return null;
+    }
+    const defsMap = this.getDefsMap(parsed);
+    const defs = this.collectDefs(group, defsMap);
+    const upem = this.unitsPerEm;
+    const advance = this.advanceWidthOf(gid) || upem;
+    // OpenType-SVG coordinate system: y-axis points down, origin at the glyph
+    // baseline, one unit == one design unit. Emoji art sits above the baseline
+    // (negative y), so the em box spans y ∈ [-upem, 0].
+    const viewBox = `0 ${-upem} ${advance} ${upem}`;
+    return (
+      `<svg xmlns="http://www.w3.org/2000/svg" ` +
+      `xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="${viewBox}">` +
+      `<defs>${defs}</defs>${group}</svg>`
+    );
+  }
+
+  protected advanceWidthOf(gid: number): number {
+    try {
+      return this._font.getGlyph(gid).advanceWidth;
+    } catch {
+      return this.unitsPerEm;
+    }
+  }
+
+  protected getGlyphGroup(parsed: ParsedDoc, gid: number): string | null {
+    if (parsed.groups.has(gid)) {
+      return parsed.groups.get(gid)!;
+    }
+    const needle = `<g id="glyph${gid}"`;
+    const idx = parsed.doc.indexOf(needle);
+    const group = idx >= 0 ? this.sliceElement(parsed.doc, idx)[0] : null;
+    parsed.groups.set(gid, group);
+    return group;
+  }
+
+  protected getDefsMap(parsed: ParsedDoc): Map<string, string> {
+    if (parsed.defs) {
+      return parsed.defs;
+    }
+    const map = new Map<string, string>();
+    const s = parsed.doc;
+    const dStart = s.indexOf("<defs>");
+    const dEnd = s.indexOf("</defs>");
+    if (dStart >= 0 && dEnd > dStart) {
+      let i = dStart + "<defs>".length;
+      while (i < dEnd) {
+        if (s[i] !== "<") {
+          i += 1;
+          continue;
+        }
+        const [outer, next] = this.sliceElement(s, i);
+        const idm = /\bid="([^"]+)"/.exec(outer);
+        if (idm) {
+          map.set(idm[1]!, outer);
+        }
+        i = next;
+      }
+    }
+    parsed.defs = map;
+    return map;
+  }
+
+  /** Transitive closure of defs referenced by `root`, concatenated. */
+  protected collectDefs(root: string, defsMap: Map<string, string>): string {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    const stack: string[] = [];
+    this.pushRefs(root, stack);
+    while (stack.length) {
+      const id = stack.pop()!;
+      if (seen.has(id)) {
+        continue;
+      }
+      seen.add(id);
+      const el = defsMap.get(id);
+      if (!el) {
+        continue;
+      }
+      out.push(el);
+      this.pushRefs(el, stack);
+    }
+    return out.join("");
+  }
+
+  protected pushRefs(str: string, stack: string[]): void {
+    REF_REGEX.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    // eslint-disable-next-line no-cond-assign
+    while ((m = REF_REGEX.exec(str))) {
+      stack.push((m[1] || m[2])!);
+    }
+  }
+
+  /**
+   * Slice out the element starting at `start` (which must point at its `<`),
+   * returning [outerXML, indexAfterElement]. Handles self-closing tags and
+   * balanced nesting of same-named tags.
+   */
+  protected sliceElement(s: string, start: number): [string, number] {
+    const nameMatch = /^<([\w:.-]+)/.exec(s.slice(start, start + 64));
+    const name = nameMatch ? nameMatch[1]! : "";
+    let gt = s.indexOf(">", start);
+    if (gt < 0) {
+      return [s.slice(start), s.length];
+    }
+    if (s[gt - 1] === "/") {
+      return [s.slice(start, gt + 1), gt + 1];
+    }
+    const openRe = new RegExp(`<${name}(?=[\\s/>])`, "g");
+    const closeTag = `</${name}>`;
+    let depth = 1;
+    let p = gt + 1;
+    while (depth > 0) {
+      const nextClose = s.indexOf(closeTag, p);
+      if (nextClose < 0) {
+        return [s.slice(start), s.length];
+      }
+      openRe.lastIndex = p;
+      const open = openRe.exec(s);
+      if (open && open.index < nextClose) {
+        const openGt = s.indexOf(">", open.index);
+        if (s[openGt - 1] !== "/") {
+          depth += 1;
+        }
+        p = openGt + 1;
+      } else {
+        depth -= 1;
+        p = nextClose + closeTag.length;
+      }
+    }
+    return [s.slice(start, p), p];
+  }
+}

--- a/packages/sparkdown-screenplay-pdf/src/emoji/emojiHtml.ts
+++ b/packages/sparkdown-screenplay-pdf/src/emoji/emojiHtml.ts
@@ -1,0 +1,89 @@
+import EmojiSvgProvider from "./EmojiSvgProvider";
+
+/**
+ * Builds an HTML emoji inliner that embeds ONLY the emoji actually used by a
+ * script, as vector SVG — the equivalent of a per-export font subset without
+ * needing to subset the (color) font itself (fontkit can't subset COLR/SVG).
+ *
+ * Each unique emoji becomes one CSS rule carrying its own `data:` SVG document,
+ * referenced by class, so a repeated emoji costs nothing extra. The real emoji
+ * character stays in the DOM at `opacity:0` (invisible but still selectable and
+ * copy-pasteable, and it reserves the correct width); our vector art is painted
+ * on top via `::after`. `color:transparent` would NOT work here — color-emoji
+ * fonts ignore `color` — but `opacity` applies to everything.
+ */
+
+export interface EmojiHtmlInliner {
+  /** Replace emoji clusters in already-generated screenplay HTML. */
+  inline(html: string): string;
+  /** `<style>` block for the emoji used so far; "" if none. Call after inline. */
+  styleAndDefs(): string;
+}
+
+let EMOJI_REGEX: RegExp | null = null;
+try {
+  EMOJI_REGEX = /\p{RGI_Emoji}/gv;
+} catch {
+  EMOJI_REGEX = null;
+}
+
+const BASE_CSS = `.spark-emoji{position:relative;display:inline-block;line-height:inherit;vertical-align:middle}
+.spark-emoji>.spark-emoji-char{opacity:0}
+.spark-emoji::after{content:"";position:absolute;inset:0;background-position:center;background-size:contain;background-repeat:no-repeat}`;
+
+const svgToDataUrl = (svg: string): string =>
+  // encodeURIComponent escapes ", #, <, > etc., so the result is safe inside a
+  // double-quoted CSS url(). Gradient url(#id) parens survive (harmless in a
+  // quoted string) and every emoji's SVG is its own document, so ids never clash.
+  `url("data:image/svg+xml,${encodeURIComponent(svg)}")`;
+
+export const createEmojiHtmlInliner = (
+  fontData: ArrayBuffer | Uint8Array,
+): EmojiHtmlInliner | undefined => {
+  if (!EMOJI_REGEX) {
+    return undefined;
+  }
+  let provider: EmojiSvgProvider;
+  try {
+    provider = new EmojiSvgProvider(fontData);
+  } catch {
+    return undefined;
+  }
+  if (!provider.hasSvg) {
+    return undefined;
+  }
+
+  const usedCss = new Map<number, string>();
+
+  const inline = (html: string): string => {
+    EMOJI_REGEX!.lastIndex = 0;
+    return html.replace(EMOJI_REGEX!, (cluster) => {
+      const run = provider.getEmojiRun(cluster);
+      // Only handle clusters that resolve to a single drawable glyph; leave
+      // anything unusual as plain text (falls back to the OS emoji font).
+      if (run.glyphs.length !== 1) {
+        return cluster;
+      }
+      const g = run.glyphs[0]!;
+      if (!g.svg) {
+        return cluster;
+      }
+      if (!usedCss.has(g.id)) {
+        usedCss.set(
+          g.id,
+          `.spark-emoji.se-${g.id}::after{background-image:${svgToDataUrl(g.svg)}}`,
+        );
+      }
+      return `<span class="spark-emoji se-${g.id}"><span class="spark-emoji-char">${cluster}</span></span>`;
+    });
+  };
+
+  const styleAndDefs = (): string => {
+    if (usedCss.size === 0) {
+      return "";
+    }
+    return `<style>\n${BASE_CSS}\n${[...usedCss.values()].join("\n")}\n</style>`;
+  };
+
+  return { inline, styleAndDefs };
+};

--- a/packages/sparkdown-screenplay-pdf/src/emoji/emojiText.ts
+++ b/packages/sparkdown-screenplay-pdf/src/emoji/emojiText.ts
@@ -1,0 +1,117 @@
+import type PDFKit from "pdfkit";
+import SVGtoPDF from "svg-to-pdfkit";
+import EmojiSvgProvider from "./EmojiSvgProvider";
+
+// A single regex that matches whole RGI emoji sequences (ZWJ joins, skin-tone
+// modifiers, flags, keycaps) as one unit. The `v` flag + `\p{RGI_Emoji}`
+// property-of-strings is supported by modern V8 (Node 20+, Chromium 112+). If
+// the runtime lacks it we simply never split, and emoji fall back to text.
+let EMOJI_REGEX: RegExp | null = null;
+try {
+  EMOJI_REGEX = /\p{RGI_Emoji}/gv;
+} catch {
+  EMOJI_REGEX = null;
+}
+
+export interface EmojiTextRun {
+  text: string;
+  isEmoji: boolean;
+}
+
+/**
+ * Split a string into alternating plain-text and emoji runs. Each emoji run is
+ * exactly one RGI emoji cluster so it can be routed to the SVG renderer while
+ * the surrounding text keeps flowing through the normal Courier pipeline.
+ */
+export const splitEmojiRuns = (text: string): EmojiTextRun[] => {
+  if (!EMOJI_REGEX || !text) {
+    return [{ text, isEmoji: false }];
+  }
+  const runs: EmojiTextRun[] = [];
+  let last = 0;
+  EMOJI_REGEX.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  // eslint-disable-next-line no-cond-assign
+  while ((m = EMOJI_REGEX.exec(text))) {
+    if (m.index > last) {
+      runs.push({ text: text.slice(last, m.index), isEmoji: false });
+    }
+    runs.push({ text: m[0], isEmoji: true });
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) {
+    runs.push({ text: text.slice(last), isEmoji: false });
+  }
+  return runs.length ? runs : [{ text, isEmoji: false }];
+};
+
+/** The emoji provider stashed on the PDF document by buildPDF, if any. */
+export const getEmojiProvider = (
+  doc: PDFKit.PDFDocument,
+): EmojiSvgProvider | undefined =>
+  (doc as unknown as { __emojiProvider?: EmojiSvgProvider }).__emojiProvider;
+
+export const setEmojiProvider = (
+  doc: PDFKit.PDFDocument,
+  provider: EmojiSvgProvider,
+): void => {
+  (doc as unknown as { __emojiProvider?: EmojiSvgProvider }).__emojiProvider =
+    provider;
+};
+
+/** Width (in PDF points) an emoji cluster occupies at the given font size. */
+export const measureEmojiWidth = (
+  provider: EmojiSvgProvider,
+  cluster: string,
+  fontSize: number,
+): number => {
+  const run = provider.getEmojiRun(cluster);
+  return (run.advanceUnits * fontSize) / provider.unitsPerEm;
+};
+
+/**
+ * Draw an emoji cluster as vector art at (x, baselineOrTopY) and return the
+ * advanced x. `baseline` matches the value passed to `doc.text`: "top" aligns
+ * the emoji box with the text top; anything else aligns the emoji baseline with
+ * the text baseline.
+ */
+export const drawEmojiChunk = (
+  doc: PDFKit.PDFDocument,
+  provider: EmojiSvgProvider,
+  cluster: string,
+  x: number,
+  y: number,
+  fontSize: number,
+  baseline: string,
+): number => {
+  const run = provider.getEmojiRun(cluster);
+  const scale = fontSize / provider.unitsPerEm;
+  // Our per-glyph SVG viewBox is `0 -upem advance upem`, so the emoji box is one
+  // em tall. Hanging it from the em-box top leaves emoji sitting low relative to
+  // the letters; nudge it up so the box is centered on the text's cap height and
+  // the emoji reads as vertically centered with the line.
+  const EMOJI_CENTER_SHIFT = 0.19; // fraction of fontSize, tuned visually
+  const topY =
+    baseline === "top"
+      ? y - EMOJI_CENTER_SHIFT * fontSize
+      : y - (1 - EMOJI_CENTER_SHIFT) * fontSize;
+  let penX = x;
+  for (const glyph of run.glyphs) {
+    const width = glyph.advanceWidth * scale;
+    if (glyph.svg) {
+      doc.save();
+      try {
+        SVGtoPDF(doc, glyph.svg, penX, topY, {
+          width,
+          height: fontSize,
+          assumePt: true,
+        });
+      } catch {
+        // ignore a single glyph that fails to render
+      }
+      doc.restore();
+    }
+    penX += width;
+  }
+  return penX;
+};

--- a/packages/sparkdown-screenplay-pdf/src/sparkdown-screenplay-pdf.ts
+++ b/packages/sparkdown-screenplay-pdf/src/sparkdown-screenplay-pdf.ts
@@ -1,4 +1,7 @@
+import ScreenplayParser from "@impower/sparkdown-screenplay/src/classes/ScreenplayParser";
+import { generateScreenplayHtmlData } from "@impower/sparkdown-screenplay/src/utils/generateScreenplayHtmlData";
 import { buildPDF } from "./buildPDF";
+import { createEmojiHtmlInliner } from "./emoji/emojiHtml";
 export { buildPDF };
 
 onmessage = async (e) => {
@@ -29,10 +32,45 @@ onmessage = async (e) => {
             },
           });
         };
-        const arrayBuffer = await buildPDF(scripts, config, fonts, onProgress);
-        postMessage({ jsonrpc: "2.0", method, id, result: arrayBuffer }, [
-          arrayBuffer,
-        ]);
+        if (method === "workspace/exportHTML") {
+          // Runs here (not on the main thread) so fontkit's Buffer shim is
+          // available to embed only the emoji the script uses as inline SVG.
+          try {
+            const parser = new ScreenplayParser();
+            const tokens = parser.parseAll(scripts);
+            const emoji = fonts.emoji
+              ? createEmojiHtmlInliner(fonts.emoji)
+              : undefined;
+            const html = generateScreenplayHtmlData(
+              tokens,
+              config,
+              fonts,
+              emoji,
+            );
+            postMessage({ jsonrpc: "2.0", method, id, result: html });
+          } catch (err) {
+            postMessage({
+              jsonrpc: "2.0",
+              method,
+              id,
+              error: {
+                code: -32000,
+                message: err instanceof Error ? err.message : String(err),
+                data: err instanceof Error ? err.stack : undefined,
+              },
+            });
+          }
+        } else {
+          const arrayBuffer = await buildPDF(
+            scripts,
+            config,
+            fonts,
+            onProgress,
+          );
+          postMessage({ jsonrpc: "2.0", method, id, result: arrayBuffer }, [
+            arrayBuffer,
+          ]);
+        }
       }
     }
   }

--- a/packages/sparkdown-screenplay-pdf/src/textbox-for-pdfkit/src/types/TextOptions.ts
+++ b/packages/sparkdown-screenplay-pdf/src/textbox-for-pdfkit/src/types/TextOptions.ts
@@ -16,6 +16,8 @@ export interface TextOptions {
   links?: boolean;
   link?: string;
   removeTrailingSpaces?: boolean;
+  /** marks a chunk as a single emoji cluster rendered from the SVG table */
+  isEmoji?: boolean;
   align?: string;
   baseline?:
     | number

--- a/packages/sparkdown-screenplay-pdf/src/textbox-for-pdfkit/src/utils/printTextbox.ts
+++ b/packages/sparkdown-screenplay-pdf/src/textbox-for-pdfkit/src/utils/printTextbox.ts
@@ -5,6 +5,7 @@ import { FormattedText } from "../types/FormattedText";
 import { TextOptions } from "../types/TextOptions";
 import { wrapTextbox } from "./wrapTextbox";
 import { getFontAscent } from "./fontHandler";
+import { drawEmojiChunk, getEmojiProvider } from "../../../emoji/emojiText";
 
 // This is the main package of textbox-for-pdfkit. It is the main function
 // which prepares the data by calling all the subfunctions.
@@ -72,7 +73,22 @@ const printLines = (
       if (textPart.color != null) {
         doc.fillColor(textPart.color as keyof PDFKit.Mixins.ColorValue);
       }
-      if (textPart.text != null) {
+      const emojiProvider = textPart.isEmoji ? getEmojiProvider(doc) : undefined;
+      if (emojiProvider && textPart.text) {
+        const fontSize =
+          textPart.fontSize ??
+          (doc as unknown as { _fontSize?: number })._fontSize ??
+          12;
+        drawEmojiChunk(
+          doc,
+          emojiProvider,
+          textPart.text,
+          xPosition,
+          yPosition,
+          fontSize,
+          String(baseline),
+        );
+      } else if (textPart.text != null) {
         doc.text(textPart.text, xPosition, yPosition, {
           link: textPart.link,
           align: "left",

--- a/packages/sparkdown-screenplay-pdf/src/textbox-for-pdfkit/src/utils/textMeasurement.ts
+++ b/packages/sparkdown-screenplay-pdf/src/textbox-for-pdfkit/src/utils/textMeasurement.ts
@@ -1,6 +1,7 @@
 import type PDFKit from "pdfkit";
 import { FormattedText } from "../types/FormattedText";
 import { MeasuredText } from "../types/MeasuredText";
+import { getEmojiProvider, measureEmojiWidth } from "../../../emoji/emojiText";
 
 // All these functions here measure some kind of text.
 // What kind of text they measure can easily be taken from
@@ -12,6 +13,16 @@ export const measureTextWidth = (
   textChunk: FormattedText,
   doc: PDFKit.PDFDocument,
 ) => {
+  if (textChunk.isEmoji) {
+    const provider = getEmojiProvider(doc);
+    if (provider) {
+      const fontSize =
+        textChunk.fontSize ??
+        (doc as unknown as { _fontSize?: number })._fontSize ??
+        12;
+      return measureEmojiWidth(provider, textChunk.text, fontSize);
+    }
+  }
   if (textChunk.font != null) {
     doc.font(textChunk.font);
   }

--- a/packages/sparkdown-screenplay-pdf/src/types/svg-to-pdfkit.d.ts
+++ b/packages/sparkdown-screenplay-pdf/src/types/svg-to-pdfkit.d.ts
@@ -1,0 +1,21 @@
+declare module "svg-to-pdfkit" {
+  interface SVGtoPDFOptions {
+    width?: number;
+    height?: number;
+    preserveAspectRatio?: string;
+    useCSS?: boolean;
+    fontCallback?: (...args: unknown[]) => unknown;
+    imageCallback?: (...args: unknown[]) => unknown;
+    colorCallback?: (...args: unknown[]) => unknown;
+    documentCallback?: (...args: unknown[]) => unknown;
+    precision?: number;
+    assumePt?: boolean;
+  }
+  export default function SVGtoPDF(
+    doc: PDFKit.PDFDocument,
+    svg: string,
+    x?: number,
+    y?: number,
+    options?: SVGtoPDFOptions,
+  ): void;
+}

--- a/packages/sparkdown-screenplay/src/constants/STATIC_CSS.ts
+++ b/packages/sparkdown-screenplay/src/constants/STATIC_CSS.ts
@@ -84,7 +84,7 @@ export const TITLE_CSS = `
 
 export const MAIN_CSS = `
 #workskin {
-  font-family: sparkdown-font, SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+  font-family: sparkdown-font, SFMono-Regular, Consolas, "Liberation Mono", Menlo, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", monospace;
   font-size: 16px;
 }
 

--- a/packages/sparkdown-screenplay/src/utils/generateScreenplayHtmlData.ts
+++ b/packages/sparkdown-screenplay/src/utils/generateScreenplayHtmlData.ts
@@ -8,6 +8,17 @@ import { encodeBase64 } from "./encodeBase64";
 import { generateScreenplayMainHtml } from "./generateScreenplayMainHtml";
 import { generateScreenplayTitleHtml } from "./generateScreenplayTitleHtml";
 
+/**
+ * Optional hook that embeds only the emoji a script actually uses, as inline
+ * vector SVG. Supplied by callers that have the emoji font (see
+ * `createEmojiHtmlInliner` in @impower/sparkdown-screenplay-pdf); kept as a
+ * local interface so this package needs no font tooling dependency.
+ */
+export interface EmojiHtmlInliner {
+  inline(html: string): string;
+  styleAndDefs(): string;
+}
+
 export const generateScreenplayHtmlData = (
   tokens: ScreenplayToken[],
   config?: ScreenplayConfig,
@@ -17,6 +28,7 @@ export const generateScreenplayHtmlData = (
     italic?: ArrayBuffer | Uint8Array;
     bolditalic?: ArrayBuffer | Uint8Array;
   },
+  emoji?: EmojiHtmlInliner,
 ): string => {
   let rawHtml: string = STATIC_HTML;
 
@@ -62,9 +74,12 @@ export const generateScreenplayHtmlData = (
     </style>`,
   );
 
-  const titleHtml = config?.screenplay_print_title_page
+  let titleHtml = config?.screenplay_print_title_page
     ? generateScreenplayTitleHtml(spans, "            ")
     : "";
+  if (emoji && titleHtml) {
+    titleHtml = emoji.inline(titleHtml);
+  }
   if (titleHtml) {
     rawHtml = rawHtml.replace(
       "$TITLEPAGE$",
@@ -78,9 +93,12 @@ export const generateScreenplayHtmlData = (
     rawHtml = rawHtml.replace("$TITLEPAGE$", "");
   }
 
-  const mainHtml = spans
+  let mainHtml = spans
     ? generateScreenplayMainHtml(spans, "            ")
     : "";
+  if (emoji && mainHtml) {
+    mainHtml = emoji.inline(mainHtml);
+  }
   if (mainHtml) {
     rawHtml = rawHtml.replace(
       "$MAINPAGE$",
@@ -92,6 +110,15 @@ export const generateScreenplayHtmlData = (
     );
   } else {
     rawHtml = rawHtml.replace("$MAINPAGE$", "");
+  }
+
+  // Embed the used-emoji styles (must come after inline() has run over both
+  // the title and main HTML so every used glyph is registered).
+  if (emoji) {
+    const emojiStyle = emoji.styleAndDefs();
+    if (emojiStyle) {
+      rawHtml = rawHtml.replace("</head>", `  ${emojiStyle}\n  </head>`);
+    }
   }
 
   return rawHtml;

--- a/packages/sparkdown-screenplay/src/utils/generateScreenplayMainHtml.ts
+++ b/packages/sparkdown-screenplay/src/utils/generateScreenplayMainHtml.ts
@@ -8,6 +8,8 @@ export const generateScreenplayMainHtml = (
   const html: string[] = [];
   bodySpans.forEach((span) => {
     if (span.tag === "meta") {
+    } else if (span.tag === "separator") {
+      html.push("<br>");
     } else if (span.tag === "page_break") {
       html.push("<hr>");
     } else if (span.tag === "dual") {

--- a/vscode-sparkdown/src/managers/SparkdownPreviewGamePanelManager.ts
+++ b/vscode-sparkdown/src/managers/SparkdownPreviewGamePanelManager.ts
@@ -477,6 +477,13 @@ export class SparkdownPreviewGamePanelManager {
       context.extensionUri,
       ["out", "data", "courier-prime-bold-italic.ttf"],
     );
+    const  fontFamilyEmoji = "Noto Color Emoji"
+    const fontFormatEmoji = "truetype";
+    const fontPathEmoji = getWebviewUri(webview, context.extensionUri, [
+      "out",
+      "data",
+      "noto-color-emoji.ttf",
+    ]);
     const styleNonce = getNonce();
     const scriptNonce = getNonce();
     return /*html*/ `
@@ -513,6 +520,13 @@ export class SparkdownPreviewGamePanelManager {
               font-weight: 700;
               font-display: block;
               src: url("${fontPathMonoBoldItalic}") format("${fontFormatMono}");
+            }
+            @font-face {
+              font-family: "${fontFamilyEmoji}";
+              font-style: normal;
+              font-weight: normal;
+              font-display: block;
+              src: url("${fontPathEmoji}") format("${fontFormatEmoji}");
             }
 
             html {

--- a/vscode-sparkdown/src/managers/SparkdownPreviewScreenplayPanelManager.ts
+++ b/vscode-sparkdown/src/managers/SparkdownPreviewScreenplayPanelManager.ts
@@ -309,6 +309,13 @@ export class SparkdownPreviewScreenplayPanelManager {
       context.extensionUri,
       ["out", "data", "courier-prime-bold-italic.ttf"],
     );
+    const  fontFamilyEmoji = "Noto Color Emoji"
+    const fontFormatEmoji = "truetype";
+    const fontPathEmoji = getWebviewUri(webview, context.extensionUri, [
+      "out",
+      "data",
+      "noto-color-emoji.ttf",
+    ]);
     const styleNonce = getNonce();
     const scriptNonce = getNonce();
     return /*html*/ `
@@ -345,6 +352,13 @@ export class SparkdownPreviewScreenplayPanelManager {
               font-weight: 700;
               font-display: block;
               src: url("${fontPathMonoBoldItalic}") format("${fontFormatMono}");
+            }
+            @font-face {
+              font-family: "${fontFamilyEmoji}";
+              font-style: normal;
+              font-weight: normal;
+              font-display: block;
+              src: url("${fontPathEmoji}") format("${fontFormatEmoji}");
             }
 
             html {

--- a/vscode-sparkdown/src/utils/exportHtml.ts
+++ b/vscode-sparkdown/src/utils/exportHtml.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { generateScreenplayHtmlData } from "@impower/sparkdown-screenplay/src/utils/generateScreenplayHtmlData";
+import { createEmojiHtmlInliner } from "@impower/sparkdown-screenplay-pdf/src/emoji/emojiHtml";
 import ScreenplayParser from "@impower/sparkdown-screenplay/src/classes/ScreenplayParser";
 import { SparkdownCommandTreeDataProvider } from "../providers/SparkdownCommandTreeDataProvider";
 import { getActiveSparkdownDocument } from "./getActiveSparkdownDocument";
@@ -31,7 +32,15 @@ export const exportHtml = async (
   const tokens = parser.parseAll([script]);
   const config = getSparkdownPreviewConfig(uri);
   const fonts = await getFonts(context);
-  const rawHtml: string = generateScreenplayHtmlData(tokens, config, fonts);
+  const emoji = fonts.emoji
+    ? createEmojiHtmlInliner(fonts.emoji)
+    : undefined;
+  const rawHtml: string = generateScreenplayHtmlData(
+    tokens,
+    config,
+    fonts,
+    emoji,
+  );
   const output =
     process?.platform !== "win32" ? rawHtml.replace(/\r\n/g, "\n") : rawHtml;
   await writeFile(fsPath, output);

--- a/vscode-sparkdown/src/utils/getDefaultScreenplayFonts.ts
+++ b/vscode-sparkdown/src/utils/getDefaultScreenplayFonts.ts
@@ -8,8 +8,9 @@ export const getFonts = async (
   bold: ArrayBuffer;
   italic: ArrayBuffer;
   bolditalic: ArrayBuffer;
+  emoji: ArrayBuffer;
 }> => {
-  const [normal, bold, italic, bolditalic] = await Promise.all([
+  const [normal, bold, italic, bolditalic, emoji] = await Promise.all([
     readFile(
       vscode.Uri.joinPath(
         context.extensionUri,
@@ -42,6 +43,14 @@ export const getFonts = async (
         "courier-prime-bold-italic.ttf",
       ),
     ),
+    readFile(
+      vscode.Uri.joinPath(
+        context.extensionUri,
+        "out",
+        "data",
+        "noto-color-emoji.ttf",
+      ),
+    ),
   ]);
 
   if (!normal) {
@@ -56,10 +65,14 @@ export const getFonts = async (
   if (!bolditalic) {
     throw new Error("Missing 'bolditalic' font");
   }
+  if (!emoji) {
+    throw new Error("Missing 'emoji' font");
+  }
   return {
     normal,
     bold,
     italic,
     bolditalic,
+    emoji
   };
 };


### PR DESCRIPTION
Adds end-to-end **color emoji** support to the screenplay pipeline (Noto Color Emoji), across all three surfaces.

## What & how

**Preview + editor (browser-native)**
- Emoji family appended to the screenplay-preview, code-editor, and HTML-export font-family fallback stacks so browsers render COLR/SVG color emoji.
- Fixed the bundled `@font-face`/`FontFace` being registered as **bold-italic** (copy-pasted descriptors) — now `normal`, so it matches all text.

**PDF export** — PDFKit/fontkit can only embed monochrome outlines and ignore `COLR`/`CPAL`/`SVG `; the base glyphs are empty. So:
- New `EmojiSvgProvider` pulls each glyph's art from the font's **OpenType-SVG table**, subsetting the transitive `<defs>` closure per glyph, and resolves clusters → glyphs via fontkit `layout()` (ZWJ / skin-tone / flags / keycaps).
- Text is split into emoji runs, measured, and each cluster drawn as **true vector** via `svg-to-pdfkit` — crisp at any zoom, pure-JS, no canvas. Emoji are centered vertically with the text.

**HTML export** — embed only what the script uses:
- Each used emoji becomes an inline SVG: the real character is kept at `opacity:0` (still **selectable/copyable**, reserves width) and the art is painted via `::after`. Each unique emoji is embedded once as a data-URL SVG — so a script embeds only the emoji it uses, not the 24 MB font. (A pure-JS *font* subset isn't possible here — fontkit's subsetter drops the color tables.)
- HTML export now runs in the PDF **worker** (fontkit needs the `Buffer` shim, which the main thread lacks). New `ExportHTMLMessage` protocol + a method branch in the worker.

## Pre-existing bugs fixed (blockers for the above)
- `generateScreenplayMainHtml` crashed on `separator` spans (`span.lines is not iterable`) — HTML export was broken for any real screenplay.
- `ShareScreenplay` called the removed `Workspace.ls.getPrograms` → both Share **PDF and HTML** buttons threw before exporting. Switched to `readProjectScriptBundle` (raw `.sd` text, which is what the screenplay parser wants).

## Verification
- PDF: rendered CLI + in-browser worker output — color vector emoji inline and vertically centered, incl. ZWJ/skin-tone/flag/keycap.
- Preview + code editor: color emoji inline (screenshotted).
- HTML: real **Share → Screenplay HTML** button downloads a working file — only-used emoji embedded, `getSelection()` returns the real emoji characters.
- `tsc` is not a gate in this repo; verified via rendered output.

## Note — repo size
Adds `noto-color-emoji.ttf` (~24 MB) in two locations (`impower-dev/src/public/fonts` and `vscode-sparkdown/data`), matching how the Courier fonts are stored (raw `binary`, not LFS). The full font is required for the PDF and preview paths; only HTML export is subsetted. Consider a build-time **subset** of the committed font as a follow-up to cut the ~48 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)