### PR TITLE
fix(sparkdown): don't dedent on sparkdown's doubled display brackets

### DIFF
--- a/definitions/yaml/sparkdown.language-config.yaml
+++ b/definitions/yaml/sparkdown.language-config.yaml
@@ -196,7 +196,17 @@ indentationRules: # Increase the next line's indent when the current line:
   # a block-closing token: `end`, `until`, `else`, `elseif`,
   # `}`, `)`, or `]`. This gives the satisfying "type `end`
   # and the line snaps to the right column" behavior.
-  decreaseIndentPattern: '^\s*((\b(elseif|else|end|until)\b)|\}|\)|\])'
+  #
+  # The `(?!\))` / `(?!\])` guards exclude DOUBLED brackets.
+  # Sparkdown's display directives are written with doubled
+  # brackets — `[[portrait]]`, `((sound))` — so a line
+  # starting with `]]` or `))` is the tail of an inline
+  # directive, not a Luau block closer. Without the guards,
+  # splitting `[[bunny~jacket]]` before its closer dedents
+  # the continuation line by one unit. Single `)` / `]` still
+  # dedent, so multi-line Luau call args and index
+  # expressions behave as before.
+  decreaseIndentPattern: '^\s*((\b(elseif|else|end|until)\b)|\}|\)(?!\))|\](?!\]))'
 
   # Apply ONE extra level of indent to the line following a
   # line that ends with an assignment operator. Covers:

--- a/packages/codemirror-vscode-language/src/extensions/vscodeIndentationRules.ts
+++ b/packages/codemirror-vscode-language/src/extensions/vscodeIndentationRules.ts
@@ -52,8 +52,6 @@ const vscodeIndentService = indentService.of((context, pos) => {
     newIndentSize -= context.unit;
   }
 
-  console.log("vscodeIndentService", isIncrease, isDecrease, newIndentSize);
-
   if (isIncrease || isDecrease) {
     // Ensure we never return a negative indent size
     return Math.max(0, newIndentSize);

--- a/packages/sparkdown/language/sparkdown.language-config.json
+++ b/packages/sparkdown/language/sparkdown.language-config.json
@@ -289,7 +289,7 @@
   ],
   "indentationRules": {
     "increaseIndentPattern": "^((?!--).)*((\\b(else|then|do|repeat|define|scene|branch)\\b\\s*(--.*)?$)|(\\bfunction\\b(?:(?!\\bend\\b).)*$)|([\\{\\(\\[]\\s*(--.*)?$))",
-    "decreaseIndentPattern": "^\\s*((\\b(elseif|else|end|until)\\b)|\\}|\\)|\\])",
+    "decreaseIndentPattern": "^\\s*((\\b(elseif|else|end|until)\\b)|\\}|\\)(?!\\))|\\](?!\\]))",
     "indentNextLinePattern": "^((?!--).)*(?<![=<>!~])=\\s*(--.*)?$",
     "unIndentedLinePattern": "^#\\!"
   },

--- a/vscode-sparkdown/language/sparkdown.language-config.json
+++ b/vscode-sparkdown/language/sparkdown.language-config.json
@@ -289,7 +289,7 @@
   ],
   "indentationRules": {
     "increaseIndentPattern": "^((?!--).)*((\\b(else|then|do|repeat|define|scene|branch)\\b\\s*(--.*)?$)|(\\bfunction\\b(?:(?!\\bend\\b).)*$)|([\\{\\(\\[]\\s*(--.*)?$))",
-    "decreaseIndentPattern": "^\\s*((\\b(elseif|else|end|until)\\b)|\\}|\\)|\\])",
+    "decreaseIndentPattern": "^\\s*((\\b(elseif|else|end|until)\\b)|\\}|\\)(?!\\))|\\](?!\\]))",
     "indentNextLinePattern": "^((?!--).)*(?<![=<>!~])=\\s*(--.*)?$",
     "unIndentedLinePattern": "^#\\!"
   },


### PR DESCRIPTION
Closes #253.

## The bug

Pressing Enter inside a `[[...]]` directive dedented the continuation line by one unit. The split-off `]]` fragment matched `decreaseIndentPattern`'s `^\s*\]` arm — a block-closer rule inherited from Luau.

## The fix

Sparkdown writes display directives with **doubled** brackets — `[[portrait]]`, `((sound))` — so a line starting with `]]` or `))` is the tail of an inline directive, not a block closer:

```diff
- ^\s*((\b(elseif|else|end|until)\b)|\}|\)|\])
+ ^\s*((\b(elseif|else|end|until)\b)|\}|\)(?!\))|\](?!\]))
```

Single `)` and `]` still dedent, so multi-line Luau call args and index expressions behave exactly as before.

Edited the **YAML source** and regenerated — `packages/sparkdown/language/` and `vscode-sparkdown/language/` are build artifacts of `definitions/yaml/sparkdown.language-config.yaml`, so both consumers stay in sync and the VS Code extension gets the fix too.

Also removes the stray `console.log("vscodeIndentService", ...)` that was shipping in the bundle, as #253 noted.

## Verified

**Live A/B**, same fixture both ways:

| Pattern | `]]` continuation lands at |
| --- | --- |
| old | indent **0** — dedented |
| new | indent **2** — preserved |

**13 regex cases** checked directly: `]]`, `))`, `  ]]` no longer dedent; `]`, `)`, `}`, `end` still do; `[`, `(`, `{`, `t = {`, `foo(` still increase.

## One thing I deliberately did NOT change

While verifying, I found the mirror symptom: a line ending in `[[` indents the next line by an extra unit. I initially "fixed" it with matching lookbehinds on `increaseIndentPattern` — and then reverted it, because the fix didn't work and the reason mattered.

With the config **demonstrably fresh** (the decrease fix was active in the very same page load), `[[` still increased. A plain line preserved its indent, so an increase really was firing — just not from this pattern. That extra indent comes from somewhere else, most likely CodeMirror's language-level indentation rather than the VS Code indentation rules.

So I reverted rather than ship a speculative narrowing of a rule that also governs genuine Luau brackets. Worth filing separately — happy to do that and dig into the real source if you want it chased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
