### PR TITLE
feat(spark-web-player): advance dialogue with Enter/Space

### DIFF
--- a/packages/spark-engine/src/game/core/classes/Coordinator.ts
+++ b/packages/spark-engine/src/game/core/classes/Coordinator.ts
@@ -1,9 +1,15 @@
 import { NotificationMessage } from "@impower/jsonrpc/src/common/types/NotificationMessage";
 import { RequestMessage } from "@impower/jsonrpc/src/common/types/RequestMessage";
+import { IKeyboardEvent } from "../types/IKeyboardEvent";
 import { Instructions } from "../types/Instructions";
 import { Clock } from "./Clock";
 import type { Game } from "./Game";
 import { EventMessage } from "./messages/EventMessage";
+
+/**
+ * Keys that advance the game the same way a tap does.
+ */
+const ADVANCE_KEYS = ["Enter", " "];
 
 export class Coordinator<G extends Game> {
   protected _game: G;
@@ -61,8 +67,28 @@ export class Coordinator<G extends Game> {
         if (params.button === 0) {
           this._interacted = true;
         }
+      } else if (params.type === "keydown") {
+        if (this.isAdvanceKey(params)) {
+          this._interacted = true;
+        }
       }
     }
+  }
+
+  /**
+   * Whether a keypress should advance the game the same way a tap does.
+   * Auto-repeat is ignored so that holding the key down doesn't blast through
+   * several beats at once, and modified presses are left alone so they stay
+   * available as shortcuts.
+   */
+  protected isAdvanceKey(event: IKeyboardEvent<"keydown">): boolean {
+    if (event.repeat) {
+      return false;
+    }
+    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+      return false;
+    }
+    return ADVANCE_KEYS.includes(event.key);
   }
 
   /**

--- a/packages/spark-web-player/src/app/Application.ts
+++ b/packages/spark-web-player/src/app/Application.ts
@@ -46,6 +46,24 @@ export const loadBuffer: LoaderParser = {
 } as LoaderParser;
 extensions.add(loadBuffer);
 
+/**
+ * Whether the event target is somewhere the player is typing, in which case
+ * keys belong to that field rather than to the game.
+ */
+const isEditableTarget = (target: EventTarget | null): boolean => {
+  const el = target as HTMLElement | null;
+  if (!el || typeof el.tagName !== "string") {
+    return false;
+  }
+  const tag = el.tagName.toLowerCase();
+  return (
+    tag === "input" ||
+    tag === "textarea" ||
+    tag === "select" ||
+    el.isContentEditable
+  );
+};
+
 export class Application implements IApplication {
   protected _game: Game;
   get game() {
@@ -384,6 +402,10 @@ export class Application implements IApplication {
       this._overlay.addEventListener("pointerup", this.onPointerUpOverlay);
       this._overlay.addEventListener("click", this.onClickOverlay);
     }
+    // Keys don't target the canvas or the overlay (neither is focusable), so
+    // they have to be picked up at the window level. The player is its own
+    // frame, so this can't swallow keys meant for the surrounding editor.
+    window.addEventListener("keydown", this.onKeyDown);
   }
 
   unbind() {
@@ -405,6 +427,7 @@ export class Application implements IApplication {
       this._overlay.removeEventListener("pointerup", this.onPointerUpOverlay);
       this._overlay.removeEventListener("click", this.onClickOverlay);
     }
+    window.removeEventListener("keydown", this.onKeyDown);
   }
 
   emit(message: Message, _transfer?: ArrayBuffer[]) {
@@ -433,6 +456,14 @@ export class Application implements IApplication {
   };
 
   onClickOverlay = (event: MouseEvent): void => {
+    this.emit(EventMessage.type.notification(getEventData(event)));
+  };
+
+  onKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === " " && !isEditableTarget(event.target)) {
+      // Otherwise space scrolls the player document out from under the game
+      event.preventDefault();
+    }
     this.emit(EventMessage.type.notification(getEventData(event)));
   };
 


### PR DESCRIPTION
Closes #225.

## What

Pressing <kbd>Enter</kbd> or <kbd>Space</kbd> now advances dialogue, matching what a click/tap already does.

Advancing was pointer-only: `Coordinator.onMessage` handled just `pointerdown` with `button === 0`, and `Application` bound only pointer/click listeners. So when the game paused at a beat with the ▼ indicator, the keyboard did nothing.

## How

Two small pieces — the rest of the plumbing already existed (`EventMap` already declared `keydown` as `IKeyboardEvent`, and `getEventData` already serialized `key` and `repeat`, so there are no type or protocol changes).

**`Application.ts`** — forward `keydown` from the player `window` over the existing `EventMessage` channel, torn down in `unbind()`. It has to be window-level because keys don't target the canvas or the overlay — neither is focusable. The player is its own frame, so this can't swallow keys meant for the surrounding editor.

**`Coordinator.ts`** — a `keydown` branch that sets the same `_interacted` latch a tap sets:

```ts
} else if (params.type === "keydown") {
  if (this.isAdvanceKey(params)) {
    this._interacted = true;
  }
}
```

Because it's the *same* latch — `shouldContinue()` cannot tell where it came from — all three behaviours from the ticket match tap exactly and for free: instant-reveal mid-type, advance once finished, and no-op while choices are up.

Guards in `isAdvanceKey`: auto-repeat is ignored so holding the key doesn't blast through several beats, and modified presses are left alone so they stay available as shortcuts. Separately, <kbd>Space</kbd> gets `preventDefault()` outside editable fields so it can't scroll the player document.

## Verified

Manually in the dev editor (`npm run web:dev`), plus confirmed by the repo owner:

| Input | Expected | Result |
| --- | --- | --- |
| <kbd>Enter</kbd> (real OS keystroke) | advance | beat 1 → 2 ✅ |
| <kbd>Space</kbd> | advance | beat 2 → 3 ✅ |
| <kbd>Enter</kbd> auto-repeat | ignored | ✅ |
| <kbd>Ctrl</kbd>+<kbd>Enter</kbd> | ignored | ✅ |
| <kbd>Shift</kbd>+<kbd>Space</kbd> | ignored | ✅ |
| <kbd>Escape</kbd>, letter keys | ignored | ✅ |
| <kbd>Enter</kbd>/<kbd>Space</kbd> with choices on screen | no-op | ✅ |
| Click a choice | still works | ✅ |

Two things stated plainly rather than glossed:

- **Space was exercised through the window listener, not an OS keystroke.** The browser automation harness emits `space`/`Return` with an empty `key` value. <kbd>Enter</kbd> (the correct spelling) did work end-to-end with a real keystroke, proving OS key delivery reaches the listener; Space was then dispatched into that same verified listener. The untested sliver is the harness's key-name mapping, not this code.
- **The mid-reveal instant-reveal case was not directly observed** — the timing kept landing outside the reveal window. It's correct by construction (same `_interacted` latch, no separate keyboard path, and instant-reveal on tap is pre-existing verified behaviour), but it's an assertion from the code rather than something I watched happen.

## Not included

No automated test: `spark-engine` has no vitest config and no test files at all, so covering `isAdvanceKey` would mean standing up a harness for that package. Happy to do that as its own PR if wanted.

## Context

This came out of #214, which reported both click *and* keyboard advance as broken. The click half turned out to be already fixed on `main` (re-verified against the reporter's own project) and that issue is closed; the keyboard half was never implemented, which is what this PR adds.

Worth noting for future readers: #214's suggested root cause pointed at the `clock.speed > 0` gating in `World.ts`. That's a red herring — no `World` subclass implements `onTap`, and `#game-ui` fully covers the canvas, so the canvas input path never fires for a normal dialogue game. The live path is `#game-ui` → `Application` → `EventMessage` → `Coordinator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
