### PR TITLE
fix(spark-editor): stop the faded-out New Script FAB stealing clicks

### DIFF
--- a/impower-dev/src/modules/spark-editor/components/logic-list/LogicList.tsx
+++ b/impower-dev/src/modules/spark-editor/components/logic-list/LogicList.tsx
@@ -141,13 +141,22 @@ export default function LogicList(_props: LogicListProps) {
               previous panel's content mid-slide — it waits until the
               new panel is fully in place, then fades in. The fade-OUT
               has no delay so the FAB clears immediately as soon as the
-              user navigates away. */}
-          <div class="pointer-events-none absolute inset-x-0 bottom-0 h-24 [&_button]:pointer-events-auto">
+              user navigates away.
+
+              The faded-out branch has to disable pointer events ON the
+              button, not just on its wrapper. `pointer-events` is not a
+              clipping mechanism -- hit-testing reads the element's own
+              computed value -- and `Button` ships `pointer-events-auto` in
+              its own base classes, so an inherited `none` from the wrapper
+              is overridden and the invisible FAB stays fully clickable over
+              the editor. `[&_button]:pointer-events-none` wins on
+              specificity (`.wrapper button` beats `.pointer-events-auto`). */}
+          <div class="pointer-events-none absolute inset-x-0 bottom-0 h-24">
             <div
               class={`transition-opacity duration-200 ${
                 panel === "scripts"
-                  ? "opacity-100 delay-150"
-                  : "pointer-events-none opacity-0"
+                  ? "opacity-100 delay-150 [&_button]:pointer-events-auto"
+                  : "opacity-0 [&_button]:pointer-events-none"
               }`}
             >
               <FileAddButton


### PR DESCRIPTION
Closes #248.

## The bug

On **Logic > Main** the New Script FAB is `opacity-0` but stayed fully hit-testable, so clicks along the bottom strip of the panel were swallowed by an invisible button instead of reaching the editor. Each one silently queued a phantom draft that surfaced later as an unexplained blank row in the Scripts list.

`pointer-events` is not a clipping mechanism — hit-testing reads the element's **own** computed value, not an ancestor's — so the wrapper's `pointer-events-none` never applied to the button.

## The root cause in the issue was only half of it

#248 blamed the overlay's `[&_button]:pointer-events-auto`. Removing that alone fixes nothing, which I only found by checking live rather than trusting the write-up: **`Button` ships `pointer-events-auto` in its own base classes**, so the button re-enables itself regardless of what the overlay does.

```
after removing the overlay rule:
  buttonPointerEvents: "auto"   <-- still clickable
  wrapperOpacity:      "0"
  hitIsTheButton:      true
```

## The fix

Disable pointer events on the button directly in the faded-out branch:

```diff
- <div class="pointer-events-none ... [&_button]:pointer-events-auto">
+ <div class="pointer-events-none ...">
    <div class={`transition-opacity duration-200 ${
      panel === "scripts"
-       ? "opacity-100 delay-150"
-       : "pointer-events-none opacity-0"
+       ? "opacity-100 delay-150 [&_button]:pointer-events-auto"
+       : "opacity-0 [&_button]:pointer-events-none"
    }`}>
```

`[&_button]:pointer-events-none` resolves to `.wrapper button`, which beats `.pointer-events-auto` on specificity — so it wins wherever it lands in the stylesheet, rather than depending on rule order.

## Verified live

| Tab | Result |
| --- | --- |
| **Main** | button computes `pointer-events: none`; `elementFromPoint` over its rect returns `.cm-line` instead of the button |
| **Scripts** | FAB still visible, still creates a draft row on click |

Both directions matter — the first is the bug, the second is the feature I could easily have broken while fixing it.

## Also checked

The sibling Assets FAB uses the same overlay pattern, so I checked whether it had the same defect. It doesn't: the shell stays at full opacity and cross-fades its contents rather than fading out, so there's no invisible-but-clickable state. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
