### PR TITLE
fix(spark-editor): don't reload/wipe the script editor on our own autosave echo (#216)

### DIFF
--- a/impower-dev/src/modules/spark-editor/components/logic-script-editor/LogicScriptEditor.tsx
+++ b/impower-dev/src/modules/spark-editor/components/logic-script-editor/LogicScriptEditor.tsx
@@ -45,6 +45,18 @@ export default function LogicScriptEditor({
   const versionRef = useRef<number | undefined>(undefined);
   const textRef = useRef<string | undefined>(undefined);
 
+  // Normalized snapshots of every text THIS editor has written to disk. A
+  // `DidWriteFiles` whose text matches one of these is our own autosave/rename
+  // echo — never an external edit — so it must not trigger a reload. We match
+  // against what we WROTE (not the live buffer) because an in-flight autosave
+  // can lag behind the buffer after further keystrokes; comparing the echo to
+  // the buffer would then misread our own stale write as a divergent external
+  // edit and destroy + rebuild the editor mid-typing, wiping the just-typed
+  // characters (#216). Bounded so a long session can't grow it without limit.
+  const ownWritesRef = useRef<Set<string>>(new Set<string>());
+  const OWN_WRITES_LIMIT = 16;
+  const normalizeText = (s: string) => s.replace(/\r\n|\r/g, "\n");
+
   // Latest props/store values stashed in refs so the listener (mounted
   // once) always reads current values without needing to reattach.
   const filenameRef = useRef(filename);
@@ -149,13 +161,22 @@ export default function LogicScriptEditor({
 
       const debouncedSave = debounce(async () => {
         if (uriRef.current && versionRef.current && textRef.current != null) {
+          const written = textRef.current;
+          // Remember what we're writing so its DidWriteFiles echo is recognized
+          // as our own and never reloads the editor (#216).
+          ownWritesRef.current.add(normalizeText(written));
+          if (ownWritesRef.current.size > OWN_WRITES_LIMIT) {
+            ownWritesRef.current = new Set(
+              [...ownWritesRef.current].slice(-OWN_WRITES_LIMIT),
+            );
+          }
           const { Workspace } = await import("../../workspace/Workspace");
           if (disposed) return;
           await Workspace.fs.writeTextDocument({
             textDocument: {
               uri: uriRef.current,
               version: versionRef.current,
-              text: textRef.current,
+              text: written,
             },
           });
           await Workspace.window.recordScriptChange();
@@ -184,17 +205,25 @@ export default function LogicScriptEditor({
           //    is showing — an EXTERNAL edit, e.g. a reference-aware asset
           //    rename rewriting this script via applyWorkspaceEdit from the
           //    file manager pane.
-          // The editor's OWN writes are skipped because they echo back
-          // identical text (autosave) or update the buffer first (in-editor F2
-          // rename), so `textRef` already matches. Without this reload the
-          // buffer would keep showing the pre-rename reference and its next
-          // autosave would revert the on-disk rewrite.
-          const normalize = (s: string) => s.replace(/\r\n|\r/g, "\n");
+          // The editor's OWN writes are skipped: they echo back text this
+          // editor wrote, which we track in `ownWritesRef`. We must match the
+          // echo against what we WROTE — not the live buffer — because an
+          // in-flight autosave lags behind the buffer once the user keeps
+          // typing, so a buffer comparison would misclassify our own stale echo
+          // as an external edit and reload (destroying the editor + wiping the
+          // just-typed characters, #216). A genuine external rewrite (e.g. a
+          // reference-aware asset rename rewriting this script via
+          // applyWorkspaceEdit from the file manager pane) is text we never
+          // wrote, so it still diverges and reloads.
+          const changedText =
+            changed.text != null ? normalizeText(changed.text) : null;
+          const isOwnWrite =
+            changedText != null && ownWritesRef.current.has(changedText);
           const diverged =
-            changed.text != null &&
+            changedText != null &&
             textRef.current != null &&
-            normalize(changed.text) !== normalize(textRef.current);
-          if (params.remote || diverged) {
+            changedText !== normalizeText(textRef.current);
+          if (params.remote || (diverged && !isOwnWrite)) {
             loadFile();
           }
         }),


### PR DESCRIPTION
Fixes the destructive half of #216: the script editor tearing down + rebuilding mid-typing and wiping the latest keystrokes.

## Root cause

`LogicScriptEditor`'s `DidWriteFiles` handler decided whether to reload the open buffer by comparing the on-disk text to the **live buffer** (`textRef.current`):

```ts
const diverged =
  changed.text != null &&
  textRef.current != null &&
  normalize(changed.text) !== normalize(textRef.current);
if (params.remote || diverged) loadFile();
```

That divergence check exists to catch genuine **external** rewrites (e.g. a reference-aware asset rename rewriting this script via `applyWorkspaceEdit` from the file-manager pane). But it also misfires on our **own** autosave: during the save cycle an in-flight write lags behind the buffer once the user keeps typing, so its `DidWriteFiles` echo carries slightly older text than the buffer → `diverged` is true → `loadFile()` → `LoadEditorMessage{ preserveEditor: false }` → `ScriptEditorController.loadTextDocument()` calls `this._view.destroy()` and rebuilds the editor from the **stale** snapshot, discarding the just-typed characters (and producing the visible hide → spinner → rebuild "refresh").

## Fix

Track the texts this editor writes (`ownWritesRef`) and skip the reload when a `DidWriteFiles` echoes one of them — matching against **what we wrote**, not the live buffer:

```ts
const changedText = changed.text != null ? normalizeText(changed.text) : null;
const isOwnWrite = changedText != null && ownWritesRef.current.has(changedText);
const diverged =
  changedText != null &&
  textRef.current != null &&
  changedText !== normalizeText(textRef.current);
if (params.remote || (diverged && !isOwnWrite)) loadFile();
```

- Our own autosave echo — even when it lags behind the buffer — is recognized and **never** reloads. ✅ fixes #216
- A genuine external rewrite is text we never wrote, so it still diverges and reloads. ✅ preserves the asset-rename behavior the check was added for (a8deeec1d)
- Remote pulls still reload unconditionally. ✅

The set is matched (not the single last write) so out-of-order echoes from back-to-back autosaves are still recognized, and it's bounded (16) so a long session can't grow it without limit.

## Verification (live, in the running editor)

Drove the actual `workspace/didWriteFiles` → `loadFile` path with real keyboard input and a remount observer on the editor container:

| Scenario | Expected | Result |
|---|---|---|
| Type EDIT_ONE (autosaved), type EDIT_TWO, then a **local** `didWriteFiles` echoing the stale EDIT_ONE text (diverges from buffer) | no reload, EDIT_TWO survives | ✅ `remounts: 0`, EDIT_TWO intact |
| **Local** `didWriteFiles` with foreign text we never wrote | reload | ✅ editor rebuilt |
| `didWriteFiles` with `remote: true` | reload | ✅ editor rebuilt |

Before the fix, the first scenario destroyed the editor and reverted to the stale snapshot (the reported wipe).

## Scope / follow-ups (not in this PR)

- This targets the **trigger**. A deeper hardening — never `view.destroy()` for a routine reload; apply a diff (`preserveEditor: true`) with a version guard so an older snapshot can never overwrite newer buffer text — is worth doing separately (`ScriptEditorController.ts:545-567`).
- The **lag** half of #216 (LSP requests timing out at 3 s on large scripts because sync/diagnostics run un-debounced) is separate and not addressed here.
- An automated regression test is outlined in #216; it needs mocking the protocol bus + `Workspace.fs`, so it's left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
