### PR TITLE
test(spark-engine): cover Coordinator advance behaviour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17849,6 +17849,9 @@
       "dependencies": {
         "@impower/jsonrpc": "file:../jsonrpc",
         "@impower/sparkdown": "file:../sparkdown"
+      },
+      "devDependencies": {
+        "vitest": "^2.1.8"
       }
     },
     "packages/spark-evaluate": {

--- a/packages/spark-engine/package.json
+++ b/packages/spark-engine/package.json
@@ -3,8 +3,15 @@
   "displayName": "Spark Engine",
   "description": "A light-weight library used to run spark games.",
   "version": "0.0.1",
+  "scripts": {
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
   "dependencies": {
     "@impower/sparkdown": "file:../sparkdown",
     "@impower/jsonrpc": "file:../jsonrpc"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/spark-engine/src/game/core/classes/Coordinator.test.ts
+++ b/packages/spark-engine/src/game/core/classes/Coordinator.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+import { Instructions } from "../types/Instructions";
+import { Clock } from "./Clock";
+import { Coordinator } from "./Coordinator";
+import type { Game } from "./Game";
+import { EventMessage } from "./messages/EventMessage";
+
+/**
+ * `shouldContinue()` return codes.
+ */
+const STAY = 0;
+const AUTO_ADVANCED = 1;
+const INTERACTED = 2;
+
+interface Calls {
+  clickedToContinue: number;
+  autoAdvancedToContinue: number;
+  chosePathToContinue: number[];
+  /** One entry per `ui.text.write`, recording whether it was an instant reveal. */
+  textWrites: { target: string; instant: boolean }[];
+  loadedWorlds: string[];
+}
+
+/**
+ * A stand-in for `Game` exposing only the surface `Coordinator` touches.
+ * `setTimeout` runs synchronously so a tick fully resolves before returning,
+ * which keeps the tests free of timers.
+ */
+const createGame = (
+  overrides: { autoAdvanceDelay?: number; previewing?: boolean } = {},
+) => {
+  const calls: Calls = {
+    clickedToContinue: 0,
+    autoAdvancedToContinue: 0,
+    chosePathToContinue: [],
+    textWrites: [],
+    loadedWorlds: [],
+  };
+  const game = {
+    context: {
+      system: {
+        previewing: overrides.previewing,
+        simulating: undefined,
+        setTimeout: (handler: Function) => {
+          handler();
+          return 0;
+        },
+      },
+      preferences: {
+        flow: { auto_advance_delay: overrides.autoAdvanceDelay ?? 0 },
+      },
+    },
+    module: {
+      world: {
+        loadWorld: (name: string) => calls.loadedWorlds.push(name),
+      },
+      ui: {
+        getTransientTargets: () => [],
+        showScreen: () => {},
+        reveal: () => {},
+        hideAll: () => {},
+        observe: () => {},
+        unobserve: () => {},
+        text: {
+          clearAll: () => {},
+          write: (target: string, _events: unknown, instant?: boolean) =>
+            calls.textWrites.push({ target, instant: Boolean(instant) }),
+        },
+        image: { clearAll: () => {}, write: () => {} },
+        style: { update: () => {} },
+      },
+      audio: {
+        stopChannel: () => {},
+        schedule: () => 0,
+        isReady: () => true,
+        triggerAll: () => {},
+        outputLatency: 0,
+      },
+    },
+    clickedToContinue: () => {
+      calls.clickedToContinue += 1;
+    },
+    autoAdvancedToContinue: () => {
+      calls.autoAdvancedToContinue += 1;
+    },
+    chosePathToContinue: (index: number) =>
+      calls.chosePathToContinue.push(index),
+  };
+  return { game: game as unknown as Game, calls };
+};
+
+const tick = (deltaMS: number) => ({ deltaMS }) as Clock;
+
+/** A beat with text that takes 1s to reveal. */
+const textBeat = (extra: Partial<Instructions> = {}): Instructions => ({
+  text: { textbox: [{ text: "Hello." }] as never },
+  end: 1,
+  ...extra,
+});
+
+/**
+ * A coordinator part-way through revealing its text: execution has started
+ * (so an interaction means "reveal the rest"), but hasn't finished.
+ */
+const midReveal = (instructions: Instructions = textBeat()) => {
+  const { game, calls } = createGame();
+  const coordinator = new Coordinator(game, instructions);
+  return { coordinator, calls };
+};
+
+/**
+ * A coordinator whose text has fully revealed and is now waiting on the
+ * player (this is the state that shows the tap-to-continue indicator).
+ */
+const finishedBeat = (
+  instructions: Instructions = textBeat(),
+  gameOverrides: Parameters<typeof createGame>[0] = {},
+) => {
+  const { game, calls } = createGame(gameOverrides);
+  const coordinator = new Coordinator(game, instructions);
+  // Run out the reveal duration so handleFinished() fires
+  coordinator.onUpdate(tick(instructions.end * 1000));
+  return { coordinator, calls };
+};
+
+const pointerdown = (button = 0) =>
+  EventMessage.type.notification({ type: "pointerdown", button } as never);
+
+const keydown = (key: string, modifiers: Record<string, boolean> = {}) =>
+  EventMessage.type.notification({
+    type: "keydown",
+    key,
+    repeat: false,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    ...modifiers,
+  } as never);
+
+/**
+ * The three ways a player can say "continue". These must stay
+ * indistinguishable to the Coordinator -- they all set the same latch.
+ */
+const ADVANCE_INPUTS = [
+  ["tap", () => pointerdown(0)],
+  ["Enter", () => keydown("Enter")],
+  ["Space", () => keydown(" ")],
+] as const;
+
+describe("Coordinator", () => {
+  describe("advancing a finished beat", () => {
+    for (const [name, event] of ADVANCE_INPUTS) {
+      it(`advances on ${name}`, () => {
+        const { coordinator } = finishedBeat();
+        coordinator.onMessage(event());
+        expect(coordinator.shouldContinue()).toBe(INTERACTED);
+      });
+    }
+
+    it("stays put with no interaction", () => {
+      const { coordinator } = finishedBeat();
+      expect(coordinator.shouldContinue()).toBe(STAY);
+    });
+
+    it("consumes the interaction so one press advances one beat", () => {
+      const { coordinator } = finishedBeat();
+      coordinator.onMessage(keydown("Enter"));
+      expect(coordinator.shouldContinue()).toBe(INTERACTED);
+      expect(coordinator.shouldContinue()).toBe(STAY);
+    });
+
+    it("calls clickedToContinue through onUpdate", () => {
+      const { coordinator, calls } = finishedBeat();
+      coordinator.onMessage(keydown("Enter"));
+      coordinator.onUpdate(tick(16));
+      expect(calls.clickedToContinue).toBe(1);
+      expect(calls.autoAdvancedToContinue).toBe(0);
+    });
+  });
+
+  describe("instant reveal mid-type", () => {
+    for (const [name, event] of ADVANCE_INPUTS) {
+      it(`reveals the rest of the beat on ${name} instead of advancing`, () => {
+        const { coordinator, calls } = midReveal();
+        // The initial reveal is animated, not instant
+        expect(calls.textWrites).toEqual([
+          { target: "textbox", instant: false },
+        ]);
+
+        coordinator.onMessage(event());
+
+        expect(coordinator.shouldContinue()).toBe(STAY);
+        expect(calls.textWrites).toContainEqual({
+          target: "textbox",
+          instant: true,
+        });
+        expect(calls.clickedToContinue).toBe(0);
+      });
+    }
+
+    it("advances on the second interaction, once revealed", () => {
+      const { coordinator } = midReveal();
+      coordinator.onMessage(keydown("Enter"));
+      expect(coordinator.shouldContinue()).toBe(STAY);
+      coordinator.onMessage(keydown("Enter"));
+      expect(coordinator.shouldContinue()).toBe(INTERACTED);
+    });
+  });
+
+  describe("choices block advancing", () => {
+    const withChoices = () => textBeat({ choices: ["choice_0", "choice_1"] });
+
+    for (const [name, event] of ADVANCE_INPUTS) {
+      it(`does not advance past choices on ${name}`, () => {
+        const { coordinator, calls } = finishedBeat(withChoices());
+        coordinator.onMessage(event());
+        expect(coordinator.shouldContinue()).toBe(STAY);
+        expect(calls.clickedToContinue).toBe(0);
+      });
+    }
+
+    it("does not instant-reveal past choices mid-type", () => {
+      const { coordinator, calls } = midReveal(withChoices());
+      coordinator.onMessage(keydown("Enter"));
+      expect(coordinator.shouldContinue()).toBe(STAY);
+      expect(calls.textWrites).not.toContainEqual({
+        target: "textbox",
+        instant: true,
+      });
+    });
+  });
+
+  describe("keys that must not advance", () => {
+    const ignored: [string, ReturnType<typeof keydown>][] = [
+      ["auto-repeat Enter", keydown("Enter", { repeat: true })],
+      ["auto-repeat Space", keydown(" ", { repeat: true })],
+      ["Ctrl+Enter", keydown("Enter", { ctrlKey: true })],
+      ["Alt+Enter", keydown("Enter", { altKey: true })],
+      ["Meta+Enter", keydown("Enter", { metaKey: true })],
+      ["Shift+Space", keydown(" ", { shiftKey: true })],
+      ["Escape", keydown("Escape")],
+      ["a letter key", keydown("a")],
+      ["Tab", keydown("Tab")],
+    ];
+
+    for (const [name, event] of ignored) {
+      it(`ignores ${name}`, () => {
+        const { coordinator } = finishedBeat();
+        coordinator.onMessage(event);
+        expect(coordinator.shouldContinue()).toBe(STAY);
+      });
+    }
+
+    it("ignores non-primary pointer buttons", () => {
+      const { coordinator } = finishedBeat();
+      coordinator.onMessage(pointerdown(2));
+      expect(coordinator.shouldContinue()).toBe(STAY);
+    });
+
+    it("ignores keyup", () => {
+      const { coordinator } = finishedBeat();
+      coordinator.onMessage(
+        EventMessage.type.notification({
+          type: "keyup",
+          key: "Enter",
+        } as never),
+      );
+      expect(coordinator.shouldContinue()).toBe(STAY);
+    });
+  });
+
+  describe("auto advance", () => {
+    it("advances without interaction once the delay elapses", () => {
+      const { calls } = finishedBeat(textBeat({ auto: true }), {
+        autoAdvanceDelay: 0,
+      });
+      expect(calls.autoAdvancedToContinue).toBe(1);
+      expect(calls.clickedToContinue).toBe(0);
+    });
+
+    it("waits for the delay before auto advancing", () => {
+      const { coordinator, calls } = finishedBeat(textBeat({ auto: true }), {
+        autoAdvanceDelay: 5,
+      });
+      expect(calls.autoAdvancedToContinue).toBe(0);
+      expect(coordinator.shouldContinue()).toBe(STAY);
+    });
+
+    it("advances a beat with nothing to show once its duration is up", () => {
+      const { game } = createGame();
+      const coordinator = new Coordinator(game, { end: 0 });
+      expect(coordinator.shouldContinue()).toBe(AUTO_ADVANCED);
+    });
+  });
+
+  describe("loading", () => {
+    it("stays put while a world is loading", () => {
+      const { game, calls } = createGame();
+      const coordinator = new Coordinator(game, {
+        load: [{ name: "world" }] as never,
+        end: 0,
+      });
+      expect(coordinator.shouldContinue()).toBe(STAY);
+      expect(calls.loadedWorlds).toEqual(["world"]);
+    });
+  });
+});

--- a/packages/spark-engine/vitest.config.ts
+++ b/packages/spark-engine/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    exclude: ["**/node_modules/**", "**/dist/**", "**/out/**"],
+  },
+});


### PR DESCRIPTION
## Why

`spark-engine` had no test setup at all — no vitest config, no test files. That meant `Coordinator`, the class that decides when the game advances, shipped the Enter/Space feature (#225 / #228) on manual verification alone, and the mid-reveal case never got observed at all.

This adds the harness and covers the behaviour.

## What

A `vitest.config.ts` copied verbatim from `packages/sparkdown` for consistency, and 29 tests over `shouldContinue()`:

- **advancing a finished beat** — plus latch consumption (one press = one beat) and the `onUpdate` → `clickedToContinue` wiring
- **instant reveal mid-type** — asserts the re-write happens with `instant: true` and that it does *not* advance
- **choices block advancing** — both finished and mid-type
- **keys that must not advance** — auto-repeat, Ctrl/Alt/Meta/Shift, Escape, letters, Tab, `keyup`, non-primary pointer buttons
- **auto advance** — with and without a delay, plus a beat with nothing to show
- **loading** — stays put while a world loads

The advance cases are table-driven over tap / <kbd>Enter</kbd> / <kbd>Space</kbd>, so the parity #225 depends on is *asserted* rather than assumed. Those three must stay indistinguishable to the Coordinator — they all set the same `_interacted` latch, and that's the entire basis of the feature.

The fake `Game` exposes only the surface `Coordinator` touches and runs `setTimeout` synchronously, so there are no timers and the suite runs in ~20ms.

## Verification

A green suite proves nothing by itself, so I mutation-tested it. Each mutation was applied to the source, the suite run, and the source restored:

| Mutation | Tests failed |
| --- | --- |
| `isAdvanceKey` always returns `false` | 7 — all keyboard cases, tap correctly still green |
| Drop the auto-repeat guard | 2 — exactly the auto-repeat tests |
| Drop the modifier guard | 4 — exactly Ctrl/Alt/Meta/Shift |
| Let choices be skipped | 3 |
| Drop the pointer `button === 0` check | 1 |

Every mutant was caught by precisely the tests meant to catch it. Source verified pristine afterwards.

```bash
npm --prefix packages/spark-engine run test:run
```

## Notes

- vitest 2.1.9 was already hoisted at the root, so the lockfile delta is three lines declaring the devDependency.
- No production code changes — this is additive.
- While writing these I noticed a latent state-machine wart in `shouldContinue()`: an interaction while choices are on screen clears `_finishedExecution` even though nothing advances. It has no user-visible effect today, so I left the behaviour alone and the tests pin the *observable* result (returns `0`, no advance) rather than encoding the quirk. Filed as #231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
