### PR TITLE
chore(sparkdown): drop the stale `main` entry pointer

### DIFF
--- a/packages/sparkdown/package.json
+++ b/packages/sparkdown/package.json
@@ -4,7 +4,6 @@
   "description": "Sparkdown is a simple markup syntax for writing, editing, and sharing games and screenplays in plain, human-readable text.",
   "version": "0.0.1",
   "type": "module",
-  "main": "dist/sparkdown.js",
   "scripts": {
     "test": "vitest",
     "test:run": "vitest run"


### PR DESCRIPTION
One-line removal of a package.json field that has never pointed at anything.

## The problem

```json
"main": "dist/sparkdown.js"
```

That file has never existed. `@impower/sparkdown` has no build script, no `dist/`, and no entry file under `src/` for one to be built from — `src/` contains only directories. Every consumer in the repo imports deep `src/` paths, so nothing ever resolved it.

## Why removing rather than fixing

Removing matches what the other **source-consumed** workspace packages already do:

| Convention | Packages |
| --- | --- |
| No `main` — consumed via deep `src/` imports | `spark-engine`, `spark-dom`, `jsonrpc`, `spark-editor-protocol`, `sparkle-screen-renderer`, `textmate-grammar-tree`, … |
| `main` + `exports` — genuinely built | `impower-ui`, `opfs-workspace`, `sparkdown-language-server`, `sparkdown-screenplay-pdf`, `sparkle-style-transformer` |

`@impower/sparkdown` belongs in the first group but was wearing the second group's metadata.

**Deliberately not adding an `exports` map.** That would restrict subpath access and break every deep `src/` import across the repo.

## Safety

`main` only affects resolution of the package *root*, so it can't affect the deep imports that are actually used. Confirmed nothing resolves the bare specifier: every reference to `@impower/sparkdown` outside the lockfile is a `file:` dependency declaration — there are no bare-specifier imports or requires anywhere.

Checked after the change:

- `packages/spark-engine` suite passes (it deep-imports the compiler)
- `packages/sparkdown` smoke tests pass
- the editor dev server boots, compiles a script, previews it at `main : 1`, and plays it

## One thing this does *not* do

I found this because Vite's dep optimizer reported `Failed to resolve entry for package "@impower/sparkdown"` while I was investigating test startup cost. **Fixing the pointer does not unlock pre-bundling** — Vite treats symlinked workspace packages as source regardless of their entry metadata, which I verified by trying the deep specifier form too (runs clean, changes nothing).

So this is metadata hygiene, filed so a stale pointer stops misleading the next person. It is not a performance change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
