### PR TITLE
perf(lsp-client): stop stringify+parse round-tripping every worker message on the main thread

### DIFF
--- a/packages/codemirror-vscode-lsp-client/src/client.ts
+++ b/packages/codemirror-vscode-lsp-client/src/client.ts
@@ -525,8 +525,13 @@ export class LSPClient {
     return null;
   }
 
-  private async receiveMessage(msg: string) {
-    const value = JSON.parse(msg) as
+  private async receiveMessage(msg: string | object) {
+    // Transports that already hold a parsed message object (Worker
+    // structured-clone data) pass it through as-is; only parse when the
+    // transport delivered a string. Avoids a stringify+parse round-trip on
+    // the main thread for every server response (huge for whole-document
+    // payloads like semantic tokens and diagnostics on large files).
+    const value = (typeof msg === "string" ? JSON.parse(msg) : msg) as
       | lsp.ResponseMessage
       | lsp.NotificationMessage
       | lsp.RequestMessage;

--- a/packages/codemirror-vscode-lsp-client/src/transport.ts
+++ b/packages/codemirror-vscode-lsp-client/src/transport.ts
@@ -12,10 +12,15 @@ export type Transport = {
   /// Send a message to the server. Should throw if the connection is
   /// broken somehow.
   send(message: string): void;
-  /// Register a handler for messages coming from the server.
-  subscribe(handler: (value: string) => void): void;
+  /// Register a handler for messages coming from the server. Transports
+  /// that already hold the message as a parsed object (e.g. a Worker's
+  /// structured-clone `e.data`) may pass the object through directly —
+  /// re-serializing it to a string just so the client can JSON.parse it
+  /// again costs real main-thread time on large payloads (whole-document
+  /// semantic tokens / diagnostics on big files).
+  subscribe(handler: (value: string | object) => void): void;
   /// Unregister a handler registered with `subscribe`.
-  unsubscribe(handler: (value: string) => void): void;
+  unsubscribe(handler: (value: string | object) => void): void;
 };
 
 export class WorkerTransport implements Transport {
@@ -35,9 +40,12 @@ export class WorkerTransport implements Transport {
     this.worker.postMessage(json);
   }
 
-  subscribe(handler: (value: string) => void) {
+  subscribe(handler: (value: string | object) => void) {
     this._onMessage = (e: MessageEvent) => {
-      handler(JSON.stringify(e.data));
+      // Pass the structured-clone object straight through — stringifying
+      // here (for the client to immediately re-parse) doubled the
+      // main-thread cost of every server response.
+      handler(e.data);
     };
     this.worker.addEventListener("message", this._onMessage);
   }
@@ -73,9 +81,11 @@ export class BrowserTransport {
     this.writer.write(json);
   }
 
-  subscribe(handler: (value: string) => void) {
+  subscribe(handler: (value: string | object) => void) {
     this._listener = this.reader.listen((data) => {
-      handler(JSON.stringify(data));
+      // Reader already delivers a parsed message object — pass it through
+      // (see WorkerTransport.subscribe).
+      handler(data as object);
     });
   }
 


### PR DESCRIPTION
Part of the typing-lag investigation on large scripts (#216's "lag" half). This removes a pure main-thread waste in the LSP client transport, guided by per-message instrumentation on the real ~8,300-line project.

## What was happening

`WorkerTransport` receives every language-server message as a structured-clone **object** (`e.data`), but the string-based `Transport` interface forced it to `JSON.stringify` the object on the **main thread**, and `LSPClient.receiveMessage` immediately `JSON.parse`d it back:

```ts
// transport.ts (before)
this._onMessage = (e: MessageEvent) => {
  handler(JSON.stringify(e.data));   // main-thread serialize…
};
// client.ts (before)
private async receiveMessage(msg: string) {
  const value = JSON.parse(msg) as ...   // …main-thread parse, same data
```

## Why it matters (measured on the real project)

Live-traffic instrumentation (temporarily timing what the legacy round-trip costs for each real message) showed, **per keystroke**:

| Message | Size | Legacy stringify+parse (main thread) |
|---|---|---|
| `compiler/didCompile` (full compiled program, re-broadcast on every recompile) | **~9 MB** | **~380 ms** healthy, **4.5 s** under memory pressure |
| `textDocument/foldingRange` responses | ~160 KB × 3 per edit | ~9 ms |
| diagnostics | ~130 KB | ~4–14 ms |
| `semanticTokens/full` response | ~0.3 KB (delta-encoded — tiny!) | ~0 |

The kicker: the LSP client has **no handler** for `compiler/didCompile` — it round-tripped 9 MB through stringify+parse just to *discard the message*. (The message is separately consumed via the vscode-jsonrpc connection by `WorkspaceLanguageServer`, which is unaffected by this change.)

This was the dominant share of the `WorkerTransport.onmessage` main-thread cost (~1.7–3.1 s per typing burst) profiled via Long-Animation-Frames while investigating typing lag.

## The change

- Transports may hand the client the parsed message **object** directly; the client only `JSON.parse`s when a transport actually delivers a string. String-based transports keep working unchanged.
- `WorkerTransport`/`BrowserTransport` pass their already-parsed messages through.

Receive-path only — outgoing messages are small (incremental `didChange` deltas), so the send-path stringify→parse is left as is.

## Verification

On the imported real project (8,309 lines): page loads, semantic highlighting renders, the warnings counter (diagnostics) arrives, and editing works end-to-end through the object path. Not yet exercised: hover/completion/rename under this patch (same code path as diagnostics/tokens — `receiveMessage` routing is unchanged — but worth a click-around before merging).

## Follow-up (bigger fish, separate work)

The deeper fix this measurement points at: **stop shipping the full ~9 MB compiled program to the main thread on every keystroke** (`compiler/didCompile` → `WorkspaceLanguageServer` → re-broadcast on the in-page bus). Even with this patch, the main thread still structured-clone-deserializes ~9 MB per edit and re-dispatches it. A delta/on-demand program channel would eliminate the remaining cost; tracked as part of the #216 lag investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
