### PR TITLE
fix(script-editor): keep the status bar's diagnostic context on one row

### DIFF
--- a/packages/sparkdown-document-views/src/modules/script-editor/utils/extensions/statusPanel.ts
+++ b/packages/sparkdown-document-views/src/modules/script-editor/utils/extensions/statusPanel.ts
@@ -513,9 +513,16 @@ const statusPanelTheme = EditorView.baseTheme({
     color: EDITOR_COLORS.statusLabel,
     backgroundColor: EDITOR_COLORS.panel,
     display: "flex",
+    // Every flex row in this panel states its direction explicitly rather than
+    // leaning on the browser's `row` default. Hosts are free to normalize
+    // `flex-direction` across a subtree — spark-editor forces `column` on all
+    // descendants of the editor root — and a direction-less flex container
+    // silently stacks when they do.
+    flexDirection: "row",
     justifyContent: "space-between",
     "& .cm-diagnosticContext": {
       display: "flex",
+      flexDirection: "row",
       alignItems: "center",
       justifyContent: "space-between",
       overflow: "hidden",
@@ -539,6 +546,7 @@ const statusPanelTheme = EditorView.baseTheme({
       fontSize: "14px",
       textAlign: "center",
       display: "flex",
+      flexDirection: "row",
       alignItems: "center",
       gap: "4px",
       position: "relative",
@@ -552,6 +560,7 @@ const statusPanelTheme = EditorView.baseTheme({
       fontSize: "14px",
       textAlign: "center",
       display: "flex",
+      flexDirection: "row",
       alignItems: "center",
       gap: "4px",
       position: "relative",
@@ -593,12 +602,21 @@ const statusPanelTheme = EditorView.baseTheme({
     padding: "1px 8px",
     fontSize: "14px",
     display: "flex",
+    flexDirection: "row",
     alignItems: "center",
     gap: "4px",
     position: "relative",
+    // Same reason as the explicit directions above: hosts may normalize
+    // `flex-shrink` across the subtree (spark-editor sets `0` globally), which
+    // stops a long diagnostic message from ever giving ground and pushes the
+    // prev/next navigation outside the bar's `overflow: hidden`. Shrinking is
+    // what lets `.cm-activeDiagnosticMessage` ellipsize instead.
+    flexShrink: 1,
+    minWidth: 0,
   },
   "& .cm-diagnosticNavigation": {
     display: "flex",
+    flexDirection: "row",
   },
   "& .cm-activeDiagnosticMessage": {
     whiteSpace: "nowrap",


### PR DESCRIPTION
Fixes #263.

## What was wrong

`.cm-diagnosticContext`, `.cm-diagnosticSummary` and `.cm-diagnosticNavigation` set `display: flex` and relied on the browser's `row` default. spark-editor's normalize forces `flex-direction: column` on every descendant of the editor root, so they silently stacked — the same defect class as #247.

This UI is **mobile-only** (`isMobile() && view.hasFocus` at `statusPanel.ts:309`), which is why it went unnoticed on desktop.

## Before / after

Reproduced at a 375×812 viewport with two `((missing_audio))` warnings, clicking directly into a squiggled range so the real code path fires.

**Before** — the warning icon lands on its own line, the message wraps to a second line clipped by the bottom nav, and `‹ 1/2 ›` is pushed out of the bar entirely:

| element | flex-direction | box | top |
| --- | --- | --- | --- |
| `.cm-status` | row | 375×28 | 724 |
| `.cm-diagnosticContext` | **column** | 375×28 | 724 |
| `.cm-diagnosticSummary` | **column** | 257×28 | 724 |
| `.cm-diagnosticNavigation` | **column** | **32×53** | **752** |

The navigation is 53px tall (its prev/next buttons stacked) and starts at y=752 — below the bar's own 724+28 band.

**After** — one 28px row: icon, message, `‹ 2/2 ›`, all inside the bar. Clicking `‹` correctly jumps to diagnostic 1/2 and selects the range.

| element | flex-direction | box | top |
| --- | --- | --- | --- |
| `.cm-diagnosticContext` | row | 375×28 | 724 |
| `.cm-diagnosticSummary` | row | 284×28 | 724 |
| `.cm-diagnosticNavigation` | row | 91×18 | 729 |

## Second bug, exposed by the first fix

Once the direction was right, the stacking stopped masking a `flex-shrink` variant of the same problem. That normalize also sets **`flex-shrink: 0`** globally, so `.cm-diagnosticSummary` never gave ground: a long message kept it at its full 330px content width and pushed the navigation to `right: 421` in a 375px viewport — **46px outside** the context's `overflow: hidden`, i.e. invisible and unclickable.

`.cm-activeDiagnosticMessage` already carries `flex: 1`, `overflow: hidden` and `text-overflow: ellipsis`; it just never got the chance to use them. Giving the summary `flex-shrink: 1` and `min-width: 0` restores that — the message ellipsizes and the navigation lands flush at x=375.

I've folded this in rather than splitting it, since shipping only the direction fix would trade a stacked bar for a bar with unreachable navigation buttons.

## Approach

Set both properties explicitly in the theme rather than extending the re-assertion list in `sparkdown-script-editor.css`, so the panel is correct under any embedder's normalize instead of only where the host happens to patch it.

## Verification

Live in Chrome via `npm run web:dev`, driven through the real code path (real click into the diagnostic range, `isMobile()` satisfied by touch emulation) — not by forcing styles. Captured the broken state first by stashing the fix and letting the dev server rebuild, so the before/after is the same build pipeline and the same interaction.

Also confirmed the desktop status bar is unchanged (`› 2 Warnings … Ln 1, Col 1`), and that prev/next navigation works after the fix.

## Follow-up

Filed #266 for the remaining direction-less flex rules — 8 more sites across `references.ts`, `rename.ts`, `lens.ts` and `EDITOR_THEME.ts`. I deliberately did **not** blanket-fix them here: two plausibly want `column`, and I'd be changing them from static reading rather than from looking at the rendered result. That ticket also notes `.cm-context-menu` is direction-less *by design* (its `.cm-horizontal`/`.cm-vertical` modifiers set it) and should be left alone, and suggests a lint or mount-test to end this class of bug rather than fixing instances one at a time.
