### PR TITLE
fix(sparkdown): anchor define-property diagnostics to their source

### DIFF
--- a/packages/sparkdown/src/compiler/lower/lowerers/lowerLuauDefine.ts
+++ b/packages/sparkdown/src/compiler/lower/lowerers/lowerLuauDefine.ts
@@ -27,6 +27,7 @@ import {
 } from "../expression/lowerExpression";
 import { lowerStatements } from "../lower";
 import { findChildByName } from "../utils/alternatorArms";
+import { stampDebugMetadata } from "../utils/debugMetadata";
 import { findOwnDeclarationName } from "../utils/findOwnDeclarationName";
 import { getFunctionBodyContent } from "../utils/getFunctionBodyContent";
 import { lowerArguments } from "../utils/lowerArguments";
@@ -569,6 +570,17 @@ function readPropertyDefinition(
   // expressions) instead of re-deriving the RHS by string-scanning for `=`.
   const valueNode = findAssignmentValueNode(opNode);
   const rawValue = valueNode ? ctx.read(valueNode.from, opNode!.to) : "";
+
+  // Anchor the property's value expression to its source range. Diagnostics
+  // raised from inside it (notably `Cannot find variable named \`x\`` from
+  // VariableReference) report themselves as the source, and ParsedObject's
+  // debugMetadata getter walks the parent chain -- so stamping the top-level
+  // expression is enough to give every nested node a location. Without this
+  // the compiler's diagnostic callback falls back to the ENTRY document at
+  // 0:0, piling every such warning invisibly at the top of the wrong file.
+  if (valueNode && opNode) {
+    stampDebugMetadata([expr], valueNode.from, opNode.to, ctx);
+  }
 
   // Modifiers live in the property's begin captures, OUTSIDE the
   // variable assignment.

--- a/packages/sparkdown/src/tests/compiler/DefineDiagnosticLocations.test.ts
+++ b/packages/sparkdown/src/tests/compiler/DefineDiagnosticLocations.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+
+// Diagnostics raised from inside a `define` property's value expression must
+// point at that expression. They come from the ink compiler (VariableReference
+// reports itself as the diagnostic source), so they only carry a location if
+// the lowerer stamped `debugMetadata` on the expression it synthesized.
+//
+// Without that stamp the compiler's diagnostic callback falls back to the
+// ENTRY document at 0:0 -- which silently piles every such warning at the top
+// of the wrong file, un-navigable from the lint panel. So these tests assert
+// the file AND the range, not just that a diagnostic exists.
+
+const message = (d: any): string =>
+  typeof d?.message === "string" ? d.message : (d?.message?.value ?? "");
+
+const script = (uri: string, text: string) => ({
+  uri,
+  type: "script",
+  name: uri.split("/").pop()!.replace(/\.sd$/, ""),
+  ext: "sd",
+  text,
+  version: 1,
+  languageId: "sparkdown",
+});
+
+const compile = (files: ReturnType<typeof script>[], entry: string) => {
+  const compiler = new SparkdownCompiler();
+  compiler.configure({ files } as never);
+  return compiler.compile({ textDocument: { uri: entry } } as never).program;
+};
+
+/** Every "Cannot find variable named" diagnostic, flattened with its file. */
+const undeclaredNameDiagnostics = (program: any) =>
+  Object.entries(program.diagnostics ?? {}).flatMap(([uri, list]) =>
+    (list as any[])
+      .filter((d) => /Cannot find variable named/.test(message(d)))
+      .map((d) => ({ uri, range: d.range })),
+  );
+
+const MAIN = "file://proj/main.sd";
+const PORTRAITS = "file://proj/portraits.sd";
+
+describe("define property diagnostic locations", () => {
+  it("anchors an undeclared name to the property value, not the file top", () => {
+    const program = compile(
+      [
+        script(
+          MAIN,
+          [
+            "First beat.", // 0
+            "", // 1
+            "define Portrait with", // 2
+            "  image = does_not_exist_anywhere", // 3
+            "end", // 4
+            "",
+          ].join("\n"),
+        ),
+      ],
+      MAIN,
+    );
+
+    const found = undeclaredNameDiagnostics(program);
+    expect(found).toHaveLength(1);
+    expect(found[0]!.uri).toBe(MAIN);
+    // Line 3 is `  image = does_not_exist_anywhere`; the name starts at col 10.
+    expect(found[0]!.range.start.line).toBe(3);
+    expect(found[0]!.range.start.character).toBeGreaterThan(0);
+    // A real range, not the zero-width 0:0 fallback
+    expect(found[0]!.range.end.character).toBeGreaterThan(
+      found[0]!.range.start.character,
+    );
+  });
+
+  // The fallback attributed diagnostics to the ENTRY document, so a define
+  // living in an included file reported against main.sd -- wrong file as well
+  // as wrong position.
+  it("attributes the diagnostic to the included file that declares it", () => {
+    const program = compile(
+      [
+        script(MAIN, ["include portraits.sd", "", "First beat.", ""].join("\n")),
+        script(
+          PORTRAITS,
+          [
+            "-- padding", // 0
+            "-- padding", // 1
+            "define Portrait with", // 2
+            "  image = does_not_exist_anywhere", // 3
+            "end", // 4
+            "",
+          ].join("\n"),
+        ),
+      ],
+      MAIN,
+    );
+
+    const found = undeclaredNameDiagnostics(program);
+    expect(found).toHaveLength(1);
+    expect(found[0]!.uri).toBe(PORTRAITS);
+    expect(found[0]!.range.start.line).toBe(3);
+  });
+
+  it("does not warn when the referenced name exists", () => {
+    const program = compile(
+      [
+        script(
+          MAIN,
+          [
+            "define Real with", // 0
+            "  value = 1", // 1
+            "end", // 2
+            "", // 3
+            "define Portrait with", // 4
+            "  image = Real", // 5
+            "end", // 6
+            "",
+          ].join("\n"),
+        ),
+      ],
+      MAIN,
+    );
+
+    expect(undeclaredNameDiagnostics(program)).toEqual([]);
+  });
+});

--- a/packages/sparkdown/src/tests/compiler/DefineDiagnosticLocations.test.ts
+++ b/packages/sparkdown/src/tests/compiler/DefineDiagnosticLocations.test.ts
@@ -78,7 +78,10 @@ describe("define property diagnostic locations", () => {
   it("attributes the diagnostic to the included file that declares it", () => {
     const program = compile(
       [
-        script(MAIN, ["include portraits.sd", "", "First beat.", ""].join("\n")),
+        script(
+          MAIN,
+          ["include portraits.sd", "", "First beat.", ""].join("\n"),
+        ),
         script(
           PORTRAITS,
           [


### PR DESCRIPTION
Closes #251.

## The bug

"Cannot find variable named `x`" warnings raised from inside a `define` property's value landed at offset 0 of the **entry** document instead of over the reference. In a real project that stacks dozens of un-navigable warnings invisibly at the top of the wrong file — clicking one in the lint panel goes to Ln 1, Col 1 because the range genuinely *is* 0:0.

## Why

The diagnostic comes from the ink compiler: `VariableReference` reports **itself** as the source, and `ParsedObject`'s `debugMetadata` getter walks the parent chain. But `lowerLuauDefine` never stamped metadata on the expressions it synthesizes, so the source resolved to `null` and `SparkdownCompiler`'s `onDiagnostic` fallback attributed it to the entry doc at 0:0.

## The fix

Stamp the property's value expression with its source range, using the existing `stampDebugMetadata` helper. Because the getter walks parents, stamping the top-level expression is enough — every nested node inherits, which is exactly what that helper documents.

## Verified by A/B

Same fixtures, stamp on and off:

| | single file | included file |
| --- | --- | --- |
| **without stamp** | `main.sd` 0:0 | `main.sd` 0:0 ← wrong file |
| **with stamp** | `main.sd` 3:9–3:32 | `portraits.sd` 3:9–3:32 |

The included-file case is the one that matters most, and the one #251 called out: a `define` in an included file previously reported against `main.sd`, so both the **file** and the **position** were wrong.

## Tests

Three regression tests asserting **file and range**, not just that a diagnostic exists — asserting presence alone would have passed against the broken behaviour, which is the whole trap here.

Confirmed they bite: removing the stamp fails 2 of 3. The third ("does not warn when the referenced name exists") passes either way by design — it asserts *absence*, and it's there to catch an over-eager fix that starts warning on valid references.

## Regression risk checked

`debugMetadata` feeds `pathLocations` and the compile snapshots, so that was the thing to break. Both full suites pass:

- compiler: **434 tests**
- runtime: **299 tests**

## Note for the reviewer

`lowerLuauDefine.ts` was already unformatted at `main`, so I deliberately did not run Prettier across it — that would have buried a 3-line change in unrelated churn. The new test file is formatted.

The issue also suggests auditing sibling lowerers for the same gap, and optionally making the `onDiagnostic` fallback self-describing (e.g. tagging "location unknown"). I've left both out of this PR to keep it to the reported defect — happy to follow up on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
