### PR TITLE
fix(spark-engine): don't clear the finished flag on an ignored interaction

### DIFF
--- a/packages/spark-engine/src/game/core/classes/Coordinator.test.ts
+++ b/packages/spark-engine/src/game/core/classes/Coordinator.test.ts
@@ -91,6 +91,19 @@ const createGame = (
 
 const tick = (deltaMS: number) => ({ deltaMS }) as Clock;
 
+/**
+ * Exposes the execution flags so the state-machine hygiene tests can assert
+ * them directly. Behaviour is otherwise identical to `Coordinator`.
+ */
+class ProbeCoordinator extends Coordinator<Game> {
+  get finishedExecution(): boolean {
+    return this._finishedExecution;
+  }
+  get startedExecution(): boolean {
+    return this._startedExecution;
+  }
+}
+
 /** A beat with text that takes 1s to reveal. */
 const textBeat = (extra: Partial<Instructions> = {}): Instructions => ({
   text: { textbox: [{ text: "Hello." }] as never },
@@ -104,7 +117,7 @@ const textBeat = (extra: Partial<Instructions> = {}): Instructions => ({
  */
 const midReveal = (instructions: Instructions = textBeat()) => {
   const { game, calls } = createGame();
-  const coordinator = new Coordinator(game, instructions);
+  const coordinator = new ProbeCoordinator(game, instructions);
   return { coordinator, calls };
 };
 
@@ -117,7 +130,7 @@ const finishedBeat = (
   gameOverrides: Parameters<typeof createGame>[0] = {},
 ) => {
   const { game, calls } = createGame(gameOverrides);
-  const coordinator = new Coordinator(game, instructions);
+  const coordinator = new ProbeCoordinator(game, instructions);
   // Run out the reveal duration so handleFinished() fires
   coordinator.onUpdate(tick(instructions.end * 1000));
   return { coordinator, calls };
@@ -228,6 +241,59 @@ describe("Coordinator", () => {
         target: "textbox",
         instant: true,
       });
+    });
+
+    // An interaction that is deliberately ignored must not disturb the state
+    // machine. Clearing the finished flag here used to strand the beat out of
+    // its "finished revealing" state for the rest of its life (#231).
+    for (const [name, event] of ADVANCE_INPUTS) {
+      it(`keeps the beat marked finished after an ignored ${name}`, () => {
+        const { coordinator } = finishedBeat(withChoices());
+        expect(coordinator.finishedExecution).toBe(true);
+
+        coordinator.onMessage(event());
+        coordinator.shouldContinue();
+
+        expect(coordinator.finishedExecution).toBe(true);
+      });
+    }
+
+    it("keeps the beat marked finished across repeated ignored interactions", () => {
+      const { coordinator } = finishedBeat(withChoices());
+      for (let i = 0; i < 3; i += 1) {
+        coordinator.onMessage(pointerdown(0));
+        expect(coordinator.shouldContinue()).toBe(STAY);
+      }
+      expect(coordinator.finishedExecution).toBe(true);
+    });
+  });
+
+  describe("execution flag hygiene", () => {
+    it("clears the finished flag only when the interaction advances", () => {
+      const { coordinator } = finishedBeat();
+      expect(coordinator.finishedExecution).toBe(true);
+
+      coordinator.onMessage(keydown("Enter"));
+      expect(coordinator.shouldContinue()).toBe(INTERACTED);
+      // Consumed by the advance itself
+      expect(coordinator.finishedExecution).toBe(false);
+    });
+
+    it("leaves the finished flag alone for keys that never advance", () => {
+      const { coordinator } = finishedBeat();
+      coordinator.onMessage(keydown("Escape"));
+      expect(coordinator.shouldContinue()).toBe(STAY);
+      expect(coordinator.finishedExecution).toBe(true);
+    });
+
+    it("marks the beat finished after an instant reveal", () => {
+      const { coordinator } = midReveal();
+      expect(coordinator.startedExecution).toBe(true);
+      expect(coordinator.finishedExecution).toBe(false);
+
+      coordinator.onMessage(keydown("Enter"));
+      expect(coordinator.shouldContinue()).toBe(STAY);
+      expect(coordinator.finishedExecution).toBe(true);
     });
   });
 

--- a/packages/spark-engine/src/game/core/classes/Coordinator.ts
+++ b/packages/spark-engine/src/game/core/classes/Coordinator.ts
@@ -132,11 +132,12 @@ export class Coordinator<G extends Game> {
     // Player clicked to advance
     if (this._interacted) {
       this._interacted = false;
-      if (this._finishedExecution) {
+      // Only consume the finished state on the path that actually advances --
+      // while waiting on a choice the interaction is ignored, so it must leave
+      // the beat's finished state alone.
+      if (this._finishedExecution && !waitingForChoice) {
         this._finishedExecution = false;
-        if (!waitingForChoice) {
-          return 2;
-        }
+        return 2;
       }
       if (this._startedExecution && !waitingForChoice) {
         this.display({ instant: true });


### PR DESCRIPTION
Closes #231. Builds on the test suite from #229 (now merged), so this is a clean single commit against `main`.

## The problem

While waiting on a choice, an interaction is deliberately ignored — but `shouldContinue()` still cleared `_finishedExecution` on the way past, and nothing put it back:

```ts
if (this._finishedExecution) {
  this._finishedExecution = false;   // cleared unconditionally
  if (!waitingForChoice) {
    return 2;
  }
}
if (this._startedExecution && !waitingForChoice) {
  // ...only restored on this path, which choices also skip
  this._finishedExecution = true;
}
```

With `waitingForChoice` true, the flag goes false, the early return is skipped, and the restore is skipped too. The beat is stranded out of its "finished revealing" state for the rest of its life.

## The fix

Clear the flag only on the branch that actually advances:

```ts
if (this._finishedExecution && !waitingForChoice) {
  this._finishedExecution = false;
  return 2;
}
```

Every other path through the block is unchanged, so this is behaviour-preserving except for the stranding itself.

## Scope: this is a trap, not a live defect

**No user-visible change today.** `waitingForChoice` is derived from `instructions.choices`, which never changes for a live `Coordinator`, and the one branch that reads the flag is itself gated on `!waitingForChoice` — so nothing currently observes the stranded state.

It's worth fixing because the next change is where it bites: anything that starts reading `_finishedExecution` while choices are up — keyboard choice selection, a "choices unlock once the text finishes" affordance, a timed-choice mechanic — would silently get the wrong answer, several steps removed from the symptom.

## Tests

Adds a `ProbeCoordinator` subclass exposing the execution flags so state-machine hygiene can be asserted directly, plus 7 tests:

- the flag survives an ignored tap / <kbd>Enter</kbd> / <kbd>Space</kbd> at a choices screen
- it survives repeated ignored interactions (the impatient-player case)
- it is still consumed when an interaction really does advance
- it is untouched by keys that never advance
- it is set by an instant reveal

**Verified the tests actually catch this**, in both directions:

| Variant | Result |
| --- | --- |
| Old logic (clears flag during choices) | exactly the 4 choice-flag tests fail |
| Over-correction (never clears the flag) | exactly the 1 hygiene test fails |
| This fix | 36/36 pass |

The 29 pre-existing tests stay green across the fix, which is what #231 predicted — if they hadn't, the change would have done more than intended.

## Live smoke test

Because this alters control flow on the path governing *all* advancing, I confirmed it in the dev editor rather than assuming:

1. At a live choices screen (`main : 1`) — background tap → ignored, choices intact
2. <kbd>Enter</kbd> → ignored, choices intact, location unchanged
3. Click "Left path" → advances
4. <kbd>Enter</kbd> → advances to "You went left."

I also ran the same script against **pre-fix** code and got identical behaviour, confirming nothing observable changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
