### PR TITLE
fix(script-editor): stop CodeMirror hijacking OS file drops

### DIFF
--- a/packages/sparkdown-document-views/src/modules/script-editor/constants/EDITOR_EXTENSIONS.ts
+++ b/packages/sparkdown-document-views/src/modules/script-editor/constants/EDITOR_EXTENSIONS.ts
@@ -26,8 +26,35 @@ import { indentationGuides } from "../../../cm-indentation-guides/indentationGui
 import { indentedLineWrapping } from "../../../cm-indented-line-wrapping/indentedLineWrapping";
 import { pinpoints } from "../../../cm-pinpoints/pinpoints";
 
+// Let OS file drops reach the app instead of being pasted as text.
+//
+// CodeMirror's built-in `drop` handler reads any dropped file with a
+// FileReader and inserts the result into the document -- so dragging an
+// image or a script onto the editor dumps its raw contents into the
+// screenplay. The app already imports dropped files properly (routing them
+// to `assets/` or `scripts/`) from a window-level handler.
+//
+// Returning `true` from a `domEventHandlers` handler makes CodeMirror call
+// `preventDefault()` and stop running handlers for that event, which skips
+// the built-in text insertion. It does NOT stop propagation, so the event
+// still bubbles to the window-level importer.
+//
+// The discriminator is `dataTransfer.types` containing "Files": an OS file
+// drag advertises it, whereas dragging a text selection within the editor
+// advertises `text/plain`. So internal drag-and-drop of text is untouched.
+const carriesFiles = (event: DragEvent) =>
+  Array.from(event.dataTransfer?.types ?? []).includes("Files");
+
+const deferFileDropsToApp = EditorView.domEventHandlers({
+  drop: (event) => carriesFiles(event),
+  // Also claim `dragover` so the drop caret doesn't track a file drag and
+  // imply the file is about to be inserted at that position.
+  dragover: (event) => carriesFiles(event),
+});
+
 const EDITOR_EXTENSIONS = [
   history(),
+  deferFileDropsToApp,
   // TODO: breakpoints({}),
   pinpoints(),
   lineNumbers(),


### PR DESCRIPTION
Closes #215.

## Nothing needed building

The issue suggested routing dropped files "through the existing asset-import flow" — but that flow already reaches the editor surface fine. `FileDropzone` handles `drop` at the **window** level and routes files to `assets/` or `scripts/`.

CodeMirror was simply claiming the drop first. Its built-in handler reads any dropped file with a `FileReader` and inserts the result into the document:

```js
// @codemirror/view
handlers.drop = (view, event) => {
  let files = event.dataTransfer.files;
  if (files && files.length) {   // "For a file drop, read the file's text."
    ...
```

So this is a one-extension fix: stop CodeMirror hijacking the event.

## How

```ts
const deferFileDropsToApp = EditorView.domEventHandlers({
  drop: (event) => carriesFiles(event),
  dragover: (event) => carriesFiles(event),
});
```

Per CodeMirror's `runHandlers`, returning `true` makes it call `preventDefault()` and **stop running handlers** for that event — skipping the built-in insertion. It does **not** stop propagation, so the event still bubbles to the window-level importer that does the real work.

`dragover` is claimed too, so the drop caret doesn't track a file drag and imply the contents are about to be inserted at that position.

**The discriminator is `dataTransfer.types` containing `"Files"`**, matching what `FileDropzone` already uses: an OS file drag advertises it, while dragging a text selection inside the editor advertises `text/plain`. Internal text drag-and-drop is therefore untouched.

## Verified live

**A/B on the same drop:**

| | result |
| --- | --- |
| without the fix | `"Firs<svg xmlns=..."` — markup spliced into the document mid-word |
| with the fix | document unchanged; file imported |

**Every file kind called out on the issue** (you asked for all files, not just images):

| Dropped | Document | Landed in |
| --- | --- | --- |
| `shape2.svg` | unchanged | `assets/` |
| `chapter2.sd` | unchanged | `scripts/` |
| `notes.txt` | unchanged | `assets/` |

**And the thing this could easily have broken:** dragging a text selection within the editor still inserts normally. That's asserted explicitly rather than assumed, because a blunter fix (`preventDefault` on all drops, or `stopPropagation`) would have killed either internal drag or the import itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
