### PR TITLE
test(spark-engine): cover save/load round-tripping

### DIFF
--- a/packages/spark-engine/src/game/core/classes/SaveLoad.test.ts
+++ b/packages/spark-engine/src/game/core/classes/SaveLoad.test.ts
@@ -1,0 +1,310 @@
+import { SparkdownCompiler } from "@impower/sparkdown/src/compiler/classes/SparkdownCompiler";
+import { beforeAll, describe, expect, it } from "vitest";
+import { Game } from "./Game";
+import { RuntimeState } from "./RuntimeState";
+
+/**
+ * Save corruption is the worst failure mode in the runtime: it surfaces as a
+ * broken save long after the change that caused it, and by then the only
+ * evidence is a save file nobody can load. So these tests drive a real
+ * compiled program through a real `Game` rather than a fake -- the point is
+ * to catch serialization drift between `save()` and `load()`, which a stub
+ * can't model.
+ *
+ * The compiler import makes this the slowest file in the package (a few
+ * seconds to collect). That's the price of testing the real thing here; keep
+ * unit-level work in the cheaper suites.
+ */
+
+const SOURCE = [
+  "First beat here.",
+  "Second beat here.",
+  "Third beat here.",
+  "Fourth beat here.",
+  "Fifth beat here.",
+  "",
+].join("\n");
+
+const CHOICE_SOURCE = [
+  "Pick a path.",
+  "choose",
+  "  * Left path",
+  "    You went left.",
+  "  * Right path",
+  "    You went right.",
+  "end",
+  "Done here.",
+  "",
+].join("\n");
+
+const compile = (source: string) => {
+  const uri = "inmemory:///main.sd";
+  const compiler = new SparkdownCompiler();
+  compiler.configure({
+    files: [
+      {
+        uri,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text: source,
+        version: 1,
+        languageId: "sparkdown",
+      },
+    ],
+  } as never);
+  return compiler.compile({ textDocument: { uri } } as never).program;
+};
+
+let program: ReturnType<typeof compile>;
+let choiceProgram: ReturnType<typeof compile>;
+
+beforeAll(() => {
+  program = compile(SOURCE);
+  choiceProgram = compile(CHOICE_SOURCE);
+});
+
+/** A started game, ready to advance. */
+const startGame = (p = program) => {
+  const game = new Game({
+    program: p,
+    now: () => 0,
+    setTimeout: (handler: Function) => {
+      handler();
+      return 0;
+    },
+  } as never);
+  game.start();
+  return game;
+};
+
+/** Advance `times` beats, as clicking to continue would. */
+const advance = (game: Game, times: number) => {
+  for (let i = 0; i < times; i += 1) {
+    game.clickedToContinue();
+  }
+  return game;
+};
+
+describe("Game save/load", () => {
+  it("compiles the fixture without diagnostics", () => {
+    // If this fails, every other expectation here is meaningless.
+    expect(program.diagnostics ?? {}).toEqual({});
+    expect(program.compiled).toBeTruthy();
+  });
+
+  describe("round-tripping", () => {
+    it("restores a freshly started game to an identical save", () => {
+      const game = startGame();
+      const saved = game.save();
+      expect(game.load(saved)).toBe(true);
+      expect(game.save()).toBe(saved);
+    });
+
+    it("restores a mid-story game to an identical save", () => {
+      const game = advance(startGame(), 2);
+      const saved = game.save();
+      expect(game.load(saved)).toBe(true);
+      expect(game.save()).toBe(saved);
+    });
+
+    // Guards the two tests above from being vacuous: if every game produced
+    // the same save regardless of progress, they'd pass while proving nothing.
+    it("produces different saves at different points in the story", () => {
+      const atStart = startGame().save();
+      const midStory = advance(startGame(), 2).save();
+      expect(midStory).not.toBe(atStart);
+    });
+
+    it("carries progress into a separate Game instance", () => {
+      const original = advance(startGame(), 2);
+      const saved = original.save();
+
+      const restored = startGame();
+      expect(restored.save()).not.toBe(saved);
+      expect(restored.load(saved)).toBe(true);
+      expect(restored.save()).toBe(saved);
+    });
+
+    it("stays stable across repeated round-trips", () => {
+      const game = advance(startGame(), 3);
+      const first = game.save();
+      game.load(first);
+      const second = game.save();
+      game.load(second);
+      expect(game.save()).toBe(first);
+    });
+  });
+
+  describe("restored state is usable, not just identical", () => {
+    it("restores the current story text", () => {
+      const original = advance(startGame(), 2);
+      const expectedText = original.story.currentText;
+
+      const restored = startGame();
+      restored.load(original.save());
+      expect(restored.story.currentText).toBe(expectedText);
+    });
+
+    it("restores the paths executed this frame", () => {
+      const original = advance(startGame(), 2);
+      const expectedPaths = Array.from(
+        original.runtimeState.pathsExecutedThisFrame,
+      );
+      expect(expectedPaths.length).toBeGreaterThan(0);
+
+      const restored = startGame();
+      restored.load(original.save());
+      expect(Array.from(restored.runtimeState.pathsExecutedThisFrame)).toEqual(
+        expectedPaths,
+      );
+    });
+
+    it("restores every module's state", () => {
+      const original = advance(startGame(), 2);
+      const saved = JSON.parse(original.save());
+      // The save is only meaningful if the modules actually round-trip
+      expect(Object.keys(saved.modules).length).toBeGreaterThan(0);
+
+      const restored = startGame();
+      restored.load(original.save());
+      expect(JSON.parse(restored.save()).modules).toEqual(saved.modules);
+    });
+
+    // The strongest property: a restored save doesn't just look the same, it
+    // continues the same. Byte-identical state that then diverges on the next
+    // step would be a save that silently breaks the story.
+    it("continues into the same next beat after restoring", () => {
+      const original = advance(startGame(), 2);
+      const saved = original.save();
+
+      const restored = startGame();
+      restored.load(saved);
+
+      advance(original, 1);
+      advance(restored, 1);
+
+      expect(restored.story.currentText).toBe(original.story.currentText);
+      expect(restored.save()).toBe(original.save());
+    });
+  });
+
+  describe("choices", () => {
+    it("round-trips after a choice has been made", () => {
+      const game = startGame(choiceProgram);
+      game.chosePathToContinue(0);
+      const saved = game.save();
+
+      const restored = startGame(choiceProgram);
+      restored.load(saved);
+      expect(restored.save()).toBe(saved);
+      expect(restored.story.currentText).toBe(game.story.currentText);
+    });
+
+    it("preserves the recorded choice history", () => {
+      const game = startGame(choiceProgram);
+      game.chosePathToContinue(1);
+      const expected = game.runtimeState.choicesEncountered;
+
+      const restored = startGame(choiceProgram);
+      restored.load(game.save());
+      expect(restored.runtimeState.choicesEncountered).toEqual(expected);
+    });
+  });
+
+  describe("malformed saves", () => {
+    it("reports failure on invalid JSON instead of throwing", () => {
+      const game = startGame();
+      expect(() => game.load("{not json")).not.toThrow();
+      expect(game.load("{not json")).toBe(false);
+    });
+
+    it("leaves the game usable after a failed load", () => {
+      const game = advance(startGame(), 2);
+      const before = game.save();
+      game.load("{not json");
+      expect(game.save()).toBe(before);
+    });
+  });
+});
+
+describe("RuntimeState", () => {
+  it("round-trips executed paths through JSON, preserving order", () => {
+    const state = new RuntimeState();
+    state.recordExecution("0.1");
+    state.recordExecution("0.2");
+    state.recordExecution("0.3");
+
+    const restored = RuntimeState.fromJSON(state.toJSON());
+    expect(Array.from(restored.pathsExecutedThisFrame)).toEqual([
+      "0.1",
+      "0.2",
+      "0.3",
+    ]);
+  });
+
+  // The Set is ordered deliberately: re-executing a path moves it to the end
+  // so the last entry is always the most recently executed.
+  it("moves a re-executed path to the end", () => {
+    const state = new RuntimeState();
+    state.recordExecution("0.1");
+    state.recordExecution("0.2");
+    state.recordExecution("0.1");
+
+    const restored = RuntimeState.fromJSON(state.toJSON());
+    expect(Array.from(restored.pathsExecutedThisFrame)).toEqual(["0.2", "0.1"]);
+  });
+
+  it("ignores global paths", () => {
+    const state = new RuntimeState();
+    state.recordExecution("global setup");
+    state.recordExecution("0.1");
+
+    const restored = RuntimeState.fromJSON(state.toJSON());
+    expect(Array.from(restored.pathsExecutedThisFrame)).toEqual(["0.1"]);
+  });
+
+  it("round-trips recorded conditions", () => {
+    const state = new RuntimeState();
+    state.recordCondition(true);
+    state.recordCondition(false);
+
+    const restored = RuntimeState.fromJSON(state.toJSON());
+    expect(restored.conditionsEncountered).toEqual([
+      { selected: true },
+      { selected: false },
+    ]);
+  });
+
+  // clone() must deep-copy: a shallow copy would let a checkpoint mutate the
+  // state it was cloned from, which is exactly the kind of aliasing bug that
+  // only shows up much later as a corrupted save.
+  describe("clone", () => {
+    it("does not alias the executed-path set", () => {
+      const state = new RuntimeState();
+      state.recordExecution("0.1");
+
+      const cloned = RuntimeState.clone(state);
+      cloned.recordExecution("0.2");
+
+      expect(Array.from(state.pathsExecutedThisFrame)).toEqual(["0.1"]);
+      expect(Array.from(cloned.pathsExecutedThisFrame)).toEqual(["0.1", "0.2"]);
+    });
+
+    it("does not alias the recorded choices", () => {
+      const state = new RuntimeState();
+      state.conditionsEncountered.push({ selected: true });
+
+      const cloned = RuntimeState.clone(state);
+      cloned.conditionsEncountered[0]!.selected = false;
+
+      expect(state.conditionsEncountered[0]!.selected).toBe(true);
+    });
+
+    it("tolerates being handed no state", () => {
+      const cloned = RuntimeState.clone(undefined as never);
+      expect(Array.from(cloned.pathsExecutedThisFrame)).toEqual([]);
+      expect(cloned.choicesEncountered).toEqual([]);
+    });
+  });
+});

--- a/packages/spark-engine/vitest.config.ts
+++ b/packages/spark-engine/vitest.config.ts
@@ -4,5 +4,15 @@ export default defineConfig({
   test: {
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
     exclude: ["**/node_modules/**", "**/dist/**", "**/out/**"],
+    // Threads rather than forks. Run time here is dominated by transforming
+    // and evaluating a large module graph (`Game` reaches the inkjs engine),
+    // not by the tests themselves -- they finish in well under a second.
+    // Sharing one process instead of spawning forks roughly halves it.
+    //
+    // Measured over 5 runs each, since single runs vary by 3x on a busy
+    // machine: forks 22.3-43.0s (median 29.8s), threads 8.7-24.7s (median
+    // 13.4s). Use watch mode while working -- an unaffected file reruns in
+    // ~270ms.
+    pool: "threads",
   },
 });


### PR DESCRIPTION
Refs #230 (item 3 on the coverage list).

## Why this next

Save corruption is the worst failure mode in the runtime. It surfaces as a broken save long after the change that caused it, and by then the only evidence left is a file nobody can load. It had no coverage at all.

## Testing the real thing

These drive a **real compiled program through a real `Game`** rather than a fake. That's deliberate: what's worth catching here is serialization drift between `save()` and `load()`, and a stub models exactly the thing that can't drift.

21 tests:

- **Round-tripping** — identity fresh and mid-story, stable across repeated save→load→save cycles, and progress carried into a *separate* `Game` instance
- **Restored state is usable, not just identical** — story text, executed paths, per-module state, and the strongest one: continuing after a restore lands on the same next beat as never having saved. State that looks identical but then diverges is still a broken save.
- **Choices** — round-trip after choosing, plus the recorded choice history
- **Malformed saves** — report failure rather than throwing, and leave the game usable afterwards
- **`RuntimeState`** at unit level — path ordering (a re-executed path moves to the end), global paths ignored, condition round-tripping, and `clone()` deep-copying rather than aliasing

That last one is worth calling out: an aliasing `clone()` is precisely the bug that shows up much later as a corrupted save, because a checkpoint quietly mutates the state it was cloned from.

## Guards against vacuous assertions

Round-trip tests are easy to write in a way that passes for the wrong reason, so two tests exist purely to close that hole:

- one asserts saves at **different story points actually differ** — otherwise "save → load → save is identical" would pass trivially if every save were identical
- the cross-instance test asserts the fresh game's save **differs from the target before loading it**

## Verification

| Mutation | Tests failed |
| --- | --- |
| `save()` skips module state | 2 |
| `load()` skips module state | 4 |
| `load()` skips story state | 4 |
| `load()` skips runtime state | 3 |
| `RuntimeState` drops path ordering | 1 |
| `clone()` aliases the path Set | 1 |
| `clone()` aliases conditions | 1 |
| `RuntimeState` stops ignoring global paths | 1 |

Every mutant caught by exactly the tests meant to catch it; source verified pristine afterwards.

## Cost, measured

Pulling `SparkdownCompiler` into the test graph is what makes this the slowest file in the package. To be precise about *why* — it is not the compiler running:

| | |
| --- | --- |
| `new SparkdownCompiler()` + `configure()` | **164ms** |
| `compile()` | **41ms** |
| Getting the compiler's module graph loaded | **~12s** |

Vitest transforms TypeScript on demand at run time and then evaluates every module's top-level code in a fresh worker. `SparkdownCompiler` drags in the whole inkjs compiler, parser and grammar, so that graph is large. Evaluation can't be cached across processes — a new worker starts with an empty module registry.

Measured with isolated one-test probe files:

| Probe | Duration |
| --- | --- |
| No heavy imports | 2.1s |
| Imports `Game` (runtime + inkjs Story) | ~7–9s |
| Imports `SparkdownCompiler`, never calls it | ~15–22s |

**In practice this is much less painful than those numbers suggest**, because the one-shot cost is not what you pay while working:

| Workflow | Time |
| --- | --- |
| `vitest run`, `pool=forks` (what I was using) | ~23s |
| `vitest run`, `pool=threads` | ~10s |
| Watch mode, edit a cheap test file | **266ms** |
| Watch mode, edit this file | ~7.7s |

Watch mode keeps the module graph warm and reruns only the affected file, which is the normal way you'd interact with this suite.

Worth knowing for later: Vite's dep-optimizer (the real "pre-bundle once" lever) currently **can't** pre-bundle `@impower/sparkdown` — its `main` points at `dist/sparkdown.js`, which isn't built, so the package is consumed as raw TS source. Building it would unlock pre-bundling for every consumer's tests, not just this one.

```bash
npm --prefix packages/spark-engine run test      # watch — what you want while working
npm --prefix packages/spark-engine run test:run  # one-shot
```

Note this branch is off `main`, so it shows 57 tests; it'll be 88 once #234 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
