### PR TITLE
fix(spark-engine): treat a non-positive maxFPS as unlimited

### DIFF
--- a/packages/spark-engine/src/game/core/classes/Clock.test.ts
+++ b/packages/spark-engine/src/game/core/classes/Clock.test.ts
@@ -11,10 +11,10 @@ import { Clock } from "./Clock";
  * below are written in seconds throughout; a source reporting some other unit
  * silently breaks frame limiting rather than failing loudly.
  *
- * That last point is not hypothetical -- the player currently feeds this
- * `performance.now()`, which is milliseconds. These tests pin the seconds
- * contract deliberately, so they describe what `Clock` is supposed to be
- * handed rather than what one caller happens to hand it. Tracked separately.
+ * That last point is not hypothetical: the player was handing this
+ * `performance.now()` (milliseconds) until that was corrected. These tests pin
+ * the seconds contract deliberately -- they describe what `Clock` is supposed
+ * to be handed, not what any particular caller happens to hand it.
  */
 
 const createHarness = (startSeconds = 0) => {
@@ -163,11 +163,43 @@ describe("Clock", () => {
       expect(h.ticks).toHaveLength(1);
     });
 
-    // `maxFPS = 0` is deliberately NOT covered here. It is documented as
-    // "no limit", but `1 / 0` is Infinity and nothing is ever greater than
-    // Infinity, so it currently freezes the clock completely. Asserting
-    // either way would be wrong: the current behaviour is a bug, and the
-    // documented behaviour doesn't exist yet. Tracked separately.
+    // "No limit" has to mean every frame ticks. Computing the budget as a
+    // bare `1 / maxFPS` would make it Infinity here, and nothing is greater
+    // than Infinity -- the clock would freeze instead of running unthrottled.
+    it("removes the limit at maxFPS 0", () => {
+      const h = createHarness();
+      h.clock.maxFPS = 0;
+      h.clock.start();
+      h.tick(0.0001); // far below any 60fps budget
+      expectOneTick(h.ticks, 0.0001);
+    });
+
+    it("still does not tick when no time has passed at maxFPS 0", () => {
+      const h = createHarness();
+      h.clock.maxFPS = 0;
+      h.clock.start();
+      h.frame(); // a frame with zero elapsed time
+      expect(h.ticks).toEqual([]);
+    });
+
+    it("treats a negative maxFPS as unlimited too", () => {
+      const h = createHarness();
+      h.clock.maxFPS = -1;
+      h.clock.start();
+      h.tick(0.0001);
+      expectOneTick(h.ticks, 0.0001);
+    });
+
+    it("keeps accumulating across many small frames at maxFPS 0", () => {
+      const h = createHarness();
+      h.clock.maxFPS = 0;
+      h.clock.start();
+      for (let i = 0; i < 10; i += 1) {
+        h.tick(0.001);
+      }
+      expect(h.clock.elapsedFrames).toBe(10);
+      expect(h.clock.elapsedTime).toBeCloseTo(0.01, 10);
+    });
   });
 
   describe("speed", () => {

--- a/packages/spark-engine/src/game/core/classes/Clock.ts
+++ b/packages/spark-engine/src/game/core/classes/Clock.ts
@@ -224,7 +224,10 @@ export class Clock {
       return;
     }
 
-    const frameInterval = 1 / this._maxFPS;
+    // A non-positive maxFPS means "no limit". Computing the budget as a bare
+    // reciprocal would make it Infinity, and nothing is greater than Infinity,
+    // so the clock would freeze rather than run unthrottled.
+    const frameInterval = this._maxFPS > 0 ? 1 / this._maxFPS : 0;
     const currentTime = this.getCurrentTime();
 
     const rawDeltaTime = currentTime - this._prevTime;


### PR DESCRIPTION
Closes #239. Builds on the `Clock` suite from #238 (now merged), so this is a clean single commit against `main`.

## The bug

`maxFPS = 0` is documented as removing the frame limit:

> *"When set to `0`, then there is no limit and the ticker will render as many frames as it can."*

It did the opposite. The budget was a bare reciprocal:

```ts
const frameInterval = 1 / this._maxFPS;   // 1 / 0 === Infinity
if (rawDeltaTime > frameInterval) {       // nothing is > Infinity
```

so the body never ran. No callbacks, no elapsed time, forever — and no error. The clock kept requesting frames and doing nothing on each one.

## The fix

```diff
- const frameInterval = 1 / this._maxFPS;
+ const frameInterval = this._maxFPS > 0 ? 1 / this._maxFPS : 0;
```

The condition becomes "tick whenever any time has passed", which is what "no limit" means. Kept as `>` rather than `>=` so a zero-delta frame still doesn't tick — consistent with `start()` not ticking on the frame it schedules.

## Tests

Adds the four cases the `Clock` suite deliberately left out while this was unresolved (it flagged the gap in a comment rather than asserting either the buggy or the documented behaviour):

- unlimited at `maxFPS = 0`
- unlimited at a negative `maxFPS`
- accumulation across many sub-budget frames
- **no** tick on a zero-delta frame

Verified they bite, in both directions:

| Variant | Tests failed |
| --- | --- |
| Old reciprocal (`1 / maxFPS`) | the 3 "unlimited" cases |
| Over-correction (`>=` instead of `>`) | the zero-delta case, plus 3 |
| This fix | 33/33 pass |

That second row is why the zero-delta test exists — without it, relaxing the comparison would look like a valid fix.

Package suite: 100 tests green.

## Impact

Nothing in the engine sets `maxFPS = 0` today, so this isn't fixing a live failure — it's closing a trap behind a documented API, where taking the doc comment at its word got you a silently frozen game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
