### PR TITLE
fix(sparkdown): stop `[[` and `((` from over-indenting the next line

### DIFF
--- a/definitions/yaml/sparkdown.language-config.yaml
+++ b/definitions/yaml/sparkdown.language-config.yaml
@@ -137,20 +137,34 @@ onEnterRules:
     action:
       indent: "outdent"
 
-  - beforeText: \[\s*$
+  # A line ending in an opening bracket continues onto the next
+  # line one level in (multi-line index expressions, call args).
+  #
+  # The `(?<!\[)` / `(?<!\()` guards exclude DOUBLED brackets, for
+  # the same reason `decreaseIndentPattern` carries the mirrored
+  # guards: sparkdown's display directives are written doubled —
+  # `[[portrait]]`, `((sound))` — so a line ending in `[[` or `((`
+  # is an unfinished inline directive, not a bracket to indent
+  # inside of. Without these, `\[\s*$` matches the SECOND `[` of
+  # `[[` and the next line gains a stray indent unit.
+  #
+  # These rules run from a `Prec.high` Enter keymap, which is why
+  # `increaseIndentPattern` has no say here — its own doubled-
+  # bracket exclusion would never be reached (see #259).
+  - beforeText: (?<!\[)\[\s*$
     afterText: ^\s*\].*$
     action:
       indent: "indentOutdent"
-  - beforeText: \[\s*$
+  - beforeText: (?<!\[)\[\s*$
     afterText: ^(?!\s*\])
     action:
       indent: "indent"
 
-  - beforeText: \(\s*$
+  - beforeText: (?<!\()\(\s*$
     afterText: ^\s*\).*$
     action:
       indent: "indentOutdent"
-  - beforeText: \(\s*$
+  - beforeText: (?<!\()\(\s*$
     afterText: ^(?!\s*\))
     action:
       indent: "indent"
@@ -186,11 +200,17 @@ indentationRules: # Increase the next line's indent when the current line:
   #      (covers tables, multi-line call args, long strings,
   #      and multi-line typed parameter lists).
   #
-  #        [\{\(\[] \s* (--.*)? $
+  #        (\{|(?<!\()\(|(?<!\[)\[) \s* (--.*)? $
+  #
+  #      The `(?<!\()` / `(?<!\[)` guards mirror the ones in
+  #      `decreaseIndentPattern`: a line ending in `[[` or `((`
+  #      is an unfinished sparkdown display directive, not a
+  #      bracket to indent inside of. `{` stays unguarded, for
+  #      the same reason `}` does on the decrease side.
   #
   # The leading `^((?!--).)*` prevents triggering when the
   # match would be inside a line comment.
-  increaseIndentPattern: ^((?!--).)*((\b(else|then|do|repeat|define|scene|branch)\b\s*(--.*)?$)|(\bfunction\b(?:(?!\bend\b).)*$)|([\{\(\[]\s*(--.*)?$))
+  increaseIndentPattern: ^((?!--).)*((\b(else|then|do|repeat|define|scene|branch)\b\s*(--.*)?$)|(\bfunction\b(?:(?!\bend\b).)*$)|((\{|(?<!\()\(|(?<!\[)\[)\s*(--.*)?$))
 
   # Decrease the current line's indent when it starts with
   # a block-closing token: `end`, `until`, `else`, `elseif`,

--- a/packages/sparkdown/language/sparkdown.language-config.json
+++ b/packages/sparkdown/language/sparkdown.language-config.json
@@ -241,28 +241,28 @@
       }
     },
     {
-      "beforeText": "\\[\\s*$",
+      "beforeText": "(?<!\\[)\\[\\s*$",
       "afterText": "^\\s*\\].*$",
       "action": {
         "indent": "indentOutdent"
       }
     },
     {
-      "beforeText": "\\[\\s*$",
+      "beforeText": "(?<!\\[)\\[\\s*$",
       "afterText": "^(?!\\s*\\])",
       "action": {
         "indent": "indent"
       }
     },
     {
-      "beforeText": "\\(\\s*$",
+      "beforeText": "(?<!\\()\\(\\s*$",
       "afterText": "^\\s*\\).*$",
       "action": {
         "indent": "indentOutdent"
       }
     },
     {
-      "beforeText": "\\(\\s*$",
+      "beforeText": "(?<!\\()\\(\\s*$",
       "afterText": "^(?!\\s*\\))",
       "action": {
         "indent": "indent"
@@ -288,7 +288,7 @@
     }
   ],
   "indentationRules": {
-    "increaseIndentPattern": "^((?!--).)*((\\b(else|then|do|repeat|define|scene|branch)\\b\\s*(--.*)?$)|(\\bfunction\\b(?:(?!\\bend\\b).)*$)|([\\{\\(\\[]\\s*(--.*)?$))",
+    "increaseIndentPattern": "^((?!--).)*((\\b(else|then|do|repeat|define|scene|branch)\\b\\s*(--.*)?$)|(\\bfunction\\b(?:(?!\\bend\\b).)*$)|((\\{|(?<!\\()\\(|(?<!\\[)\\[)\\s*(--.*)?$))",
     "decreaseIndentPattern": "^\\s*((\\b(elseif|else|end|until)\\b)|\\}|\\)(?!\\))|\\](?!\\]))",
     "indentNextLinePattern": "^((?!--).)*(?<![=<>!~])=\\s*(--.*)?$",
     "unIndentedLinePattern": "^#\\!"

--- a/packages/sparkdown/src/tests/language-config/indentation.test.ts
+++ b/packages/sparkdown/src/tests/language-config/indentation.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import LANGUAGE_CONFIG from "../../../language/sparkdown.language-config.json";
+
+/**
+ * Regression coverage for the indentation rules in
+ * `definitions/yaml/sparkdown.language-config.yaml`.
+ *
+ * These regexes are generated into this JSON and consumed by two hosts (the
+ * web editor via `codemirror-vscode-language`, and VS Code directly). They
+ * have broken twice — #253 (`]]` dedenting) and #259 (`[[` over-indenting) —
+ * and both times the cause was mis-attributed, because sparkdown's doubled
+ * display directives (`[[image]]`, `((sound))`) look like Luau brackets to a
+ * pattern that only inspects one character.
+ *
+ * The rules are plain regexes, so pinning them costs nothing and catches the
+ * next doubled-bracket regression at the source rather than in the editor.
+ */
+
+const { indentationRules, onEnterRules } = LANGUAGE_CONFIG as {
+  indentationRules: {
+    increaseIndentPattern: string;
+    decreaseIndentPattern: string;
+  };
+  onEnterRules: {
+    beforeText: string;
+    afterText?: string;
+    action: { indent: string };
+  }[];
+};
+
+const increase = new RegExp(indentationRules.increaseIndentPattern);
+const decrease = new RegExp(indentationRules.decreaseIndentPattern);
+
+/**
+ * Every onEnterRule keyed off a line ending in an opening bracket.
+ *
+ * Selected by the bracket the rule ends with, deliberately NOT by the guard
+ * prefix — selecting on the guard would make these tests vacuous the moment
+ * the guard is removed, which is exactly the regression they exist to catch.
+ */
+const bracketEnterRules = onEnterRules
+  .filter((r) => /\\[[(]\\s\*\$$/.test(r.beforeText))
+  .map((r) => new RegExp(r.beforeText, "u"));
+
+describe("increaseIndentPattern", () => {
+  it("does not indent after a doubled display-directive opener (#259)", () => {
+    // `\[\s*$` matches the SECOND `[` of `[[` unless guarded.
+    expect(increase.test("  [[")).toBe(false);
+    expect(increase.test("  ((")).toBe(false);
+    expect(increase.test("BUNNY:\n  [[".split("\n")[1]!)).toBe(false);
+  });
+
+  it("still indents after a single opening bracket", () => {
+    expect(increase.test("  [")).toBe(true);
+    expect(increase.test("  (")).toBe(true);
+    expect(increase.test("  foo(")).toBe(true);
+    expect(increase.test("  x = arr[")).toBe(true);
+  });
+
+  it("leaves braces unguarded, matching the decrease side", () => {
+    expect(increase.test("local t = {")).toBe(true);
+    expect(increase.test("  local t = {{")).toBe(true);
+  });
+
+  it("still indents after block-opening keywords", () => {
+    for (const line of [
+      "  if a then",
+      "  for i = 1, 3 do",
+      "  repeat",
+      "  else",
+      "  function f(x)",
+      "  define",
+    ]) {
+      expect(increase.test(line), line).toBe(true);
+    }
+  });
+
+  it("does not fire inside a line comment", () => {
+    expect(increase.test("  -- [")).toBe(false);
+  });
+});
+
+describe("decreaseIndentPattern", () => {
+  it("does not dedent on a doubled display-directive closer (#253)", () => {
+    expect(decrease.test("  ]]")).toBe(false);
+    expect(decrease.test("  ))")).toBe(false);
+  });
+
+  it("still dedents on a single closing bracket", () => {
+    expect(decrease.test("  )")).toBe(true);
+    expect(decrease.test("  ]")).toBe(true);
+    expect(decrease.test("  }")).toBe(true);
+  });
+
+  it("still dedents on block-closing keywords", () => {
+    for (const line of ["  end", "  until x", "  else", "  elseif a then"]) {
+      expect(decrease.test(line), line).toBe(true);
+    }
+  });
+});
+
+describe("bracket onEnterRules", () => {
+  // These run from a Prec.high Enter keymap, ahead of the indent service, so
+  // they need the same doubled-bracket guards independently — narrowing only
+  // one of the two sources leaves the symptom unchanged, which is what made
+  // #259 hard to attribute.
+  it("guards both bracket kinds", () => {
+    expect(bracketEnterRules).toHaveLength(4); // [ and ( × indentOutdent/indent
+  });
+
+  it("does not fire on a doubled opener", () => {
+    for (const re of bracketEnterRules) {
+      expect(re.test("  [["), String(re)).toBe(false);
+      expect(re.test("  (("), String(re)).toBe(false);
+    }
+  });
+
+  it("still fires on a single opener", () => {
+    const matchesSingle = (s: string) =>
+      bracketEnterRules.some((re) => re.test(s));
+    expect(matchesSingle("  [")).toBe(true);
+    expect(matchesSingle("  (")).toBe(true);
+    expect(matchesSingle("  foo(")).toBe(true);
+  });
+});

--- a/vscode-sparkdown/language/sparkdown.language-config.json
+++ b/vscode-sparkdown/language/sparkdown.language-config.json
@@ -241,28 +241,28 @@
       }
     },
     {
-      "beforeText": "\\[\\s*$",
+      "beforeText": "(?<!\\[)\\[\\s*$",
       "afterText": "^\\s*\\].*$",
       "action": {
         "indent": "indentOutdent"
       }
     },
     {
-      "beforeText": "\\[\\s*$",
+      "beforeText": "(?<!\\[)\\[\\s*$",
       "afterText": "^(?!\\s*\\])",
       "action": {
         "indent": "indent"
       }
     },
     {
-      "beforeText": "\\(\\s*$",
+      "beforeText": "(?<!\\()\\(\\s*$",
       "afterText": "^\\s*\\).*$",
       "action": {
         "indent": "indentOutdent"
       }
     },
     {
-      "beforeText": "\\(\\s*$",
+      "beforeText": "(?<!\\()\\(\\s*$",
       "afterText": "^(?!\\s*\\))",
       "action": {
         "indent": "indent"
@@ -288,7 +288,7 @@
     }
   ],
   "indentationRules": {
-    "increaseIndentPattern": "^((?!--).)*((\\b(else|then|do|repeat|define|scene|branch)\\b\\s*(--.*)?$)|(\\bfunction\\b(?:(?!\\bend\\b).)*$)|([\\{\\(\\[]\\s*(--.*)?$))",
+    "increaseIndentPattern": "^((?!--).)*((\\b(else|then|do|repeat|define|scene|branch)\\b\\s*(--.*)?$)|(\\bfunction\\b(?:(?!\\bend\\b).)*$)|((\\{|(?<!\\()\\(|(?<!\\[)\\[)\\s*(--.*)?$))",
     "decreaseIndentPattern": "^\\s*((\\b(elseif|else|end|until)\\b)|\\}|\\)(?!\\))|\\](?!\\]))",
     "indentNextLinePattern": "^((?!--).)*(?<![=<>!~])=\\s*(--.*)?$",
     "unIndentedLinePattern": "^#\\!"


### PR DESCRIPTION
Fixes #259.

## Root cause — there were two sources, not one

This is why the earlier investigation recorded in #259 came up empty.

Pressing Enter after `  [[` added an indent unit from **two independent places**, each producing an identical +1:

1. **The `\[\s*$` / `\(\s*$` onEnterRules.** `beforeText: \[\s*$` is unanchored, so on `  [[` it matches the **second** `[`. These run from a `Prec.high` Enter keymap in [`vscodeOnEnterRules.ts`](https://github.com/ImpowerGames/impower/blob/main/packages/codemirror-vscode-language/src/extensions/vscodeOnEnterRules.ts), ahead of the indent service.
2. **`increaseIndentPattern`'s `[\{\(\[]\s*(--.*)?$` arm**, consulted via `vscodeIndentService`, which matches the same way.

#259 narrowed **only** #2, saw no change, and reverted it as ineffective — but #1 was still firing and producing the same result. That fix was correct, just insufficient on its own. I hit the mirror image of this: I narrowed only #1 first, confirmed the new regex was live in the running editor, and the indent was *still* 4.

I traced every onEnterRule in order against `"  [["` to confirm which one fires first:

```
before:n after:Y  -> ->
before:n after:Y  ->
before:Y after:n  [ +outdent      <- beforeText matches, afterText doesn't
FIRST MATCH -> [ +indent
```

## The fix

Guard both, mirroring the `(?!\))` / `(?!\])` guards `decreaseIndentPattern` already carries from #258:

| rule | before | after |
| --- | --- | --- |
| onEnterRules (×4) | `\[\s*$`, `\(\s*$` | `(?<!\[)\[\s*$`, `(?<!\()\(\s*$` |
| `increaseIndentPattern` | `[\{\(\[]\s*(--.*)?$` | `(\{|(?<!\()\(|(?<!\[)\[)\s*(--.*)?$` |

`{` stays unguarded on the increase side for the same reason `}` is unguarded on the decrease side — `{{` isn't sparkdown directive syntax.

**Trade-off, same as #258 made:** a Luau line ending in `((` (doubled grouping parens) no longer auto-indents. That's the unavoidable cost of a config shared between Luau and sparkdown display syntax, and it's consistent with `))` already not dedenting.

## Verification

**Live in Chrome** (`npm run web:dev`), the issue's exact repro — real click at the end of `  [[`, real Enter keypress:

```
BUNNY:
  [[
  bunny~jacket     <- 2 spaces, aligned with [[  (was 4)
```

Then drove 11 more cases through the real editor via the Enter keymap:

| input | want | got |
| --- | --- | --- |
| `  [[` / `  ((` | 2 (preserve) | 2 ✓ |
| `  [` / `  (` / `  foo(` / `  local t = {` | 4 (indent) | 4 ✓ |
| `  if a then` | 4 | 4 ✓ |
| `  foo`, `  hello` (dialogue) | 2 (preserve) | 2 ✓ |
| split before `]]` (#253's case) | 2 | 2 ✓ |
| split before single `)` | 0 (dedent) | 0 ✓ |

**Tests.** There was no coverage for this config anywhere, despite it breaking twice now and being misdiagnosed both times. Added `packages/sparkdown/src/tests/language-config/indentation.test.ts` — 11 tests over `increaseIndentPattern`, `decreaseIndentPattern` and the bracket onEnterRules, asserted against the **generated JSON** so it covers what the web editor and VS Code actually load, not the YAML source.

Mutation-tested — reverting either guard alone fails a distinct test:

| mutant | failing test |
| --- | --- |
| `increaseIndentPattern` unguarded | `does not indent after a doubled display-directive opener (#259)` |
| onEnterRules unguarded | `does not fire on a doubled opener` |

My first version of that second test was **worthless** and I caught it here: it selected the bracket rules *by their guard prefix*, so removing the guard emptied the array and the assertion passed vacuously. It now selects on the trailing bracket instead, independent of the thing under test.

Full `packages/sparkdown` suite: **1540 passed, 24 skipped, 0 failed**.
