### PR TITLE
fix(workspace): surface language-server startup failures + wait out compiler configuration (#224)

### DIFF
--- a/impower-dev/src/modules/spark-editor/workspace/WorkspaceFileSystem.ts
+++ b/impower-dev/src/modules/spark-editor/workspace/WorkspaceFileSystem.ts
@@ -89,7 +89,13 @@ export default class WorkspaceFileSystem {
       console.error(e);
     };
     this._worker.addEventListener("message", this.handleWorkerMessage);
-    this._initialFilesRef.get(projectId);
+    // Observe the rejection: this promise gates language-server startup (it
+    // ends in `Workspace.ls.start`), and an unobserved failure here used to be
+    // indistinguishable from "still loading" — the editor just silently ran
+    // without any program-dependent LSP features.
+    void this._initialFilesRef.get(projectId).catch((e) => {
+      console.error("[workspace] initial file load failed:", e);
+    });
   }
 
   getLoadedProjectId() {
@@ -175,10 +181,15 @@ export default class WorkspaceFileSystem {
         return this.executeCommand(params);
       },
     );
-    Workspace.ls.start(
-      this.getDirectoryUri(projectId),
-      Object.values(this._files),
-    );
+    // Fire-and-forget on purpose (project load must not block on the language
+    // server initializing, which includes a full compile), but the failure has
+    // to be visible — a rejected `start()` previously vanished as an unhandled
+    // rejection and left every program-dependent LSP request erroring.
+    void Workspace.ls
+      .start(this.getDirectoryUri(projectId), Object.values(this._files))
+      .catch((e) => {
+        console.error("[workspace] language server failed to start:", e);
+      });
     // Auto-expire old recycle-bin batches (>30 days). Fire-and-forget — it must
     // not block the project load, and trash is local-only so there's no remote
     // coordination.

--- a/packages/sparkdown-language-server/src/sparkdown-language-server.ts
+++ b/packages/sparkdown-language-server/src/sparkdown-language-server.ts
@@ -118,6 +118,19 @@ try {
   connection.onInitialized(async () => {
     const settings = await connection.workspace.getConfiguration("sparkdown");
     workspace.loadConfiguration(settings);
+    // Ask the client to re-request anything it may have asked for while we were
+    // still starting up. Initialization loads every project file into the
+    // compiler and runs a full compile, and on a large project that takes long
+    // enough that the editor's first semantic-token / diagnostic requests are
+    // rejected outright ("Compiler has not been configured!"). Those requests
+    // are never retried on their own, so without this the features stay dead
+    // until something else happens to trigger a re-request. See #224.
+    try {
+      connection.languages.semanticTokens.refresh();
+      connection.languages.diagnostics.refresh();
+    } catch (e) {
+      console.error("failed to request client refresh after initialize", e);
+    }
   });
 
   // foldingRangeProvider

--- a/packages/sparkdown/src/workspace/classes/SparkdownWorkspace.ts
+++ b/packages/sparkdown/src/workspace/classes/SparkdownWorkspace.ts
@@ -172,6 +172,29 @@ export abstract class SparkdownWorkspace {
     return this._initializedCompiler;
   }
 
+  /**
+   * Resolves once `configureCompiler` has completed — i.e. the compiler worker
+   * has its document registry and can actually compile.
+   *
+   * Requests that arrive before then used to fail hard with "Compiler has not
+   * been configured!" (the `documents` getter throws), which on a large project
+   * meant semantic tokens / code lenses erroring for as long as initialization
+   * took, with no retry. Compiles now wait for this instead.
+   *
+   * Deliberately `undefined` until `initialize()` is entered: if initialization
+   * is never going to happen there is nothing to wait for, and waiting forever
+   * would turn a loud error into a silent hang.
+   */
+  protected _compilerConfigured = false;
+  protected _resolveCompilerConfigured?: () => void;
+  protected _compilerConfiguring?: Promise<void>;
+  get whenCompilerConfigured(): Promise<void> | undefined {
+    if (this._compilerConfigured) {
+      return Promise.resolve();
+    }
+    return this._compilerConfiguring;
+  }
+
   constructor(compilerInlineWorkerContent: string, profilerId?: string) {
     this._profilerId = profilerId;
     const compilerWorker = new Worker(
@@ -246,6 +269,9 @@ export abstract class SparkdownWorkspace {
     }[];
   }> {
     this._clientCapabilities = params.capabilities;
+    this._compilerConfiguring ??= new Promise<void>((resolve) => {
+      this._resolveCompilerConfigured = resolve;
+    });
     if (params.initializationOptions) {
       // (slimProgramNotifications must be destructured out so it doesn't
       // fall through into compilerConfig.)
@@ -380,10 +406,17 @@ export abstract class SparkdownWorkspace {
   }
 
   async configureCompiler(config: SparkdownCompilerConfig) {
-    return this._compilerChannelConnection.sendRequest(
-      ConfigureCompilerMessage.type,
-      config,
-    );
+    try {
+      return await this._compilerChannelConnection.sendRequest(
+        ConfigureCompilerMessage.type,
+        config,
+      );
+    } finally {
+      // Settle even on failure: a waiter blocking forever would be worse than
+      // the original error surfacing at the compile site.
+      this._compilerConfigured = true;
+      this._resolveCompilerConfigured?.();
+    }
   }
 
   async loadFile(file: { uri: string }) {
@@ -751,6 +784,12 @@ export abstract class SparkdownWorkspace {
   }
 
   protected async compileDocument(uri: string) {
+    // Wait out initialization rather than throwing "Compiler has not been
+    // configured!" at whoever asked first (see `whenCompilerConfigured`).
+    const configuring = this.whenCompilerConfigured;
+    if (configuring) {
+      await configuring;
+    }
     this._lastCompiledUri = uri;
     const result = await this._compilerChannelConnection.sendRequest(
       CompileProgramMessage.type,


### PR DESCRIPTION
Part of #224. This is the **hygiene half** — it does not cure the reported symptom on its own (see "What this does *not* fix" below), but it removes the silent-failure behavior that made the bug so hard to diagnose in the first place.

## The problem

Two links in the language-server startup chain were fire-and-forget:

- `loadInitialFiles` is wrapped in a `SingletonPromise` whose rejection was never observed — and it's what eventually calls `Workspace.ls.start(...)`.
- `Workspace.ls.start(...)` was called with no `await` and no `.catch`, so a rejection became an unhandled promise rejection.

Net effect: if language-server startup broke, the editor simply carried on with **no program-dependent LSP features** and no indication anything was wrong. Syntax coloring still worked (client-side TextMate), diagnostics still appeared (they come from the player iframe's workspace), so nothing looked broken — while semantic tokens and code lenses were failing on every request.

Separately, requests that arrive after `initialize()` starts but before `configureCompiler()` finishes hit a hard throw from the compiler's `documents` getter:

```
Error: Compiler has not been configured!
```

## The change

- Both startup paths now log a clear error instead of vanishing. Startup stays non-blocking — project load must not wait on the language server, whose `initialize` performs a full compile.
- `compileDocument()` (the single choke point every compile goes through) waits on a new `whenCompilerConfigured` promise instead of letting the request explode.

Two deliberate details on that promise:

- It is **undefined until `initialize()` is entered**. If initialization is never going to happen there's nothing to wait for, and waiting forever would convert a loud error into a silent hang.
- It settles in a `finally`, so a *failed* configuration can't strand waiters either.

## What this does *not* fix

The dominant delay is upstream of everything here. `readDirectoryFiles` reads the **contents of every file** in the project before `ls.start(...)` is ever reached. Measured on the ~630-file R&B project:

| Enumeration | Time |
|---|---|
| Warm (contents already cached, `readFile` skipped) | **1.2 s** |
| Cold (startup — must read each file) | **still unresolved after 4+ minutes** |

So enumeration is cheap; the cost is 630 concurrent OPFS reads + blob-URL creation + `.url` HEAD probes in one unbounded `Promise.all` — with LS startup queued behind all of it. Caveat: measured on a machine at 85-98% RAM, so absolute numbers are inflated; the ratio and the ordering are the real signal.

That fix (don't read every file's bytes just to enumerate, and/or bound the concurrency) is the remaining work on #224 and is deliberately not bundled here — it changes when `src` becomes available for binary assets, which needs its own review.

## Verification

Verified live that the new gate is reached and behaves (compiles wait rather than throw once `initialize()` has started). Not verifiable on my box: the end-to-end "semantic tokens come back" path, because startup never completes there within minutes — that's the upstream issue above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
