### PR TITLE
fix(impower-dev): let SingletonPromise retry after a failed attempt

### DIFF
--- a/impower-dev/src/modules/spark-editor/workspace/SingletonPromise.ts
+++ b/impower-dev/src/modules/spark-editor/workspace/SingletonPromise.ts
@@ -17,7 +17,24 @@ export default class SingletonPromise<
   async get(...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> {
     if (this._value === undefined) {
       if (!this._promise) {
-        this._promise = this._func(...args);
+        // A rejected attempt must not stay cached. Without this, `_promise`
+        // keeps pointing at the rejected promise and every later `get()`
+        // re-awaits the same rejection — so one transient failure (a script
+        // load that dropped, a read that lost a race) permanently disables
+        // whatever is being memoized for the rest of the session, with no way
+        // back short of an explicit `reset()` that nothing calls.
+        //
+        // Callers already in flight still share this single attempt; only
+        // callers arriving after it fails get to start a fresh one.
+        const attempt: Promise<Awaited<ReturnType<T>>> = this._func(
+          ...args
+        ).then(undefined, (e: unknown) => {
+          if (this._promise === attempt) {
+            this._promise = undefined;
+          }
+          throw e;
+        });
+        this._promise = attempt;
       }
       this._value = await this._promise;
     }

--- a/impower-dev/test/workspace/singletonPromise.test.ts
+++ b/impower-dev/test/workspace/singletonPromise.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from "vitest";
+import SingletonPromise from "../../src/modules/spark-editor/workspace/SingletonPromise";
+
+/** A deferred whose settlement we drive by hand, so races are deterministic. */
+const deferred = <V>() => {
+  let resolve!: (v: V) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<V>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("SingletonPromise", () => {
+  describe("memoization", () => {
+    it("invokes the function only once across many gets", async () => {
+      const func = vi.fn(async () => "value");
+      const ref = new SingletonPromise(func);
+
+      expect(await ref.get()).toBe("value");
+      expect(await ref.get()).toBe("value");
+      expect(await ref.get()).toBe("value");
+
+      expect(func).toHaveBeenCalledTimes(1);
+    });
+
+    it("shares a single in-flight attempt between concurrent callers", async () => {
+      const d = deferred<string>();
+      const func = vi.fn(() => d.promise);
+      const ref = new SingletonPromise(func);
+
+      const all = Promise.all([ref.get(), ref.get(), ref.get()]);
+      d.resolve("value");
+
+      expect(await all).toEqual(["value", "value", "value"]);
+      expect(func).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes through the arguments of the first caller", async () => {
+      const func = vi.fn(async (a: string, b: number) => `${a}:${b}`);
+      const ref = new SingletonPromise(func);
+
+      expect(await ref.get("x", 1)).toBe("x:1");
+      // Later args are ignored — that is the point of memoizing.
+      expect(await ref.get("y", 2)).toBe("x:1");
+      expect(func).toHaveBeenCalledTimes(1);
+      expect(func).toHaveBeenCalledWith("x", 1);
+    });
+
+    it("exposes the resolved value synchronously via `value`", async () => {
+      const ref = new SingletonPromise(async () => "value");
+
+      expect(ref.value).toBeUndefined();
+      await ref.get();
+      expect(ref.value).toBe("value");
+    });
+  });
+
+  describe("rejection recovery (#224)", () => {
+    it("retries after a failure instead of caching the rejection forever", async () => {
+      // The bug: `_promise` stayed pointed at the rejected promise, so every
+      // later `get()` re-awaited the same rejection and the memoized thing was
+      // permanently dead for the session.
+      const func = vi
+        .fn<() => Promise<string>>()
+        .mockRejectedValueOnce(new Error("transient"))
+        .mockResolvedValueOnce("recovered");
+      const ref = new SingletonPromise(func);
+
+      await expect(ref.get()).rejects.toThrow("transient");
+      expect(await ref.get()).toBe("recovered");
+      expect(func).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps retrying across repeated failures", async () => {
+      const func = vi
+        .fn<() => Promise<string>>()
+        .mockRejectedValueOnce(new Error("first"))
+        .mockRejectedValueOnce(new Error("second"))
+        .mockResolvedValueOnce("third time lucky");
+      const ref = new SingletonPromise(func);
+
+      await expect(ref.get()).rejects.toThrow("first");
+      await expect(ref.get()).rejects.toThrow("second");
+      expect(await ref.get()).toBe("third time lucky");
+      expect(func).toHaveBeenCalledTimes(3);
+    });
+
+    it("rejects every concurrent caller of a failing attempt, but only runs it once", async () => {
+      const d = deferred<string>();
+      const func = vi.fn(() => d.promise);
+      const ref = new SingletonPromise(func);
+
+      const results = Promise.allSettled([ref.get(), ref.get(), ref.get()]);
+      d.reject(new Error("boom"));
+
+      const settled = await results;
+      expect(settled.map((r) => r.status)).toEqual([
+        "rejected",
+        "rejected",
+        "rejected",
+      ]);
+      expect(func).toHaveBeenCalledTimes(1);
+    });
+
+    it("leaves `value` unset after a failure", async () => {
+      const ref = new SingletonPromise(async () => {
+        throw new Error("nope");
+      });
+
+      await expect(ref.get()).rejects.toThrow("nope");
+      expect(ref.value).toBeUndefined();
+    });
+
+    it("lets later callers join the retry rather than starting more attempts", async () => {
+      const first = deferred<string>();
+      const second = deferred<string>();
+      const func = vi
+        .fn<() => Promise<string>>()
+        .mockImplementationOnce(() => first.promise)
+        .mockImplementationOnce(() => second.promise);
+      const ref = new SingletonPromise(func);
+
+      const firstGet = ref.get();
+      first.reject(new Error("first"));
+      await expect(firstGet).rejects.toThrow("first");
+
+      // Second attempt starts and is still pending.
+      const secondGet = ref.get();
+      expect(func).toHaveBeenCalledTimes(2);
+
+      // A third caller must join the pending second attempt, not start a third.
+      const thirdGet = ref.get();
+      expect(func).toHaveBeenCalledTimes(2);
+
+      second.resolve("value");
+      expect(await secondGet).toBe("value");
+      expect(await thirdGet).toBe("value");
+    });
+
+    it("a stale rejection does not evict the attempt that replaced it", async () => {
+      // Covers the `this._promise === attempt` identity check. `reset()` is
+      // the one way an attempt can be replaced while it is still in flight;
+      // when that abandoned attempt later fails, it must not clear the
+      // *current* one, or the retry already running gets orphaned and a
+      // redundant duplicate is fired off behind it.
+      const first = deferred<string>();
+      const second = deferred<string>();
+      const func = vi
+        .fn<() => Promise<string>>()
+        .mockImplementationOnce(() => first.promise)
+        .mockImplementationOnce(() => second.promise);
+      const ref = new SingletonPromise(func);
+
+      const firstGet = ref.get();
+      ref.reset(); // abandon the in-flight attempt
+      const secondGet = ref.get();
+      expect(func).toHaveBeenCalledTimes(2);
+
+      // The abandoned attempt fails, late — after its replacement is cached.
+      first.reject(new Error("stale"));
+      await expect(firstGet).rejects.toThrow("stale");
+
+      // The second attempt must still be cached, so a new caller joins it.
+      const thirdGet = ref.get();
+      expect(func).toHaveBeenCalledTimes(2);
+
+      second.resolve("value");
+      expect(await secondGet).toBe("value");
+      expect(await thirdGet).toBe("value");
+    });
+  });
+
+  describe("reset", () => {
+    it("forces the function to run again", async () => {
+      let n = 0;
+      const func = vi.fn(async () => `run ${++n}`);
+      const ref = new SingletonPromise(func);
+
+      expect(await ref.get()).toBe("run 1");
+      ref.reset();
+      expect(await ref.get()).toBe("run 2");
+      expect(func).toHaveBeenCalledTimes(2);
+    });
+
+    it("clears the cached value", async () => {
+      const ref = new SingletonPromise(async () => "value");
+
+      await ref.get();
+      expect(ref.value).toBe("value");
+      ref.reset();
+      expect(ref.value).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Fixes the "never recovers" half of #224.

## What was wrong

`SingletonPromise.get()` cached rejections forever:

```ts
if (!this._promise) {
  this._promise = this._func(...args);   // stays set even if it rejects
}
this._value = await this._promise;       // every later call re-awaits the rejection
```

Once an attempt failed, `_promise` kept pointing at the rejected promise, so **every subsequent `get()` re-awaited the same rejection**. A single transient failure permanently disabled whatever was being memoized for the rest of the session — the only way out was `reset()`, which nothing calls on the failure path.

## Why this is #224's mechanism

`WorkspaceFileSystem._initialFilesRef` memoizes `loadInitialFiles`, and `loadInitialFiles` ends in `Workspace.ls.start(...)` — the **only** call site that initializes the language server ([WorkspaceFileSystem.ts:188](https://github.com/ImpowerGames/impower/blob/main/impower-dev/src/modules/spark-editor/workspace/WorkspaceFileSystem.ts)).

So if that load fails once:

1. The constructor's fire-and-forget `get()` rejects and logs.
2. `getFiles()` — called all over the editor — now rejects **forever**, because the rejection is cached.
3. `loadInitialFiles` is therefore never re-run, so `ls.start()` is never reached.
4. Program-dependent requests await `initialization()`, which resolves only via `_onInitialized` callbacks that `start()` would have fired. It never rejects, so it just **hangs** — indistinguishable from "still loading".

That last step is why the ticket describes it as failing *silently*, and step 2 is why it's "intermittent but never recovers". With this change, the next ordinary `getFiles()` retries the whole load and reaches `ls.start()`.

## The fix

```ts
const attempt = this._func(...args).then(undefined, (e) => {
  if (this._promise === attempt) {
    this._promise = undefined;
  }
  throw e;
});
this._promise = attempt;
```

Callers already in flight still share the single attempt — only callers arriving *after* it fails start a fresh one. The `this._promise === attempt` identity check keeps a stale rejection (one abandoned by `reset()` while still in flight) from evicting the attempt that replaced it.

The blast radius is wider than #224: `SingletonPromise` also backs project load and the Google Drive GSI/gapi/picker script loads and account fetch — all of which were equally one-failure-and-done.

## Verification

**Unit tests** — 12 new, in `impower-dev/test/workspace/singletonPromise.test.ts`. Full `impower-dev` suite: 154/154 pass.

**Mutation-tested**, both mutants killed:

| mutant | result |
| --- | --- |
| restore the original `get()` | 3 failures — all in `rejection recovery (#224)` |
| drop the `this._promise === attempt` check | 1 failure — `a stale rejection does not evict the attempt that replaced it` |

The second mutant initially **survived** my first attempt at that test, because a rejection handler always runs before any replacement can be installed — `reset()` abandoning an in-flight attempt is the only way `_promise` can differ. The test was rewritten to actually reach that state.

**Live in Chrome** (`npm run web:dev`), against the real compiled module served by Vite, running the #224 scenario (`loadInitialFiles` fails once, then succeeds):

| | invocations | get1 | get2 | get3 |
| --- | --- | --- | --- | --- |
| pre-fix (`origin/main`) | 1 | rejected | rejected | rejected |
| post-fix | 2 | rejected | **recovered** | cached |

Pre-fix the loader is never retried at all. Post-fix the second call recovers and the value is cached from then on.

Also confirmed **no regression** to normal startup — loaded a project in the editor and checked that LSP init still completes: semantic highlighting present (sections, characters, `define` keyword, strings all colored), path locations resolving in the status bar (`main:1 → main:3`), and the game preview compiling and rendering.

## What this does *not* fix

I could not reproduce #224 — LSP init succeeds consistently on current `main`, so there is no failing case to point at. This fixes a mechanism that demonstrably produces the reported symptom, not an observed instance of it.

One related gap is left deliberately: if **`ls.start()` itself** rejects, `_initialFilesRef` has already resolved, so nothing triggers a retry and `initialization()` still hangs forever. Recovering from that would mean resetting `_initialFilesRef` from `start()`'s catch handler, which risks a retry storm — a full project re-read on every `getFiles()` against a permanently broken worker. Not worth adding speculatively; happy to file it as a follow-up if you'd like it tracked.

I'd suggest leaving #224 open after this merges, since the underlying failure was never observed directly.
