### PR TITLE
fix(lsp-client): clamp asset preview images to a thumbnail

### DIFF
--- a/packages/codemirror-vscode-lsp-client/src/completion.ts
+++ b/packages/codemirror-vscode-lsp-client/src/completion.ts
@@ -36,6 +36,16 @@ const completionTheme = EditorView.baseTheme({
   "& .cm-tooltip.cm-completionInfo pre": {
     margin: "0",
   },
+  // Asset previews carry no intrinsic bound. The panel caps its width but not
+  // its height, so a tall image runs off the bottom of the screen. Clamp to a
+  // thumbnail; `height: auto` also stops small images being stretched up.
+  "& .cm-tooltip.cm-completionInfo img": {
+    maxWidth: "100%",
+    maxHeight: "180px",
+    width: "auto",
+    height: "auto",
+    objectFit: "contain",
+  },
   "& .cm-tooltip.cm-completionInfo.cm-completionInfo-right": {
     marginTop: "-1px",
   },

--- a/packages/codemirror-vscode-lsp-client/src/hover.ts
+++ b/packages/codemirror-vscode-lsp-client/src/hover.ts
@@ -10,7 +10,18 @@ import { LSPPlugin } from "./plugin";
 import { convertFromPosition } from "./pos";
 import { escHTML } from "./text";
 
-const hoverTheme = EditorView.baseTheme({});
+const hoverTheme = EditorView.baseTheme({
+  // Asset previews carry no intrinsic bound, so a large source image renders
+  // at its natural size and engulfs the page. Clamp to a thumbnail.
+  // `height: auto` also stops small images being stretched up to the cap.
+  "& .cm-lsp-hover-tooltip img": {
+    maxWidth: "100%",
+    maxHeight: "180px",
+    width: "auto",
+    height: "auto",
+    objectFit: "contain",
+  },
+});
 
 export interface ServerHoversConfig {
   hoverTime?: number;


### PR DESCRIPTION
Closes #213.

## The bug

Asset preview images had no maximum size, so a large source image rendered at its natural dimensions and engulfed the page — a 4000×3000 asset produced a **4002px-wide** hover tooltip inside a 1920px viewport, and a completion info panel **3000px tall** running off the bottom of the screen.

The markup carries `height="180"`, but that's a presentational attribute that loses to any CSS, and the completion panel caps width without capping height.

## The fix

Clamp the image itself in both surfaces:

```ts
maxWidth: "100%",
maxHeight: "180px",
width: "auto",
height: "auto",
objectFit: "contain",
```

`height: auto` rather than a fixed height, so a *small* image renders at its natural size instead of being stretched up to the cap — the previous `height="180"` would upscale a 40px icon. `object-fit: contain` preserves aspect ratio.

The rules live with their own features — the hover clamp in `hover.ts` (whose theme was an empty placeholder, so this is its first rule) and the completion clamp in `completion.ts` — rather than one shared `.cm-tooltip img` rule that would depend on whichever extension happened to be loaded.

## Verified live

Created a 4000×3000 SVG asset and exercised both paths:

| Surface | Natural | Rendered | Container |
| --- | --- | --- | --- |
| Hover tooltip | 4000×3000 | **240×180** | 242px wide in a 1014px viewport (was 4002px) |
| Completion info | 4000×3000 | **240×180** | 260×188, fits fully on screen (was 3000px tall) |

Aspect ratio preserved in both (4:3 → 240:180), and both containers now report fitting inside the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
