### PR TITLE
fix(grammar): don't treat `--` as a Luau comment in narrative scope

### DIFF
--- a/definitions/yaml/sparkdown.language-grammar.yaml
+++ b/definitions/yaml/sparkdown.language-grammar.yaml
@@ -2853,8 +2853,21 @@ repository:
       # do-block).
 
   LuauDeclarations:
+    # NOTE: `#LuauComment` is deliberately NOT included here. `LuauDeclarations`
+    # is reached from the top-level (root) patterns and from every mixed
+    # sparkdown+display body (`LuauSparkdownBlockBody`, `LuauSparkdownChooseBlock`,
+    # `LuauSparkdownChooseThenClause`), which is exactly where scene/action/
+    # dialogue prose lives. A `--` there is a display em-dash (and `---` a
+    # front-matter fence / title-page divider), never a comment — the R&B
+    # screenplay opens dozens of action lines with `-- …`. Pulling `#LuauComment`
+    # in here made every such line parse as a `LuauLineComment` and vanish from
+    # the preview. Luau comments belong ONLY to genuine Luau-code contexts, which
+    # each reach comments directly: `LuauExpression` (the sibling in every pure
+    # `LuauBlockBody` / `LuauExplicitStatement` scope) includes `#LuauComment`,
+    # and function/param/define bodies include it themselves. See
+    # [[feedback_grammar_golden_rule]]: separate the two contexts in the grammar
+    # rather than disambiguate downstream. Regression: FrontMatterAndCommentContext.test.ts.
     patterns:
-      - { include: "#LuauComment" }
       - { include: "#LuauShebang" }
       - { include: "#LuauStyle" }
       - { include: "#LuauScreen" }

--- a/packages/sparkdown/language/sparkdown.language-grammar.json
+++ b/packages/sparkdown/language/sparkdown.language-grammar.json
@@ -4548,9 +4548,6 @@
     "LuauDeclarations": {
       "patterns": [
         {
-          "include": "#LuauComment"
-        },
-        {
           "include": "#LuauShebang"
         },
         {

--- a/packages/sparkdown/src/tests/runtime/FrontMatterAndCommentContext.test.ts
+++ b/packages/sparkdown/src/tests/runtime/FrontMatterAndCommentContext.test.ts
@@ -74,9 +74,38 @@ describe("front matter vs luau comment context", () => {
     expect(tree).not.toContain("LuauCommentMark");
   });
 
+  test("an action line that STARTS with `--` is an em-dash, not a comment", () => {
+    // Real R&B screenplay case: action lines routinely open (and close) with
+    // `--` em-dashes, e.g. `-- He closes the app.   Pockets the smartphone. --`.
+    // These live at the scene body (which parses at root), where the
+    // `LuauDeclarations → LuauComment` include used to eat the whole line as a
+    // `LuauLineComment`, so it vanished from the preview.
+    const { tree } = compile(
+      `-> main\n\nscene main\n  -- He closes the app.   Pockets the smartphone. --\n  done\nend\n`,
+    );
+    expect(tree).not.toContain("LuauLineComment");
+    expect(tree).not.toContain("LuauCommentMark");
+    expect(tree).not.toContain("LuauDocLineComment");
+  });
+
+  test("a `--`-led line inside a sparkdown `if` block is still prose", () => {
+    const { tree } = compile(
+      `-> main\n\nscene main\n  if true then\n    -- Reaches toward it --\n  end\n  done\nend\n`,
+    );
+    expect(tree).not.toContain("LuauLineComment");
+    expect(tree).not.toContain("LuauCommentMark");
+  });
+
   test("`--` comment still works inside a function body", () => {
     const { tree } = compile(
       `function greet()\n  local x = 5 -- a real comment\n  return x\nend\n`,
+    );
+    expect(tree).toContain("LuauLineComment");
+  });
+
+  test("a whole-line `--` comment still works inside a function body", () => {
+    const { tree } = compile(
+      `function greet()\n  -- a standalone comment line\n  local x = 5\n  return x\nend\n`,
     );
     expect(tree).toContain("LuauLineComment");
   });

--- a/vscode-sparkdown/language/sparkdown.language-grammar.json
+++ b/vscode-sparkdown/language/sparkdown.language-grammar.json
@@ -4548,9 +4548,6 @@
     "LuauDeclarations": {
       "patterns": [
         {
-          "include": "#LuauComment"
-        },
-        {
           "include": "#LuauShebang"
         },
         {


### PR DESCRIPTION
## Problem

Action / dialogue / prose lines that open (or close) with `--` em-dashes were being parsed as Luau line comments and dropped from the preview. This is common in real screenplays — e.g. from `R&B_EP02.sd`:

```
-- He closes the app.   Pockets the smartphone. --
-- Reaches toward it --
-- We pan over cabinets THROWN OPEN -- their contents SPILLING onto plush carpet --
```

Each of these vanished, because narrative `--` is meant to be an **em-dash**, not a comment.

## Root cause

Scene bodies parse at the top-level (root) pattern list, and the mixed sparkdown+display block bodies (`LuauSparkdownBlockBody`, `LuauSparkdownChooseBlock`, `LuauSparkdownChooseThenClause`) all reach `LuauDeclarations`. `LuauDeclarations` listed `#LuauComment` as its **first** pattern, so a `--`-led line matched a comment before the display/action rule could claim it.

This is a sibling of the earlier `Annotation → #LuauComment` fix (front-matter `---` / prose em-dashes); that one closed the display-decoration path, this one closes the declaration path.

## Fix

Drop `#LuauComment` from `LuauDeclarations`. Luau comments belong only to genuine Luau-code contexts, which already reach comments directly:

- `LuauExpression` (the sibling in every pure `LuauBlockBody` / `LuauExplicitStatement` scope) includes `#LuauComment`.
- Function / parameter / define bodies include `#LuauComment` themselves.

So comments inside function bodies, expressions, and control blocks are unaffected. Follows the grammar **Golden Rule**: separate the two contexts in the grammar rather than disambiguate downstream.

## Testing

- New regression tests in `FrontMatterAndCommentContext.test.ts`:
  - a `--`-led action line is prose (no `LuauLineComment`)
  - a `--`-led line inside a sparkdown `if` block is prose
  - a whole-line `--` comment inside a function body is **still** a comment
- Existing `FrontMatterAndCommentContext` (7 tests) and `DisplayLineComment` (3 tests) suites pass.
- Verified against the real `R&B_EP02.sd`: the compiled tree now contains **0** `LuauLineComment` / `LuauDocLineComment` nodes (was many).

🤖 Generated with [Claude Code](https://claude.com/claude-code)