### PR TITLE
Load the emoji font lazily instead of blocking editor startup

### DIFF
--- a/impower-dev/src/public/document.css
+++ b/impower-dev/src/public/document.css
@@ -60,7 +60,9 @@
 
 @font-face {
   font-family: "Noto Color Emoji";
-  font-display: block;
+  /* swap (not block) + no preload: the 24MB font is fetched lazily, only when
+     an emoji is actually rendered, and the system emoji font shows meanwhile. */
+  font-display: swap;
   src: local(""),
     url("/fonts/noto-color-emoji.ttf") format("truetype");
 }

--- a/impower-dev/src/public/document.html
+++ b/impower-dev/src/public/document.html
@@ -16,7 +16,6 @@
   <link rel="preload" href="/fonts/courier-prime-sans-bold.ttf" as="font" type="font/ttf" crossorigin>
   <link rel="preload" href="/fonts/courier-prime-sans-italic.ttf" as="font" type="font/ttf" crossorigin>
   <link rel="preload" href="/fonts/courier-prime-sans-bold-italic.ttf" as="font" type="font/ttf" crossorigin>
-  <link rel="preload" href="/fonts/noto-color-emoji.ttf" as="font" type="font/ttf" crossorigin>
   <style>
     html {
       opacity: 0;

--- a/packages/sparkdown-document-views/src/modules/script-editor/ScriptEditorController.ts
+++ b/packages/sparkdown-document-views/src/modules/script-editor/ScriptEditorController.ts
@@ -875,8 +875,14 @@ export class ScriptEditorController {
       const notoColorEmoji = new FontFace(
         '"Noto Color Emoji"',
         'url("/fonts/noto-color-emoji.ttf") format("truetype")',
-        { style: "normal", weight: "normal", display: "block" },
+        { style: "normal", weight: "normal", display: "swap" },
       );
+      // Register the emoji font so it is available, but do NOT eagerly load it:
+      // the 24MB file would block editor startup. The browser fetches it lazily,
+      // only when an emoji is actually rendered (system emoji shows meanwhile).
+      if ("add" in document.fonts && typeof document.fonts.add === "function") {
+        document.fonts.add(notoColorEmoji);
+      }
       await Promise.all(
         [
           courierPrimeSans,
@@ -887,7 +893,6 @@ export class ScriptEditorController {
           courierPrimeBold,
           courierPrimeItalic,
           courierPrimeBoldItalic,
-          notoColorEmoji
         ].map(async (fontFace) => {
           if (
             "add" in document.fonts &&

--- a/vscode-sparkdown/src/managers/SparkdownPreviewGamePanelManager.ts
+++ b/vscode-sparkdown/src/managers/SparkdownPreviewGamePanelManager.ts
@@ -525,7 +525,7 @@ export class SparkdownPreviewGamePanelManager {
               font-family: "${fontFamilyEmoji}";
               font-style: normal;
               font-weight: normal;
-              font-display: block;
+              font-display: swap;
               src: url("${fontPathEmoji}") format("${fontFormatEmoji}");
             }
 

--- a/vscode-sparkdown/src/managers/SparkdownPreviewScreenplayPanelManager.ts
+++ b/vscode-sparkdown/src/managers/SparkdownPreviewScreenplayPanelManager.ts
@@ -357,7 +357,7 @@ export class SparkdownPreviewScreenplayPanelManager {
               font-family: "${fontFamilyEmoji}";
               font-style: normal;
               font-weight: normal;
-              font-display: block;
+              font-display: swap;
               src: url("${fontPathEmoji}") format("${fontFormatEmoji}");
             }
 


### PR DESCRIPTION
Follow-up to #209. That PR made the 24 MB Noto Color Emoji font load **eagerly**, which delayed editor startup even for screenplays with no emoji. This makes it lazy.

## Problem
The emoji font was forced to download eagerly in three ways:
- `<link rel="preload">` in `document.html` — fetched on every page load.
- `@font-face { font-display: block }` — hid emoji text until the font parsed.
- `ScriptEditorController.loadFonts()` **awaited `fontFace.load()`** on the emoji font alongside the Courier fonts — so editor init blocked on the 24 MB download.

## Change
- Remove the `<link rel="preload">` for the emoji font (keep it for the small Courier fonts the editor needs immediately).
- Switch the emoji `@font-face` to `font-display: swap` (impower-dev `document.css` + both vscode preview managers).
- In `ScriptEditorController`, register the emoji `FontFace` via `document.fonts.add()` **without** awaiting its load.

## Result
The browser now fetches the emoji font **lazily, only when an emoji is actually rendered**, showing the system emoji font meanwhile (`swap`). Screenplays with no emoji never download it, and editor startup no longer waits on 24 MB. No change to whether/how emoji render — only when the font loads.

## Verification
Straightforward font-loading change (affects *when* the font loads, not *whether* emoji render, which #209 already verified). I was unable to re-verify live because the browser automation extension became unresponsive during this session — the network-timing / lazy-fetch behavior is unverified in a running browser and worth a quick manual check on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)