### PR TITLE
docs: warn about the `@-` body footgun in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,36 @@ by hand.
 
 OPFS project storage is **per-origin**, so a project saved at one editor port is
 invisible at another — use the URL the launcher prints.
+
+## Multi-line bodies for `gh` and `git` (silent-corruption footgun)
+
+`@-` means "read stdin" to **curl**, not to `gh` or `git`. Both accept it as a
+**literal string** and exit 0, so the command looks like it worked:
+
+```sh
+gh pr create --body @- <<'EOF'    # WRONG — body is the 2 chars "@-"
+git commit -m @- <<'EOF'          # WRONG — message is the 2 chars "@-"
+```
+
+Use the file flags instead (`-` means stdin):
+
+```sh
+gh pr create    --body-file body.md     # or --body-file -
+gh issue create --body-file body.md
+gh issue edit N --body-file body.md     # also how you repair a mangled one
+git commit -F msg.txt                   # or -F -
+```
+
+Inline `--body "..."` / `-m "..."` is fine; it's only the `@-` form that breaks.
+
+**Failure signature:** `gh` prints a real issue/PR URL and returns 0, and `git`
+creates a real commit — the damage is only visible if you read the artifact
+back. This has already shipped a merged PR with an empty description.
+
+**So: after publishing anything, read it back.** `gh pr view N --json body`,
+`gh issue view N --json body`, `git log -1`. Prefer writing the body to a file
+first — it survives a bad invocation and can be re-applied with `--body-file`.
+
+Heredocs are also lossy through some shell paths here (a `//` comment came out
+as `/`, breaking a file mid-edit). For anything with code in it, write the file
+with the editor tool rather than piping a heredoc.


### PR DESCRIPTION
Adds a CLAUDE.md section documenting a footgun that already caused real damage in this repo.

## The bug it prevents

`@-` means "read from stdin" to **curl**. It means nothing to `gh` or `git` — both take it as a **literal string** and exit 0:

```sh
gh pr create --body @- <<'EOF'    # posts a body of exactly "@-"
git commit -m @- <<'EOF'          # creates a commit titled "@-"
```

`gh` prints a real PR/issue URL and returns success, so nothing looks wrong unless you go read the artifact back.

## Why it's worth documenting

It got past me six times in one session: five issue/PR bodies plus an issue comment, all posted as `@-`. #228 was **merged with an empty description** before anyone noticed. I'd even hit the identical bug on `git commit -m @-` earlier in the same session, caught it there because `git log` surfaced it, and still didn't connect it to the `gh` calls — because I never read a single body back after creating it.

The asymmetry is the real lesson: the code in that session was verified hard (mutation-tested tests, real browser keystrokes), while the publishing step — the part other people actually read — was taken entirely on faith.

## What the section says

- The correct flags: `--body-file` for `gh`, `-F` for `git`, both of which accept `-` for stdin
- That inline `--body "..."` / `-m "..."` is fine — only the `@-` form breaks
- The failure signature (real URL, exit 0, damage invisible without reading it back)
- `gh issue edit N --body-file` as the repair path
- The habit that actually catches it: read the artifact back after publishing

It also notes a second thing that bit during the same session: heredocs are lossy through some shell paths here — a `//` comment reached a file as `/` and broke it mid-edit — so anything containing code should be written with the editor tool rather than piped through a heredoc.

## Notes

Docs only, no code changes. Placed after the existing dev-server section, matching that section's "here's the failure signature and why it happens" framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
