### PR TITLE
fix(script-editor): don't leave the editor permanently invisible

### DIFF
--- a/packages/sparkdown-document-views/src/modules/script-editor/ScriptEditorController.ts
+++ b/packages/sparkdown-document-views/src/modules/script-editor/ScriptEditorController.ts
@@ -119,6 +119,13 @@ export interface ScriptEditorOptions {
   languageServerConnection: MessageConnection;
 }
 
+// How long a load may keep the editor hidden before it is revealed anyway.
+// Comfortably longer than a normal large-project parse (~2.7s measured on an
+// 8k-line script) so the usual idle-driven fade-in still wins the race and
+// the user doesn't see a half-parsed document flash; short enough that a
+// wedged load self-heals well inside the "is this broken?" threshold.
+const LOAD_REVEAL_TIMEOUT_MS = 5000;
+
 export class ScriptEditorController {
   protected host: HTMLElement;
   protected refs: ScriptEditorRefs;
@@ -155,6 +162,15 @@ export class ScriptEditorController {
   protected _top: number = 0;
   protected _bottom: number = 0;
   protected _focusIntervalTimeout = 0;
+
+  // Backstop for the fade-in. The idle signal that reveals the editor rides on
+  // `EditorView.updateListener`, which stops firing once updates stop -- so on
+  // a large document whose parse outlives the initial flurry of updates, the
+  // signal can simply never arrive and the editor stays invisible forever
+  // while being fully interactive underneath. An editor the user cannot see is
+  // strictly worse than one showing a still-parsing document, so reveal
+  // regardless once this elapses.
+  protected _revealTimeout = 0;
   // Owns every protocol-bus subscription; `dispose()` detaches them all.
   protected _protocols = new ProtocolObserver();
 
@@ -189,6 +205,10 @@ export class ScriptEditorController {
   }
 
   dispose(): void {
+    if (this._revealTimeout) {
+      clearTimeout(this._revealTimeout);
+      this._revealTimeout = 0;
+    }
     this.host.removeEventListener(
       "touchstart",
       this.handlePointerEnterScroller,
@@ -545,6 +565,15 @@ export class ScriptEditorController {
     } else {
       this.refs.editor.style.visibility = "hidden";
       this.refs.loading.style.opacity = "1";
+      // Arm the backstop the moment we hide, so a load whose idle signal never
+      // arrives still ends up visible rather than blank forever.
+      if (this._revealTimeout) {
+        clearTimeout(this._revealTimeout);
+      }
+      this._revealTimeout = window.setTimeout(
+        this.revealEditor,
+        LOAD_REVEAL_TIMEOUT_MS,
+      );
       if (this._view) {
         this.unbindView(this._view);
         this._view.destroy();
@@ -1002,6 +1031,31 @@ export class ScriptEditorController {
     }
   }
 
+  /**
+   * Fade the editor in. Idempotent, and deliberately NOT gated on a pending
+   * load request: `_loadingRequest` tracks whether a load was initiated by a
+   * protocol request, which says nothing about whether the editor is
+   * currently hidden. Gating visibility on it meant any path that reached
+   * `handleIdle` without an outstanding request -- notably the remount that
+   * `formatDocument` triggers on Ctrl+S -- marked the editor loaded while
+   * leaving it invisible, with no way back short of a page reload.
+   */
+  protected revealEditor = () => {
+    if (this._revealTimeout) {
+      clearTimeout(this._revealTimeout);
+      this._revealTimeout = 0;
+    }
+    if (!this.refs.editor) {
+      return;
+    }
+    if (this.refs.loading) {
+      this.refs.loading.style.opacity = "0";
+    }
+    this.refs.editor.style.visibility = "visible";
+    this.refs.editor.style.opacity = "1";
+    this._loadingRequest = undefined;
+  };
+
   protected handleIdle = () => {
     if (!this._loaded) {
       const initialFocused = this._initialFocused;
@@ -1041,12 +1095,11 @@ export class ScriptEditorController {
           }
         }, 100);
       }
-      if (this._textDocument && this._loadingRequest != null) {
-        // Only fade in once formatting has finished being applied and height is stable
-        this.refs.loading.style.opacity = "0";
-        this.refs.editor.style.visibility = "visible";
-        this.refs.editor.style.opacity = "1";
-        this._loadingRequest = undefined;
+      if (this._textDocument) {
+        // Formatting has been applied and the height is stable, so this is the
+        // preferred moment to fade in -- but it is no longer the only one, see
+        // `revealEditor` and the load watchdog.
+        this.revealEditor();
       }
       if (this._view) {
         this.bindView(this._view);


### PR DESCRIPTION
Refs #252.

> [!WARNING]
> **Verification is incomplete and I'd rather say so than imply otherwise.** I never reproduced the original wedge, so I have no failing case proving this repairs the reported symptom. Details in the last section. This is a defensive fix against a mechanism #252 analyses in detail — merge on that basis, and reopen the issue if the wedge recurs.

## The mechanism

The editor is hidden during load and was only ever revealed by `handleIdle`, under two conditions that could each fail independently:

**1. Reveal was gated on `_loadingRequest != null`.** That field only records whether a load came from a protocol request — it says nothing about whether the editor is currently hidden. So any path reaching `handleIdle` *without* an outstanding request — notably the remount `formatDocument` triggers on Ctrl+S — ran the "loaded" bookkeeping (`_loaded = true`) while leaving the editor invisible. Because `handleIdle` is `if (!this._loaded)`, it then never ran again: the wedge locked itself in, with no recovery short of a page reload.

**2. The idle signal rides on `EditorView.updateListener`**, which stops firing once updates stop. On a document whose parse outlives the initial flurry of updates, the signal never arrives at all.

## The change

- **Reveal is unconditional** once a load settles — extracted into `revealEditor()`, idempotent, no longer gated on the load request. `_loadingRequest` is still consumed there, but as bookkeeping rather than as the visibility gate.
- **A watchdog** armed the moment the editor hides reveals it after 5s regardless. That covers failure mode 2, where no signal ever comes.
- Timer cleared on reveal and in `dispose()`, so it can't fire after teardown.

5s clears a normal large-project parse (~2.7s measured on an 8k-line script in earlier profiling), so the usual idle-driven fade-in still wins the race and no half-parsed flash appears — while a wedged load self-heals well inside the "is this broken?" threshold. An editor the user cannot see is strictly worse than one showing a still-parsing document.

## What I could and couldn't establish

I built a 14,760-line project (120 scenes × 60 exchanges, ~535KB) to reproduce against.

- **I never reproduced the wedge on it.** Loads came up visible every time. The synthetic project likely differs from the reported one in the ways that matter — no includes, different parse profile.
- **One real Ctrl+S with the editor genuinely focused** (`view.hasFocus === true`) left the editor visible afterwards. But that run didn't capture whether a remount even occurred, so it's suggestive, not conclusive.
- **Later attempts couldn't give the editor focus**, so Ctrl+S never reached CodeMirror's keymap and no remount happened to observe (`sawHidden: false`, `sawCmReplaced: false` under a `MutationObserver` watching `.editor` style and subtree).

So the honest summary: the reasoning about the mechanism is solid and drawn from the ticket's own analysis, the change is small and defensive, but **it has not been demonstrated against a failing case.**

## Not addressed

#252 also asks why `formatDocument` causes a full editor remount at all — formatting should be a workspace edit applied to the live view. That's the deeper fix and it's untouched here; this change only stops the remount from stranding the editor invisible. Worth its own issue if you want it chased.

## Note

`ScriptEditorController.ts` was already unformatted at `main`, so I deliberately did not run Prettier across it — that would bury a ~59-line change in unrelated churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
