### PR TITLE
fix(spark-engine): clear listeners in place and await numeric request ids

### DIFF
--- a/packages/spark-engine/src/game/core/classes/Connection.test.ts
+++ b/packages/spark-engine/src/game/core/classes/Connection.test.ts
@@ -173,6 +173,58 @@ describe("Connection", () => {
       expect(connection.pendingRequestIds).toEqual([]);
     });
 
+    // JSON-RPC allows either form of id, and `RequestMessage.id` is typed
+    // `number | string`, so a numeric id has to be awaited like a string one
+    // rather than silently degrading to fire-and-forget.
+    it("awaits a response for a numeric id", async () => {
+      const { connection } = createConnection();
+      const pending = connection.emit({
+        jsonrpc: "2.0",
+        id: 7,
+        method: "ask",
+        params: {},
+      } as never);
+      expect(await settled(pending)).toEqual({ state: "pending" });
+
+      connection.receive({
+        jsonrpc: "2.0",
+        id: 7,
+        method: "ask",
+        result: "answered",
+      } as Message);
+      expect(await settled(pending)).toEqual({
+        state: "resolved",
+        value: "answered",
+      });
+    });
+
+    it("awaits a response for the zero id", async () => {
+      const { connection } = createConnection();
+      const pending = connection.emit({
+        jsonrpc: "2.0",
+        id: 0,
+        method: "ask",
+        params: {},
+      } as never);
+      expect(await settled(pending)).toEqual({ state: "pending" });
+    });
+
+    // An empty-string id identifies nothing to reply to, so it stays a
+    // notification -- awaiting it would hang forever.
+    it("treats an empty-string id as a notification", async () => {
+      const { connection, sent } = createConnection();
+      const result = await settled(
+        connection.emit({
+          jsonrpc: "2.0",
+          id: "",
+          method: "ask",
+          params: {},
+        } as never) as Promise<unknown>,
+      );
+      expect(result).toEqual({ state: "resolved", value: undefined });
+      expect(sent).toHaveLength(1);
+    });
+
     it("does not leak bookkeeping across many requests", async () => {
       const { connection } = createConnection();
       for (let i = 0; i < 5; i += 1) {
@@ -379,11 +431,58 @@ describe("Connection", () => {
       expect(seen).toEqual([]);
     });
 
-    // `removeAllListeners()` is deliberately NOT covered here. It replaces the
-    // socket's listener map instead of clearing it, which detaches the socket
-    // from the map `Connection` actually broadcasts to -- so previously
-    // registered listeners keep firing and newly added ones never do. Asserting
-    // either way would be wrong: the current behaviour is a bug, and the
-    // intended behaviour doesn't exist yet. Tracked separately.
+    // The listener map is shared by reference with the Connection that
+    // broadcasts through it, so clearing has to happen in place. Reassigning
+    // detaches the socket instead: old listeners keep firing, and anything
+    // registered afterwards lands in an orphaned map that nothing reads.
+    describe("removeAllListeners", () => {
+      it("stops delivering to listeners registered before the call", () => {
+        const seen: string[] = [];
+        const { connection } = createConnection();
+        connection.incoming.addListener("note", () => seen.push("before"));
+        connection.receive(notification("note"));
+        expect(seen).toEqual(["before"]);
+
+        connection.incoming.removeAllListeners();
+        connection.receive(notification("note"));
+        expect(seen).toEqual(["before"]);
+      });
+
+      it("keeps working for listeners registered after the call", () => {
+        const seen: string[] = [];
+        const { connection } = createConnection();
+        connection.incoming.addListener("note", () => seen.push("before"));
+        connection.incoming.removeAllListeners();
+
+        connection.incoming.addListener("note", () => seen.push("after"));
+        connection.receive(notification("note"));
+        expect(seen).toEqual(["after"]);
+      });
+
+      it("clears every method at once, including the wildcard", () => {
+        const seen: string[] = [];
+        const { connection } = createConnection();
+        connection.incoming.addListener("*", () => seen.push("wildcard"));
+        connection.incoming.addListener("one", () => seen.push("one"));
+        connection.incoming.addListener("two", () => seen.push("two"));
+
+        connection.incoming.removeAllListeners();
+        connection.receive(notification("one"));
+        connection.receive(notification("two"));
+        expect(seen).toEqual([]);
+      });
+
+      it("leaves the other direction alone", async () => {
+        const seen: string[] = [];
+        const { connection } = createConnection();
+        connection.incoming.addListener("note", () => seen.push("incoming"));
+        connection.outgoing.addListener("note", () => seen.push("outgoing"));
+
+        connection.incoming.removeAllListeners();
+        connection.receive(notification("note"));
+        await connection.emit(notification("note") as never);
+        expect(seen).toEqual(["outgoing"]);
+      });
+    });
   });
 });

--- a/packages/spark-engine/src/game/core/classes/Connection.ts
+++ b/packages/spark-engine/src/game/core/classes/Connection.ts
@@ -109,7 +109,14 @@ export class Connection {
     msg: RequestMessage<M, P, R> | NotificationMessage<M, P>,
     transfer?: ArrayBuffer[],
   ): Promise<R> {
-    if ("id" in msg && typeof msg.id === "string" && msg.id) {
+    // JSON-RPC allows either a string or a number id, and `RequestMessage.id`
+    // is typed to match -- so both have to be awaited. An empty-string id is
+    // still treated as a notification, since it identifies nothing to reply to.
+    if (
+      "id" in msg &&
+      (typeof msg.id === "number" ||
+        (typeof msg.id === "string" && msg.id !== ""))
+    ) {
       const result = await this.emitRequest(msg as RequestMessage, transfer);
       return result as R;
     } else {

--- a/packages/spark-engine/src/game/core/classes/Socket.ts
+++ b/packages/spark-engine/src/game/core/classes/Socket.ts
@@ -23,6 +23,11 @@ export class Socket {
   }
 
   removeAllListeners(): void {
-    this._listeners = {};
+    // Clear in place. This map is shared by reference with the Connection that
+    // broadcasts through it, so reassigning would detach the socket instead of
+    // emptying it -- leaving old listeners firing and new ones dead.
+    for (const method of Object.keys(this._listeners)) {
+      delete this._listeners[method];
+    }
   }
 }


### PR DESCRIPTION
Closes #244. Closes #245.

## #244 — `Socket.removeAllListeners()` removed nothing

The listener map is shared *by reference* with the `Connection` that broadcasts through it. `addListener` / `removeListener` mutate it, but `removeAllListeners` reassigned:

```diff
  removeAllListeners(): void {
-   this._listeners = {};
+   for (const method of Object.keys(this._listeners)) {
+     delete this._listeners[method];
+   }
  }
```

Reassigning detached the socket from the map being read, failing in two opposite directions:

1. previously registered listeners **kept firing forever** — the removal was a no-op
2. anything registered afterwards landed in an orphaned map and **silently never fired again**

`Game.destroy()` is the caller. The second mode is the nastier one: clear-then-re-register gave you a dead socket with no error.

## #245 — `emit()` treated numeric request ids as notifications

JSON-RPC allows either form and `RequestMessage.id` is typed `number | string`, but only strings were awaited — so a numeric-id request resolved immediately with `undefined` and its response was never matched to a caller.

```diff
- if ("id" in msg && typeof msg.id === "string" && msg.id) {
+ if (
+   "id" in msg &&
+   (typeof msg.id === "number" ||
+     (typeof msg.id === "string" && msg.id !== ""))
+ ) {
```

An empty-string id still counts as a notification — it identifies nothing to reply to, so awaiting it would hang forever.

**I changed my recommendation from the issue.** #245 suggested narrowing `RequestMessage.id` to `string` so the mismatch became a compile error. That's the wrong call here: this repo has no typecheck in CI, so a type-only change wouldn't actually have prevented anything. Fixing it at runtime makes the behaviour correct regardless of what the type says.

Safe to widen, checked rather than assumed: `emit` is typed to accept only requests and notifications, and responses are sent through `send()` rather than `emit()` — so no response can accidentally start awaiting a reply.

## Tests

Replaces the two documented gaps with seven real tests — `removeAllListeners` stopping old listeners, keeping new ones alive, clearing every method including the wildcard, and leaving the other direction alone; plus numeric ids, the zero id, and the empty-string id.

Verified they bite:

| Variant | Tests failed |
| --- | --- |
| Revert the `Socket` fix | 4 |
| Revert the id fix | 2 |
| Over-correct to accept *any* id, including `""` | 1 |

That last row is why the empty-string test exists — without it, the sloppier `if ("id" in msg)` would look like a valid fix.

Package suite: 158 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
