### PR TITLE
fix(lsp-client): keep the sticky header row horizontal

### DIFF
--- a/packages/codemirror-vscode-lsp-client/src/symbols.ts
+++ b/packages/codemirror-vscode-lsp-client/src/symbols.ts
@@ -32,6 +32,10 @@ export const stickyScrollTheme = EditorView.theme({
   },
   ".cm-sticky-header-row": {
     display: "flex",
+    // Explicit: the host page's global reset makes `column` the effective
+    // default, which stacks the cloned gutter above the header text instead
+    // of beside it -- a double-height row with the text flush to the edge.
+    flexDirection: "row",
     backgroundColor: "inherit",
     width: "100%",
   },


### PR DESCRIPTION
Closes #247.

## The fix

```diff
  ".cm-sticky-header-row": {
    display: "flex",
+   flexDirection: "row",
    backgroundColor: "inherit",
    width: "100%",
  },
```

The row set `display: flex` but no direction, and the host page's global reset makes `column` the effective default — so the cloned gutter stacked *above* the header text instead of sitting beside it.

Worth noting: the `.cm-sticky-headers` rule immediately above it already declares `flexDirection: "column"` explicitly. The reset was known about here; the row just got missed.

## Verified live

Scrolled past a `scene` block with 45 action lines:

| Measurement | Before (per #247) | After |
| --- | --- | --- |
| `.cm-sticky-header-row` height | 49 — two stacked 24px rows | **24** |
| gutter clone / text `top` | 104 / 128 — stacked | **104 / 104** — side by side |
| sticky text `left` | 2 — flush to the edge | **41** |
| normal `.cm-line` `left` | — | **41** — exact match |

The stuck header now renders `1  scene Scene1` on a single row, with `scene` at the same x as `end` further down the document.

## One thing I checked and deliberately left alone

I scanned this package and `sparkdown-document-views` for the same pattern and found ~11 other `display: "flex"` blocks with no explicit direction (`lens.ts`, `menu.ts`, `references.ts`, `rename.ts`, `statusPanel.ts`, `EDITOR_THEME.ts`).

I didn't touch them. Flex direction only changes rendering once a container has **two or more children** — which is exactly why this row broke (gutter clone + text) and why the others apparently haven't. Blind-fixing them would be churn against layouts I haven't looked at, and could quietly change something that currently renders correctly.

Worth an audit if any of them ever grow a second child. Happy to file that as a follow-up if you'd like it tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
