### PR TITLE
fix(spark-web-player): feed Clock seconds, not milliseconds

### DIFF
--- a/packages/spark-web-player/src/app/Application.ts
+++ b/packages/spark-web-player/src/app/Application.ts
@@ -77,7 +77,11 @@ export class Application implements IApplication {
   protected _clock = new Clock(
     {
       get currentTime() {
-        return performance.now();
+        // Seconds, not milliseconds -- `ClockSource` is documented in
+        // seconds and the frame budget is computed as `1 / maxFPS`, so
+        // handing this `performance.now()` raw inflates every duration
+        // 1000x until an AudioContext takes over as the time source.
+        return performance.now() / 1000;
       },
     },
     (callback: () => void) => window.requestAnimationFrame(callback),


### PR DESCRIPTION
Closes #240.

## The change

```diff
  get currentTime() {
-   return performance.now();
+   return performance.now() / 1000;
  }
```

`ClockSource.currentTime` is documented in seconds and the frame budget is computed as `1 / maxFPS`, also seconds — but `Application` was handing it `performance.now()`, which is milliseconds. Verified at unit level with a deterministic harness: a 16.7ms frame arrives as `deltaTime` 16.7 and `deltaMS` 16700, a 1000× inflation.

## No user-visible change — and I checked rather than assumed

Whenever a *running* `AudioContext` exists, `syncToClock()` swaps in `AudioContext.currentTime` (genuinely seconds) and corrects every subsequent delta. That is the normal path, so the wrong units were being fixed downstream before they mattered.

Measured the typewriter reveal of a ~120-character line in the editor, both builds, by timing the ▼ continue indicator from PLAY to fully faded in:

| Build | Reveal duration |
| --- | --- |
| `performance.now()` (milliseconds) | ~3.1s |
| `performance.now() / 1000` (seconds) | ~3.9s |

Same ballpark; the difference is within run-to-run noise on a busy machine. **I could not produce an observable behavioural difference.**

I originally filed #240 claiming user-visible impact, including that it explained why I struggled to catch a beat mid-reveal while verifying #228. That was wrong — the reveal genuinely takes ~3–4 seconds, so that difficulty was automation latency, not clock speed. I've corrected the issue accordingly.

## Why merge it anyway

- It's a plain contract violation, and that contract is what `Clock`'s test suite (#238) pins.
- Defence in depth for the window before audio starts, and any case where audio never becomes available.
- `maxFPS` has **no effect at all** until the audio sync happens, because `16.7 > 0.0167` is always true — so frame limiting is silently inert on that path.
- One line, no risk.

## Verification

`syncToClock()` recomputes its offset on switch, so the AudioContext path is unaffected. Checked in the dev editor: script compiles with no diagnostics, previews at `main : 1`, plays, and the beat reveals progressively before the continue indicator appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
