### PR TITLE
test(spark-engine): cover the game flow engine

### DIFF
--- a/packages/spark-engine/src/game/core/classes/GameStep.test.ts
+++ b/packages/spark-engine/src/game/core/classes/GameStep.test.ts
@@ -1,0 +1,298 @@
+import { SparkdownCompiler } from "@impower/sparkdown/src/compiler/classes/SparkdownCompiler";
+import { beforeAll, describe, expect, it } from "vitest";
+import { Game } from "./Game";
+
+/**
+ * `Game.step()` / `continue()` are the flow engine: they drive the story
+ * forward, decide when to stop and wait for the player, checkpoint, and tell
+ * the host what happened. None of that is observable from a return value
+ * alone, so these tests assert on the notifications the game emits -- that is
+ * its actual contract with whatever is hosting it.
+ *
+ * Driving this needs a real compiled program; a fake story can't model the
+ * flush/wait handoff that is the whole point. Like the save/load suite, that
+ * makes this one of the slower files in the package.
+ *
+ * Deliberately out of scope: the `in` / `out` / `over` traversal modes and
+ * breakpoint stops. Those only engage mid-flow with a debugger attached, and
+ * they belong with the debug-adapter work rather than here.
+ */
+
+const THREE_BEATS = ["First beat.", "Second beat.", "Third beat.", ""].join(
+  "\n",
+);
+
+const compile = (source: string) => {
+  const uri = "inmemory:///main.sd";
+  const compiler = new SparkdownCompiler();
+  compiler.configure({
+    files: [
+      {
+        uri,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text: source,
+        version: 1,
+        languageId: "sparkdown",
+      },
+    ],
+  } as never);
+  return compiler.compile({ textDocument: { uri } } as never).program;
+};
+
+let program: ReturnType<typeof compile>;
+
+beforeAll(() => {
+  program = compile(THREE_BEATS);
+});
+
+interface Recorded {
+  method: string;
+  params: Record<string, unknown> | undefined;
+}
+
+const createGame = (
+  overrides: { now?: () => number; executionTimeout?: number } = {},
+) => {
+  const game = new Game({
+    program,
+    now: overrides.now ?? (() => 0),
+    executionTimeout: overrides.executionTimeout,
+    setTimeout: (handler: Function) => {
+      handler();
+      return 0;
+    },
+  } as never);
+
+  const emitted: Recorded[] = [];
+  game.connection.outgoing.addListener("*", (message) => {
+    emitted.push({
+      method: (message as Recorded).method,
+      params: (message as Recorded).params,
+    });
+  });
+
+  return {
+    game,
+    emitted,
+    /** Just the game/* notifications, in order -- UI churn isn't the contract. */
+    gameMethods: () =>
+      emitted.map((e) => e.method).filter((m) => m.startsWith("game/")),
+    clear: () => {
+      emitted.length = 0;
+    },
+  };
+};
+
+describe("Game flow", () => {
+  it("compiles the fixture without diagnostics", () => {
+    expect(program.diagnostics ?? {}).toEqual({});
+    expect(program.compiled).toBeTruthy();
+  });
+
+  describe("starting", () => {
+    it("reports that it started, executed, and is now waiting", () => {
+      const { game, gameMethods } = createGame();
+      game.start();
+      expect(gameMethods()).toEqual([
+        "game/started",
+        "game/awaitingInteraction",
+        "game/executed",
+      ]);
+    });
+
+    it("enters the running state", () => {
+      const { game } = createGame();
+      game.start();
+      expect(game.state).toBe("running");
+    });
+
+    it("stops on the first beat rather than running the whole script", () => {
+      const { game } = createGame();
+      game.start();
+      expect(game.story.currentText).toBe("First beat.\n");
+    });
+
+    it("checkpoints the opening beat", () => {
+      const { game } = createGame();
+      game.start();
+      expect(game.checkpoints).toHaveLength(1);
+    });
+
+    it("reports which paths it executed", () => {
+      const { game, emitted } = createGame();
+      game.start();
+      const executed = emitted.find((e) => e.method === "game/executed");
+      expect(executed?.params?.["state"]).toBe("running");
+      expect(
+        (executed?.params?.["executedPaths"] as string[]).length,
+      ).toBeGreaterThan(0);
+    });
+  });
+
+  describe("advancing", () => {
+    it("moves to the next beat", () => {
+      const { game } = createGame();
+      game.start();
+      game.clickedToContinue();
+      expect(game.story.currentText).toBe("Second beat.\n");
+    });
+
+    it("waits again on the next beat", () => {
+      const { game, gameMethods, clear } = createGame();
+      game.start();
+      clear();
+      game.clickedToContinue();
+      expect(gameMethods()).toEqual([
+        "game/awaitingInteraction",
+        "game/executed",
+        "game/clickedToContinue",
+      ]);
+    });
+
+    it("checkpoints every beat", () => {
+      const { game } = createGame();
+      game.start();
+      expect(game.checkpoints).toHaveLength(1);
+      game.clickedToContinue();
+      expect(game.checkpoints).toHaveLength(2);
+      game.clickedToContinue();
+      expect(game.checkpoints).toHaveLength(3);
+    });
+
+    it("walks the whole script one beat at a time", () => {
+      const { game } = createGame();
+      game.start();
+      const seen = [game.story.currentText];
+      game.clickedToContinue();
+      seen.push(game.story.currentText);
+      game.clickedToContinue();
+      seen.push(game.story.currentText);
+      expect(seen).toEqual([
+        "First beat.\n",
+        "Second beat.\n",
+        "Third beat.\n",
+      ]);
+    });
+
+    it("stops waiting once the script runs out", () => {
+      const { game, gameMethods, clear } = createGame();
+      game.start();
+      game.clickedToContinue();
+      game.clickedToContinue();
+      clear();
+      game.clickedToContinue(); // past the last beat
+      expect(gameMethods()).not.toContain("game/awaitingInteraction");
+    });
+
+    // `game/finished` is deliberately NOT covered here. The branch that emits
+    // it is unreachable -- it needs `canContinue && !canContinue` -- so the
+    // notification never fires when a story runs out. Asserting the current
+    // silence would enshrine that; asserting the intended notification would
+    // fail. Tracked separately.
+  });
+
+  // `step()` is one iteration of the flow loop, not one beat: it reports
+  // whether the loop is done, and `continue()` drives it until it is.
+  describe("stepping", () => {
+    it("reports not-done while there is still work to do", () => {
+      const { game } = createGame();
+      game.start();
+      expect(game.step()).toBe(false);
+    });
+
+    it("reports done once it reaches a stopping point", () => {
+      const { game } = createGame();
+      game.start();
+      game.step();
+      expect(game.step()).toBe(true);
+    });
+
+    it("advances the story when driven to its next stop", () => {
+      const { game } = createGame();
+      game.start();
+      let guard = 0;
+      while (!game.step() && guard < 50) {
+        guard += 1;
+      }
+      expect(game.story.currentText).toBe("Second beat.\n");
+    });
+
+    // Part-way through, the story is a work in progress and reading its text
+    // throws. That's transient rather than corruption -- driving the loop to
+    // its next stop resolves it. Worth pinning: a regression that left the
+    // story permanently unreadable would look identical at the call site.
+    it("recovers from a partially stepped story", () => {
+      const { game } = createGame();
+      game.start();
+      game.step();
+      expect(() => game.story.currentText).toThrow();
+
+      game.continue();
+      expect(game.story.currentText).toBe("Second beat.\n");
+    });
+
+    it("recovers when the player advances after a partial step", () => {
+      const { game } = createGame();
+      game.start();
+      game.step();
+      game.clickedToContinue();
+      expect(game.story.currentText).toBe("Second beat.\n");
+    });
+  });
+
+  describe("continue", () => {
+    // Each frame reports only what it just executed, so the host can highlight
+    // the current line rather than every line ever run.
+    it("reports only the paths executed in the latest frame", () => {
+      const { game } = createGame();
+      game.start();
+      const first = Array.from(game.runtimeState.pathsExecutedThisFrame);
+
+      game.clickedToContinue();
+      const second = Array.from(game.runtimeState.pathsExecutedThisFrame);
+
+      expect(first.length).toBeGreaterThan(0);
+      expect(second.length).toBeGreaterThan(0);
+      expect(second).not.toEqual(first);
+      // Not accumulated across frames
+      expect(second.some((p) => first.includes(p))).toBe(false);
+    });
+
+    it("keeps the execution info when asked to preserve it", () => {
+      const { game } = createGame();
+      game.start();
+      const before = Array.from(game.runtimeState.pathsExecutedThisFrame);
+      game.continue(true);
+      const after = Array.from(game.runtimeState.pathsExecutedThisFrame);
+      expect(after).toEqual(expect.arrayContaining(before));
+    });
+  });
+
+  describe("execution timeout", () => {
+    // The guard exists so a runaway script reports an error instead of
+    // hanging the host. Driving it through the injected clock keeps the test
+    // deterministic -- no actual infinite loop required.
+    it("reports a runtime error instead of looping forever", () => {
+      let calls = 0;
+      const { game, emitted } = createGame({
+        executionTimeout: 10,
+        now: () => (calls++ < 2 ? 0 : 100_000),
+      });
+      game.start();
+
+      const error = emitted.find((e) => e.method === "game/runtimeError");
+      expect(error?.params?.["message"]).toBe(
+        "Execution timed out: Possible infinite loop",
+      );
+    });
+
+    it("does not fire the guard on a normal script", () => {
+      const { game, emitted } = createGame();
+      game.start();
+      game.clickedToContinue();
+      expect(emitted.some((e) => e.method === "game/runtimeError")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Refs #230 (item 1 — the last one on the coverage list).

## Why notifications rather than return values

`Game.step()` / `continue()` drive the story, decide when to stop and wait for the player, checkpoint, and tell the host what happened. Almost none of that shows up in a return value — so these tests assert on the notifications the game emits, which is its actual contract with whatever is hosting it. That also means they survive refactors of the engine's insides.

Driving this needs a real compiled program; a fake story can't model the flush/wait handoff that is the entire point. Like the save/load suite, that makes this one of the slower files in the package.

## Coverage

20 tests: the start sequence (`started` → `awaitingInteraction` → `executed`), entering the running state, stopping on the first beat rather than running the whole script, checkpointing per beat, advancing beat by beat, the executed-paths payload, stepping semantics, `continue()`'s per-frame runtime-state reset and its preserve flag, and the execution-timeout guard.

The timeout test drives the injected clock past the deadline rather than writing an actual infinite loop — deterministic, and no risk of hanging the suite if the guard ever regresses.

## Two things I had wrong

Both were assumptions I wrote as assertions, then corrected against real behaviour:

- **`step()` is one iteration of the flow loop, not one beat.** It returns `false` meaning "call again" — exactly how `continue()` drives it in a `do/while`.
- **Part-way through a step, the story is a work in progress and reading its text throws.** That's transient rather than corruption; `continue()` or a player advance resolves it.

Both are now pinned, because a regression that left the story *permanently* unreadable would look identical at the call site.

## Verification

| Mutation | Tests failed |
| --- | --- |
| Suppress `notifyExecuted` | 3 |
| Suppress `notifyAwaitingInteraction` | 2 |
| Remove the flush-branch `checkpoint()` | 2 |
| Suppress `notifyStarted` | 1 |
| Remove the execution-timeout guard | 1 |
| Remove `continue()`'s runtime-state reset | 1 |

Two of these first appeared to survive. They hadn't — those call patterns occur at several sites and I'd mutated the wrong one. Worth flagging for anyone repeating this technique: **check the occurrence count before believing a survivor**, otherwise a mutation that changed nothing reads as a gap in the tests.

Package suite: 178 tests green.

## One divergence found, deliberately not asserted

**`game/finished` is never emitted.** The branch that sends it needs `canContinue && !canContinue` to be reachable, so it's dead code. `GamePlayerController` listens for it to call `stopGame("finished")` — which means **reaching the end of a story never stops the player**; the transport stays on STOP instead of returning to PLAY. Filed as its own issue with a suggested fix.

Not asserted here for the usual reason: pinning the current silence would enshrine the bug, and asserting the intended notification would fail. Flagged in a comment where the coverage would otherwise sit.

## Out of scope

Traversal modes (`in` / `out` / `over`) and breakpoint stops. They only engage mid-flow with a debugger attached, and belong with the debug-adapter work rather than duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
