### PR TITLE
fix(spark-engine): play synths that authors only partially specified

### DIFF
--- a/packages/spark-engine/src/game/core/classes/Game.ts
+++ b/packages/spark-engine/src/game/core/classes/Game.ts
@@ -26,6 +26,7 @@ import { StackFrame } from "../types/StackFrame";
 import { SystemConfiguration } from "../types/SystemConfiguration";
 import { Thread } from "../types/Thread";
 import { Variable, VariablePresentationHint } from "../types/Variable";
+import { applyBuiltinDefaults } from "../utils/applyBuiltinDefaults";
 import { findClosestPath } from "../utils/findClosestPath";
 import { findClosestPathLocation } from "../utils/findClosestPathLocation";
 import { Clock } from "./Clock";
@@ -271,6 +272,14 @@ export class Game<T extends M = {}> {
       },
       ...(this._program.context || {}),
     };
+
+    // Authored defines arrive carrying only the properties the author wrote,
+    // so make each one inherit the rest from its type's `$default` before any
+    // module reads it. Without this every consumer has to invent its own
+    // fallbacks, and they drift: the typewriter fallbacks in InterpreterModule
+    // were 5-16x off the real defaults, and AudioModule dropped incomplete
+    // synths outright (#268).
+    applyBuiltinDefaults(this._context);
 
     // Override default modules with custom ones if specified
     const allModules = {

--- a/packages/spark-engine/src/game/core/utils/applyBuiltinDefaults.test.ts
+++ b/packages/spark-engine/src/game/core/utils/applyBuiltinDefaults.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_BUILTIN_DEFINITIONS } from "../../modules/DEFAULT_BUILTIN_DEFINITIONS";
+import { applyBuiltinDefaults, inheritDefaults } from "./applyBuiltinDefaults";
+
+/**
+ * Authored defines reach the runtime carrying only the properties the author
+ * wrote. `Game` makes each one inherit its type's `$default` before any module
+ * reads it, so consumers never have to invent their own fallbacks (#268).
+ */
+
+describe("inheritDefaults", () => {
+  it("fills in what the author did not write", () => {
+    const result = inheritDefaults(
+      { $type: "synth", $name: "raffles", volume: 0.9 },
+      { $type: "synth", $name: "$default", shape: "triangle", volume: 0.5 },
+    );
+    expect(result).toEqual({
+      $type: "synth",
+      $name: "raffles",
+      shape: "triangle",
+      volume: 0.9,
+    });
+  });
+
+  it("never lets a default overwrite an authored value", () => {
+    const result = inheritDefaults({ a: 0 }, { a: 99 });
+    // 0 is authored, and falsy -- a `||` merge would have clobbered it.
+    expect(result.a).toBe(0);
+  });
+
+  it("keeps the instance's own identity", () => {
+    const result = inheritDefaults(
+      { $type: "synth", $name: "raffles" },
+      { $type: "synth", $name: "$default", shape: "triangle" },
+    );
+    expect(result.$name).toBe("raffles");
+  });
+
+  it("merges nested groups per leaf rather than replacing them", () => {
+    const result = inheritDefaults(
+      { pitch: { frequency: 340 } },
+      { pitch: { frequency: 440, frequency_ramp: 0, frequency_jerk: 3 } },
+    );
+    expect(result.pitch).toEqual({
+      frequency: 340,
+      frequency_ramp: 0,
+      frequency_jerk: 3,
+    });
+  });
+
+  it("recurses to any depth", () => {
+    const result = inheritDefaults(
+      { a: { b: { c: 1 } } },
+      { a: { b: { c: 9, d: 2 }, e: 3 } },
+    );
+    expect(result).toEqual({ a: { b: { c: 1, d: 2 }, e: 3 } });
+  });
+
+  it("treats an authored array as a leaf, not something to merge into", () => {
+    const result = inheritDefaults(
+      { tones: [1, 2] },
+      { tones: [7, 8, 9, 10] },
+    );
+    expect(result.tones).toEqual([1, 2]);
+  });
+
+  it("inherits a default array when the author wrote none", () => {
+    const result = inheritDefaults({}, { tones: [0, 4, 7] });
+    expect(result.tones).toEqual([0, 4, 7]);
+  });
+
+  it("does not alias the defaults, so one instance cannot mutate another", () => {
+    const defaults = { envelope: { attack: 0.007 }, tones: [0, 4] };
+    const a: any = inheritDefaults({}, defaults);
+    const b: any = inheritDefaults({}, defaults);
+    a.envelope.attack = 99;
+    a.tones.push(11);
+    expect(b.envelope.attack).toBe(0.007);
+    expect(b.tones).toEqual([0, 4]);
+    expect(defaults.envelope.attack).toBe(0.007);
+  });
+
+  it("leaves the input untouched", () => {
+    const authored = { volume: 0.9 };
+    inheritDefaults(authored, { volume: 0.5, shape: "triangle" });
+    expect(authored).toEqual({ volume: 0.9 });
+  });
+});
+
+describe("applyBuiltinDefaults", () => {
+  it("completes every authored define of a type", () => {
+    const context: any = {
+      synth: {
+        $default: { $type: "synth", shape: "triangle", volume: 0.5 },
+        raffles: { $type: "synth", $name: "raffles", volume: 0.9 },
+        bunny: { $type: "synth", $name: "bunny" },
+      },
+    };
+    applyBuiltinDefaults(context);
+    expect(context.synth.raffles).toEqual({
+      $type: "synth",
+      $name: "raffles",
+      shape: "triangle",
+      volume: 0.9,
+    });
+    expect(context.synth.bunny.shape).toBe("triangle");
+    expect(context.synth.bunny.volume).toBe(0.5);
+  });
+
+  it("leaves the $default itself alone", () => {
+    const context: any = {
+      synth: {
+        $default: { $type: "synth", shape: "triangle" },
+        raffles: { $type: "synth", shape: "sawtooth" },
+      },
+    };
+    applyBuiltinDefaults(context);
+    expect(context.synth.$default).toEqual({ $type: "synth", shape: "triangle" });
+  });
+
+  it("skips types that have no $default", () => {
+    const context: any = { config: { interpreter: { directives: {} } } };
+    applyBuiltinDefaults(context);
+    expect(context.config).toEqual({ interpreter: { directives: {} } });
+  });
+
+  it("is a no-op for types whose $default carries no real properties", () => {
+    // The structural UI types -- style/screen/component -- are meant to be
+    // sparse; being sparse IS the semantics of a cascade. Their `$default`
+    // holds only `$`-prefixed metadata, so they must come out untouched.
+    const context: any = {
+      style: {
+        $default: { $type: "style", $name: "$default", $recursive: true },
+        my_style: { $type: "style", $name: "my_style", color: "red" },
+      },
+    };
+    applyBuiltinDefaults(context);
+    expect(context.style.my_style).toEqual({
+      $type: "style",
+      $name: "my_style",
+      color: "red",
+      $recursive: true,
+    });
+  });
+
+  it("ignores non-object entries", () => {
+    const context: any = {
+      system: { previewing: true },
+      synth: { $default: { shape: "triangle" }, broken: "not-an-object" },
+    };
+    expect(() => applyBuiltinDefaults(context)).not.toThrow();
+    expect(context.synth.broken).toBe("not-an-object");
+  });
+});
+
+describe("against the real builtin definitions", () => {
+  /**
+   * #268 was reported for synths, but nothing inherited -- these are the other
+   * types with real defaults to lose. Pinning a few of the worst so a
+   * regression shows up as a named failure rather than as mysteriously wrong
+   * pacing.
+   */
+  it("completes a partially-authored define for every type with defaults", () => {
+    const builtins: any = DEFAULT_BUILTIN_DEFINITIONS;
+    const context: any = {};
+    const typesWithDefaults: string[] = [];
+    for (const [type, structs] of Object.entries<any>(builtins)) {
+      const dflt = structs?.["$default"];
+      if (!dflt) {
+        continue;
+      }
+      const realKeys = Object.keys(dflt).filter((k) => !k.startsWith("$"));
+      if (realKeys.length === 0) {
+        continue;
+      }
+      typesWithDefaults.push(type);
+      context[type] = {
+        $default: dflt,
+        partial: { $type: type, $name: "partial" },
+      };
+    }
+    // Guards the loop itself: if this collapses to a handful, the assertions
+    // below stop meaning anything.
+    expect(typesWithDefaults.length).toBeGreaterThan(15);
+
+    applyBuiltinDefaults(context);
+
+    for (const type of typesWithDefaults) {
+      const dflt = builtins[type]["$default"];
+      const completed = context[type].partial;
+      for (const key of Object.keys(dflt).filter((k) => !k.startsWith("$"))) {
+        expect(completed[key], `${type}.${key}`).toBeDefined();
+      }
+      expect(completed.$name, `${type} identity`).toBe("partial");
+    }
+  });
+
+  it("gives a partial typewriter the real pause scales", () => {
+    // These are the numbers InterpreterModule's inline fallbacks got wrong by
+    // 5-16x, which is what made this class of bug invisible.
+    const context: any = {
+      typewriter: {
+        $default: DEFAULT_BUILTIN_DEFINITIONS.typewriter.$default,
+        custom: { $type: "typewriter", $name: "custom", letter_pause: 0.05 },
+      },
+    };
+    applyBuiltinDefaults(context);
+    const t = context.typewriter.custom;
+    expect(t.letter_pause).toBe(0.05);
+    expect(t.phrase_pause_scale).toBe(5);
+    expect(t.em_dash_pause_scale).toBe(16);
+    expect(t.stressed_pause_scale).toBe(10);
+    expect(t.punctuated_pause_scale).toBe(15);
+    expect(t.min_syllable_length).toBe(3);
+  });
+
+  it("gives a partial synth a complete envelope", () => {
+    const context: any = {
+      synth: {
+        $default: DEFAULT_BUILTIN_DEFINITIONS.synth.$default,
+        raffles: {
+          $type: "synth",
+          $name: "raffles",
+          pitch: { frequency: 340 },
+        },
+      },
+    };
+    applyBuiltinDefaults(context);
+    const s = context.synth.raffles;
+    expect(s.pitch.frequency).toBe(340);
+    expect(s.pitch.frequency_ramp).toBe(0);
+    expect(s.shape).toBe("triangle");
+    expect(s.envelope.attack).toBeGreaterThan(0);
+  });
+});

--- a/packages/spark-engine/src/game/core/utils/applyBuiltinDefaults.ts
+++ b/packages/spark-engine/src/game/core/utils/applyBuiltinDefaults.ts
@@ -1,0 +1,85 @@
+const isPlainObject = (v: unknown): v is Record<string, any> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+
+/**
+ * Identity fields belong to the instance, never to the type it inherits from.
+ * Everything else on `$default` is fair game, including `$link`.
+ */
+const IDENTITY_KEYS = new Set(["$type", "$name"]);
+
+/**
+ * Deep-fills `value` with anything `defaults` has that `value` does not.
+ *
+ * Authored values always win, and only ever at the leaf: authoring one field
+ * of a nested group keeps the rest of that group's defaults rather than
+ * replacing the whole group. Arrays are treated as leaves -- an authored list
+ * replaces the default list wholesale rather than merging element-wise, since
+ * position-merging two lists is never what an author means.
+ *
+ * Returns a new object; neither input is mutated.
+ */
+export const inheritDefaults = <T>(value: T, defaults: unknown): T => {
+  if (!isPlainObject(defaults)) {
+    return value;
+  }
+  if (!isPlainObject(value)) {
+    // No authored struct at all -- the defaults ARE the value.
+    return (value === undefined ? structuredClone(defaults) : value) as T;
+  }
+  const result: Record<string, any> = { ...value };
+  for (const [key, defaultValue] of Object.entries(defaults)) {
+    if (IDENTITY_KEYS.has(key)) {
+      continue;
+    }
+    const authored = result[key];
+    if (authored === undefined) {
+      // Clone anything with identity. Handing out the builtin's own array or
+      // object would alias it across every define that inherits it, so one
+      // instance mutating its arpeggio tones would rewrite the type default
+      // and every sibling along with it.
+      result[key] =
+        typeof defaultValue === "object" && defaultValue !== null
+          ? structuredClone(defaultValue)
+          : defaultValue;
+    } else if (isPlainObject(authored) && isPlainObject(defaultValue)) {
+      result[key] = inheritDefaults(authored, defaultValue);
+    }
+  }
+  return result as T;
+};
+
+/**
+ * Makes every authored define in a game context inherit its type's defaults.
+ *
+ * A `define x as synth with ... end` reaches the runtime carrying ONLY the
+ * properties the author actually wrote -- nothing upstream merges the type's
+ * defaults in. The builtin structs look complete only because they are built
+ * by calling their `default_*()` constructor. So a voice authored as just
+ * `pitch = { frequency = 340 }` arrives with no shape, no envelope and no
+ * volume, and every consumer has to guess (#268).
+ *
+ * The type's own `$default` struct is already sitting in the context next to
+ * the authored ones, so inheritance is resolvable here without knowing
+ * anything about particular types. Types whose `$default` carries no real
+ * properties -- the structural UI ones like `style`, `screen` and `component`,
+ * where being sparse IS the semantics -- come out untouched.
+ *
+ * Mutates `context` in place, since it is the freshly-built context object.
+ */
+export const applyBuiltinDefaults = (context: Record<string, any>): void => {
+  for (const [type, structs] of Object.entries(context)) {
+    if (!isPlainObject(structs)) {
+      continue;
+    }
+    const defaults = structs["$default"];
+    if (!isPlainObject(defaults)) {
+      continue;
+    }
+    for (const [name, struct] of Object.entries(structs)) {
+      if (name === "$default" || !isPlainObject(struct)) {
+        continue;
+      }
+      structs[name] = inheritDefaults(struct, defaults);
+    }
+  }
+};

--- a/packages/spark-engine/src/game/modules/audio/classes/AudioModule.test.ts
+++ b/packages/spark-engine/src/game/modules/audio/classes/AudioModule.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Game } from "../../../core/classes/Game";
+import { applyBuiltinDefaults } from "../../../core/utils/applyBuiltinDefaults";
 import { audioBuiltinDefinitions } from "../audioBuiltinDefinitions";
 import { AudioModule } from "./AudioModule";
 
@@ -21,17 +22,22 @@ class ProbeAudioModule extends AudioModule {
   }
 }
 
+/**
+ * Builds the context the way `Game` does: authored defines are merged in
+ * sparse, then completed against their type's `$default` before any module
+ * sees them. Going through `applyBuiltinDefaults` here rather than
+ * hand-completing the fixtures keeps these tests honest about the real path.
+ */
 const createModule = (synths: Record<string, any>) => {
-  const game = {
-    context: {
-      system: {},
-      config: {},
-      // The builtins are full objects because they are built by calling
-      // `default_synth()`; the authored ones deliberately are not.
-      synth: { ...audioBuiltinDefinitions().synth, ...synths },
-    },
-  } as unknown as Game;
-  return new ProbeAudioModule(game);
+  const context: any = {
+    system: {},
+    config: {},
+    // The builtins are full objects because they are built by calling
+    // `default_synth()`; the authored ones deliberately are not.
+    synth: { ...audioBuiltinDefinitions().synth, ...synths },
+  };
+  applyBuiltinDefaults(context);
+  return new ProbeAudioModule({ context } as unknown as Game);
 };
 
 /** A voice authored with nothing but a pitch -- the shape #268 reported. */
@@ -105,6 +111,36 @@ describe("AudioModule synth resolution (#268)", () => {
       const m = createModule({});
       const builtin = audioBuiltinDefinitions().synth.character;
       expect(m.resolve(ref("character"))!.synth).toEqual(builtin);
+    });
+  });
+
+  describe("synth detection is a question about type", () => {
+    /**
+     * DEFENCE IN DEPTH, not the production path. Since `Game` completes every
+     * define, a synth arriving here always has `shape` and the old
+     * `"shape" in resolvedAsset` gate would pass too -- reverting it does not
+     * fail any other test in this repo, and I would rather say so than imply
+     * this carries the fix.
+     *
+     * It earns its place by making the module correct on its own terms: these
+     * contexts are built WITHOUT `applyBuiltinDefaults`, which is what any
+     * caller constructing a context by hand gets. Identifying a synth by the
+     * one property someone happened to author is how #268 turned a sparse
+     * define into total silence.
+     */
+    const rawModule = (synths: Record<string, any>) =>
+      new ProbeAudioModule({
+        context: { system: {}, config: {}, synth: synths },
+      } as unknown as Game);
+
+    it("recognises a synth with no `shape` in an uncompleted context", () => {
+      const m = rawModule({ raffles: PARTIAL_SYNTH });
+      expect(m.resolve(ref("raffles"))?.synth).toBeDefined();
+    });
+
+    it("hands that synth through exactly as given", () => {
+      const m = rawModule({ raffles: PARTIAL_SYNTH });
+      expect(m.resolve(ref("raffles"))!.synth).toEqual(PARTIAL_SYNTH);
     });
   });
 

--- a/packages/spark-engine/src/game/modules/audio/classes/AudioModule.test.ts
+++ b/packages/spark-engine/src/game/modules/audio/classes/AudioModule.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import type { Game } from "../../../core/classes/Game";
+import { audioBuiltinDefinitions } from "../audioBuiltinDefinitions";
+import { AudioModule } from "./AudioModule";
+
+/**
+ * A character voice authored as `define x as synth with ... end` reaches the
+ * runtime context carrying ONLY the properties the author wrote -- nothing
+ * merges the `synth` type's defaults in along the way. These tests pin that
+ * such a synth still plays (#268).
+ *
+ * They assert on the synth the module hands to the audio player, because that
+ * is the thing the player synthesises from. What made #268 silent was not a
+ * wrong value but a MISSING one: `d.synth` was never assigned at all.
+ */
+
+/** Exposes the protected resolution path under test. */
+class ProbeAudioModule extends AudioModule {
+  resolve(asset: unknown, suffix = "") {
+    return (this as any).getData("sound", asset, suffix);
+  }
+}
+
+const createModule = (synths: Record<string, any>) => {
+  const game = {
+    context: {
+      system: {},
+      config: {},
+      // The builtins are full objects because they are built by calling
+      // `default_synth()`; the authored ones deliberately are not.
+      synth: { ...audioBuiltinDefinitions().synth, ...synths },
+    },
+  } as unknown as Game;
+  return new ProbeAudioModule(game);
+};
+
+/** A voice authored with nothing but a pitch -- the shape #268 reported. */
+const PARTIAL_SYNTH = {
+  $type: "synth",
+  $name: "raffles",
+  pitch: { frequency: 340 },
+};
+
+/** A voice that happens to author `shape`, so it passed the old gate. */
+const SHAPE_ONLY_SYNTH = {
+  $type: "synth",
+  $name: "operator",
+  shape: "sawtooth",
+};
+
+const ref = (name: string) => ({ $type: "synth", $name: name });
+
+describe("AudioModule synth resolution (#268)", () => {
+  describe("partially-authored synths", () => {
+    it("attaches a synth authored with only a pitch", () => {
+      // The regression itself: this used to be undefined, so nothing played.
+      const m = createModule({ raffles: PARTIAL_SYNTH });
+      expect(m.resolve(ref("raffles"))?.synth).toBeDefined();
+    });
+
+    it("fills in the defaults the author did not write", () => {
+      const m = createModule({ raffles: PARTIAL_SYNTH });
+      const synth = m.resolve(ref("raffles"))!.synth!;
+      expect(synth.shape).toBe("triangle");
+      expect(synth.volume).toBe(0.5);
+      expect(synth.envelope).toBeDefined();
+      expect(synth.envelope.attack).toBeGreaterThan(0);
+    });
+
+    it("keeps the authored values, and the untouched siblings beside them", () => {
+      const m = createModule({ raffles: PARTIAL_SYNTH });
+      const synth = m.resolve(ref("raffles"))!.synth!;
+      expect(synth.pitch.frequency).toBe(340);
+      // Deep-merged, not replaced wholesale.
+      expect(synth.pitch.frequency_ramp).toBe(0);
+    });
+
+    it("preserves identity", () => {
+      const m = createModule({ raffles: PARTIAL_SYNTH });
+      const synth = m.resolve(ref("raffles"))!.synth!;
+      expect(synth.$name).toBe("raffles");
+      expect(synth.$type).toBe("synth");
+    });
+
+    it("completes a synth that authored only `shape` (the case that used to pass the gate)", () => {
+      // These played before the fix, but sparsely -- no envelope, no volume.
+      const m = createModule({ operator: SHAPE_ONLY_SYNTH });
+      const synth = m.resolve(ref("operator"))!.synth!;
+      expect(synth.shape).toBe("sawtooth");
+      expect(synth.volume).toBe(0.5);
+      expect(synth.envelope).toBeDefined();
+    });
+  });
+
+  describe("builtin synths", () => {
+    it("still resolves the builtin character voice", () => {
+      const m = createModule({});
+      const synth = m.resolve(ref("character"))!.synth!;
+      expect(synth).toBeDefined();
+      expect(synth.shape).toBeDefined();
+      expect(synth.envelope).toBeDefined();
+    });
+
+    it("leaves an already-complete builtin unchanged", () => {
+      const m = createModule({});
+      const builtin = audioBuiltinDefinitions().synth.character;
+      expect(m.resolve(ref("character"))!.synth).toEqual(builtin);
+    });
+  });
+
+  describe("non-synth assets", () => {
+    it("does not attach a synth to a plain audio asset", () => {
+      const game = {
+        context: {
+          system: {},
+          config: {},
+          audio: {
+            music: { $type: "audio", $name: "music", src: "music.mp3" },
+          },
+        },
+      } as unknown as Game;
+      const m = new ProbeAudioModule(game);
+      const d = m.resolve({ $type: "audio", $name: "music" })!;
+      expect(d.synth).toBeUndefined();
+      expect(d.src).toBe("music.mp3");
+    });
+  });
+});

--- a/packages/spark-engine/src/game/modules/audio/classes/AudioModule.ts
+++ b/packages/spark-engine/src/game/modules/audio/classes/AudioModule.ts
@@ -4,6 +4,7 @@ import {
   AudioBuiltins,
   audioBuiltinDefinitions,
 } from "../audioBuiltinDefinitions";
+import { default_synth } from "../constructors/default_synth";
 import { AudioPlayerUpdate } from "../types/AudioPlayerUpdate";
 import { ChannelState } from "../types/ChannelState";
 import { LoadAudioPlayerParams } from "../types/LoadAudioPlayerParams";
@@ -18,6 +19,14 @@ import {
   UpdateAudioPlayersMessage,
   UpdateAudioPlayersMessageMap,
 } from "./messages/UpdateAudioPlayersMessage";
+
+/**
+ * A context entry is a synth if it says so, or if it was looked up under the
+ * `synth` type. The `$type` check is the reliable one; the `type` fallback
+ * covers entries reached through a path that resolved the type separately.
+ */
+const isSynth = (asset: object, type: string): boolean =>
+  ("$type" in asset && asset.$type === "synth") || type === "synth";
 
 export interface AudioConfig {}
 
@@ -206,8 +215,21 @@ export class AudioModule extends Module<
         if ("loop_end" in resolvedAsset) {
           d.loopEnd = resolvedAsset.loop_end;
         }
-        if ("shape" in resolvedAsset) {
-          d.synth = resolvedAsset as Synth;
+        if (isSynth(resolvedAsset, d.type)) {
+          // Fill in the type's defaults. A `define x as synth with ... end`
+          // reaches the context carrying ONLY the properties the author
+          // actually wrote -- nothing merges the `synth` constructor's
+          // defaults in on the way -- so a voice authored as just
+          // `pitch = { frequency = 340 }` arrives without `shape`, without an
+          // envelope, and without a volume. The builtin synths look complete
+          // only because they are built by calling `default_synth()`.
+          //
+          // This used to gate on `"shape" in resolvedAsset`, which silently
+          // dropped every partially-authored synth: `d.synth` was never set,
+          // so the tone events played nothing at all. Detect synths by their
+          // type instead, and give them the same complete shape the builtins
+          // get.
+          d.synth = default_synth(resolvedAsset as Synth);
         }
         d.tones = this.parseTones(d.key);
       }

--- a/packages/spark-engine/src/game/modules/audio/classes/AudioModule.ts
+++ b/packages/spark-engine/src/game/modules/audio/classes/AudioModule.ts
@@ -4,7 +4,6 @@ import {
   AudioBuiltins,
   audioBuiltinDefinitions,
 } from "../audioBuiltinDefinitions";
-import { default_synth } from "../constructors/default_synth";
 import { AudioPlayerUpdate } from "../types/AudioPlayerUpdate";
 import { ChannelState } from "../types/ChannelState";
 import { LoadAudioPlayerParams } from "../types/LoadAudioPlayerParams";
@@ -216,20 +215,15 @@ export class AudioModule extends Module<
           d.loopEnd = resolvedAsset.loop_end;
         }
         if (isSynth(resolvedAsset, d.type)) {
-          // Fill in the type's defaults. A `define x as synth with ... end`
-          // reaches the context carrying ONLY the properties the author
-          // actually wrote -- nothing merges the `synth` constructor's
-          // defaults in on the way -- so a voice authored as just
-          // `pitch = { frequency = 340 }` arrives without `shape`, without an
-          // envelope, and without a volume. The builtin synths look complete
-          // only because they are built by calling `default_synth()`.
-          //
           // This used to gate on `"shape" in resolvedAsset`, which silently
           // dropped every partially-authored synth: `d.synth` was never set,
-          // so the tone events played nothing at all. Detect synths by their
-          // type instead, and give them the same complete shape the builtins
-          // get.
-          d.synth = default_synth(resolvedAsset as Synth);
+          // so the tone events played nothing at all (#268). Whether a thing
+          // is a synth is a question about its type, not about which
+          // properties its author happened to write.
+          //
+          // The struct is already complete by this point -- `Game` makes every
+          // define inherit its type's `$default` when it builds the context.
+          d.synth = resolvedAsset as Synth;
         }
         d.tones = this.parseTones(d.key);
       }

--- a/packages/spark-engine/src/game/modules/interpreter/classes/InterpreterModule.ts
+++ b/packages/spark-engine/src/game/modules/interpreter/classes/InterpreterModule.ts
@@ -1,7 +1,5 @@
 import { getCharacterIdentifier } from "@impower/sparkdown/src/compiler/utils/getCharacterIdentifier";
 import { Module } from "../../../core/classes/Module";
-import { default_synth } from "../../audio/constructors/default_synth";
-import type { Synth } from "../../audio/types/Synth";
 import {
   AudioInstruction,
   ImageInstruction,
@@ -427,20 +425,18 @@ export class InterpreterModule extends Module<
     return "$default";
   }
 
-  protected getMinSynthDuration(synth: Partial<Synth> | undefined) {
-    // A `define x as synth with ... end` reaches the context carrying only the
-    // properties the author wrote, so a voice authored as just
-    // `pitch = { frequency = 340 }` arrives with no envelope at all. Reading
-    // it raw returned 0 here, which under-sizes the syllable length -- while
-    // AudioModule plays that same synth with the type's default envelope. Fill
-    // the defaults in so both agree on the note's length (#268).
-    const synthEnvelope = default_synth(synth as Synth).envelope;
-    return (
-      (synthEnvelope.attack ?? 0) +
-      (synthEnvelope.decay ?? 0) +
-      (synthEnvelope.sustain ?? 0) +
-      (synthEnvelope.release ?? 0)
-    );
+  protected getMinSynthDuration(synth: { envelope?: Record<string, number> }) {
+    // The synth arrives complete -- `Game` makes every define inherit its
+    // type's `$default` when it builds the context -- so an authored voice
+    // that never wrote an envelope still has the type's one here, and this
+    // duration agrees with what AudioModule actually plays (#268).
+    const synthEnvelope = synth?.envelope;
+    return synthEnvelope
+      ? (synthEnvelope.attack ?? 0) +
+          (synthEnvelope.decay ?? 0) +
+          (synthEnvelope.sustain ?? 0) +
+          (synthEnvelope.release ?? 0)
+      : 0;
   }
 
   protected createImageChunk(imageTagContent: string): Chunk {

--- a/packages/spark-engine/src/game/modules/interpreter/classes/InterpreterModule.ts
+++ b/packages/spark-engine/src/game/modules/interpreter/classes/InterpreterModule.ts
@@ -1,5 +1,7 @@
 import { getCharacterIdentifier } from "@impower/sparkdown/src/compiler/utils/getCharacterIdentifier";
 import { Module } from "../../../core/classes/Module";
+import { default_synth } from "../../audio/constructors/default_synth";
+import type { Synth } from "../../audio/types/Synth";
 import {
   AudioInstruction,
   ImageInstruction,
@@ -425,21 +427,20 @@ export class InterpreterModule extends Module<
     return "$default";
   }
 
-  protected getMinSynthDuration(synth: {
-    envelope: {
-      attack: number;
-      decay: number;
-      sustain: number;
-      release: number;
-    };
-  }) {
-    const synthEnvelope = synth?.envelope;
-    return synthEnvelope
-      ? (synthEnvelope.attack ?? 0) +
-          (synthEnvelope.decay ?? 0) +
-          (synthEnvelope.sustain ?? 0) +
-          (synthEnvelope.release ?? 0)
-      : 0;
+  protected getMinSynthDuration(synth: Partial<Synth> | undefined) {
+    // A `define x as synth with ... end` reaches the context carrying only the
+    // properties the author wrote, so a voice authored as just
+    // `pitch = { frequency = 340 }` arrives with no envelope at all. Reading
+    // it raw returned 0 here, which under-sizes the syllable length -- while
+    // AudioModule plays that same synth with the type's default envelope. Fill
+    // the defaults in so both agree on the note's length (#268).
+    const synthEnvelope = default_synth(synth as Synth).envelope;
+    return (
+      (synthEnvelope.attack ?? 0) +
+      (synthEnvelope.decay ?? 0) +
+      (synthEnvelope.sustain ?? 0) +
+      (synthEnvelope.release ?? 0)
+    );
   }
 
   protected createImageChunk(imageTagContent: string): Chunk {

--- a/packages/spark-engine/src/game/modules/synthDefaults.test.ts
+++ b/packages/spark-engine/src/game/modules/synthDefaults.test.ts
@@ -1,7 +1,9 @@
 import { SparkdownCompiler } from "@impower/sparkdown/src/compiler/classes/SparkdownCompiler";
 import { describe, expect, it } from "vitest";
-import type { Game } from "../core/classes/Game";
+import { Game } from "../core/classes/Game";
+import { applyBuiltinDefaults } from "../core/utils/applyBuiltinDefaults";
 import { AudioModule } from "./audio/classes/AudioModule";
+import { audioBuiltinDefinitions } from "./audio/audioBuiltinDefinitions";
 import { DEFAULT_BUILTIN_DEFINITIONS } from "./DEFAULT_BUILTIN_DEFINITIONS";
 import { InterpreterModule } from "./interpreter/classes/InterpreterModule";
 
@@ -16,8 +18,9 @@ import { InterpreterModule } from "./interpreter/classes/InterpreterModule";
  *
  * Before the fix they disagreed for any partially-authored voice: AudioModule
  * dropped it entirely (silence), and InterpreterModule read a duration of 0.
- * These tests pin the agreement rather than any particular number, so
- * retuning the defaults doesn't churn them.
+ * Both now read a context that `Game` has already completed, so these tests
+ * pin the agreement rather than any particular number -- retuning the defaults
+ * doesn't churn them.
  */
 
 /** A voice authored with nothing but a pitch -- the shape #268 reported. */
@@ -27,15 +30,20 @@ const PARTIAL_SYNTH = {
   pitch: { frequency: 340 },
 };
 
-const contextWith = (synth: Record<string, any>) =>
-  ({
-    context: {
-      system: {},
-      config: { interpreter: { directives: {} } },
-      character: {},
-      synth,
-    },
-  }) as unknown as Game;
+/** Builds a context the way `Game` does, defaults included. */
+const contextWith = (synth: Record<string, any>) => {
+  const context: any = {
+    system: {},
+    config: { interpreter: { directives: {} } },
+    character: {},
+    synth: { ...audioBuiltinDefinitions().synth, ...synth },
+  };
+  applyBuiltinDefaults(context);
+  return context;
+};
+
+const gameWith = (synth: Record<string, any>) =>
+  ({ context: contextWith(synth) }) as unknown as Game;
 
 class ProbeAudioModule extends AudioModule {
   synthFor(name: string) {
@@ -54,12 +62,14 @@ const envelopeDuration = (e: any) =>
   (e.attack ?? 0) + (e.decay ?? 0) + (e.sustain ?? 0) + (e.release ?? 0);
 
 describe("partially-authored synth defaults (#268)", () => {
-  const game = contextWith({ raffles: PARTIAL_SYNTH });
+  const game = gameWith({ raffles: PARTIAL_SYNTH });
+  /** What the modules actually see -- the completed struct, not the fixture. */
+  const resolved = (game as any).context.synth.raffles;
 
   it("the interpreter reports a non-zero note duration", () => {
     // Was 0: the authored synth has no envelope, and nothing filled one in.
     const interpreter = new ProbeInterpreterModule(game);
-    expect(interpreter.durationOf(PARTIAL_SYNTH)).toBeGreaterThan(0);
+    expect(interpreter.durationOf(resolved)).toBeGreaterThan(0);
   });
 
   it("the interpreter's duration matches the envelope the audio module plays", () => {
@@ -69,7 +79,7 @@ describe("partially-authored synth defaults (#268)", () => {
     const played = audio.synthFor("raffles");
     expect(played).toBeDefined();
 
-    expect(interpreter.durationOf(PARTIAL_SYNTH)).toBeCloseTo(
+    expect(interpreter.durationOf(resolved)).toBeCloseTo(
       envelopeDuration(played!.envelope),
       10,
     );
@@ -89,28 +99,24 @@ describe("partially-authored synth defaults (#268)", () => {
         level: 0.5,
       },
     };
-    const g = contextWith({ custom: complete });
+    const g = gameWith({ custom: complete });
     const audio = new ProbeAudioModule(g);
     const interpreter = new ProbeInterpreterModule(g);
+    const authored = (g as any).context.synth.custom;
 
-    expect(interpreter.durationOf(complete)).toBeCloseTo(1.0, 10);
-    expect(interpreter.durationOf(complete)).toBeCloseTo(
+    expect(interpreter.durationOf(authored)).toBeCloseTo(1.0, 10);
+    expect(interpreter.durationOf(authored)).toBeCloseTo(
       envelopeDuration(audio.synthFor("custom")!.envelope),
       10,
     );
-  });
-
-  it("a missing synth still yields a usable duration", () => {
-    const interpreter = new ProbeInterpreterModule(game);
-    expect(interpreter.durationOf(undefined)).toBeGreaterThan(0);
   });
 });
 
 /**
  * The fixtures above hand-write the sparse synth #268 reported. This block
  * closes the loop by taking the shape from the REAL compiler instead, so the
- * chain that actually ships -- authored script -> compiled context -> played
- * synth -- is what gets asserted.
+ * chain that actually ships -- authored script -> compiled context ->
+ * completed context -> played synth -- is what gets asserted.
  *
  * Note that "compiles the voice without the type's defaults" below is a
  * CHARACTERIZATION test: it pins what the compiler does today in order to
@@ -169,6 +175,7 @@ describe("end-to-end: authored voice through the real compiler (#268)", () => {
 
   it("plays that compiled voice with a complete synth", () => {
     const context = compileContext(SCRIPT);
+    applyBuiltinDefaults(context); // what `Game` does on the way in
     const audio = new ProbeAudioModule({ context } as unknown as Game);
 
     const synth = audio.synthFor("raffles");
@@ -183,9 +190,61 @@ describe("end-to-end: authored voice through the real compiler (#268)", () => {
     // `crawshay` is never defined, so the lookup misses and the builtin
     // character voice is used -- this is the path that always worked.
     const context = compileContext(SCRIPT);
+    applyBuiltinDefaults(context);
     const audio = new ProbeAudioModule({ context } as unknown as Game);
     const synth = audio.synthFor("character");
     expect(synth).toBeDefined();
     expect(synth!.envelope).toBeDefined();
+  });
+
+  /**
+   * Everything above calls `applyBuiltinDefaults` itself, so it would keep
+   * passing even if `Game` stopped calling it -- which is exactly the mutant
+   * that survived a first pass of this suite. These build a REAL `Game` and
+   * assert its context, so the wiring is what is under test.
+   */
+  describe("Game wires it in", () => {
+    const buildGame = () => {
+      const compiler = new SparkdownCompiler();
+      compiler.configure({
+        definitions: { builtins: DEFAULT_BUILTIN_DEFINITIONS },
+        files: [
+          {
+            uri: MAIN_URI,
+            type: "script",
+            name: "main",
+            ext: "sd",
+            text: SCRIPT,
+            version: 1,
+            languageId: "sparkdown",
+          },
+        ],
+      } as any);
+      const program = compiler.compile({
+        textDocument: { uri: MAIN_URI },
+      } as any).program;
+      return new Game({
+        program,
+        now: () => 0,
+        setTimeout: (handler: Function) => {
+          handler();
+          return 0;
+        },
+      } as never);
+    };
+
+    it("completes authored defines in the context it builds", () => {
+      const game = buildGame();
+      const raffles = (game.context as any).synth.raffles;
+      expect(raffles.pitch.frequency).toBe(340);
+      expect(raffles.shape).toBeDefined();
+      expect(raffles.envelope).toBeDefined();
+      expect(raffles.volume).toBeGreaterThan(0);
+    });
+
+    it("keeps each define's own identity", () => {
+      const game = buildGame();
+      expect((game.context as any).synth.raffles.$name).toBe("raffles");
+    });
   });
 });

--- a/packages/spark-engine/src/game/modules/synthDefaults.test.ts
+++ b/packages/spark-engine/src/game/modules/synthDefaults.test.ts
@@ -1,0 +1,191 @@
+import { SparkdownCompiler } from "@impower/sparkdown/src/compiler/classes/SparkdownCompiler";
+import { describe, expect, it } from "vitest";
+import type { Game } from "../core/classes/Game";
+import { AudioModule } from "./audio/classes/AudioModule";
+import { DEFAULT_BUILTIN_DEFINITIONS } from "./DEFAULT_BUILTIN_DEFINITIONS";
+import { InterpreterModule } from "./interpreter/classes/InterpreterModule";
+
+/**
+ * A `define x as synth with ... end` reaches the runtime context carrying only
+ * the properties the author wrote. Two modules consume that synth
+ * independently, and they have to agree about it (#268):
+ *
+ *   - AudioModule decides what to actually synthesise.
+ *   - InterpreterModule sizes syllables from the envelope, so the typewriter
+ *     paces letters to match how long a note really lasts.
+ *
+ * Before the fix they disagreed for any partially-authored voice: AudioModule
+ * dropped it entirely (silence), and InterpreterModule read a duration of 0.
+ * These tests pin the agreement rather than any particular number, so
+ * retuning the defaults doesn't churn them.
+ */
+
+/** A voice authored with nothing but a pitch -- the shape #268 reported. */
+const PARTIAL_SYNTH = {
+  $type: "synth",
+  $name: "raffles",
+  pitch: { frequency: 340 },
+};
+
+const contextWith = (synth: Record<string, any>) =>
+  ({
+    context: {
+      system: {},
+      config: { interpreter: { directives: {} } },
+      character: {},
+      synth,
+    },
+  }) as unknown as Game;
+
+class ProbeAudioModule extends AudioModule {
+  synthFor(name: string) {
+    return (this as any).getData("sound", { $type: "synth", $name: name }, "")
+      ?.synth;
+  }
+}
+
+class ProbeInterpreterModule extends InterpreterModule {
+  durationOf(synth: unknown) {
+    return (this as any).getMinSynthDuration(synth);
+  }
+}
+
+const envelopeDuration = (e: any) =>
+  (e.attack ?? 0) + (e.decay ?? 0) + (e.sustain ?? 0) + (e.release ?? 0);
+
+describe("partially-authored synth defaults (#268)", () => {
+  const game = contextWith({ raffles: PARTIAL_SYNTH });
+
+  it("the interpreter reports a non-zero note duration", () => {
+    // Was 0: the authored synth has no envelope, and nothing filled one in.
+    const interpreter = new ProbeInterpreterModule(game);
+    expect(interpreter.durationOf(PARTIAL_SYNTH)).toBeGreaterThan(0);
+  });
+
+  it("the interpreter's duration matches the envelope the audio module plays", () => {
+    const audio = new ProbeAudioModule(game);
+    const interpreter = new ProbeInterpreterModule(game);
+
+    const played = audio.synthFor("raffles");
+    expect(played).toBeDefined();
+
+    expect(interpreter.durationOf(PARTIAL_SYNTH)).toBeCloseTo(
+      envelopeDuration(played!.envelope),
+      10,
+    );
+  });
+
+  it("still agrees for a fully-specified synth", () => {
+    const complete = {
+      $type: "synth",
+      $name: "custom",
+      shape: "sawtooth",
+      envelope: {
+        offset: 0,
+        attack: 0.1,
+        decay: 0.2,
+        sustain: 0.3,
+        release: 0.4,
+        level: 0.5,
+      },
+    };
+    const g = contextWith({ custom: complete });
+    const audio = new ProbeAudioModule(g);
+    const interpreter = new ProbeInterpreterModule(g);
+
+    expect(interpreter.durationOf(complete)).toBeCloseTo(1.0, 10);
+    expect(interpreter.durationOf(complete)).toBeCloseTo(
+      envelopeDuration(audio.synthFor("custom")!.envelope),
+      10,
+    );
+  });
+
+  it("a missing synth still yields a usable duration", () => {
+    const interpreter = new ProbeInterpreterModule(game);
+    expect(interpreter.durationOf(undefined)).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * The fixtures above hand-write the sparse synth #268 reported. This block
+ * closes the loop by taking the shape from the REAL compiler instead, so the
+ * chain that actually ships -- authored script -> compiled context -> played
+ * synth -- is what gets asserted.
+ *
+ * Note that "compiles the voice without the type's defaults" below is a
+ * CHARACTERIZATION test: it pins what the compiler does today in order to
+ * document why the runtime has to fill defaults in at all. If it ever fails
+ * because the compiler started merging type defaults itself, that is an
+ * improvement, not a regression -- delete that test and check whether the
+ * runtime fill-in is still needed.
+ */
+describe("end-to-end: authored voice through the real compiler (#268)", () => {
+  const MAIN_URI = "file://proj/main.sd";
+
+  const compileContext = (text: string) => {
+    const compiler = new SparkdownCompiler();
+    compiler.configure({
+      definitions: { builtins: DEFAULT_BUILTIN_DEFINITIONS },
+      files: [
+        {
+          uri: MAIN_URI,
+          type: "script",
+          name: "main",
+          ext: "sd",
+          text,
+          version: 1,
+          languageId: "sparkdown",
+        },
+      ],
+    } as any);
+    return (compiler.compile({ textDocument: { uri: MAIN_URI } }).program as any)
+      .context;
+  };
+
+  const SCRIPT = [
+    "define raffles as character with",
+    '  name = "RAFFLES"',
+    "end",
+    "",
+    "define raffles as synth with",
+    "  pitch = {",
+    "    frequency = 340",
+    "  }",
+    "end",
+    "",
+    "RAFFLES:",
+    "\tDo I make a sound now?",
+    "",
+  ].join("\n");
+
+  it("compiles the voice without the type's defaults (the upstream cause)", () => {
+    const context = compileContext(SCRIPT);
+    const authored = context.synth.raffles;
+    expect(authored.pitch.frequency).toBe(340);
+    // Documents WHY the runtime has to fill defaults in: nothing upstream does.
+    expect(authored.shape).toBeUndefined();
+    expect(authored.envelope).toBeUndefined();
+  });
+
+  it("plays that compiled voice with a complete synth", () => {
+    const context = compileContext(SCRIPT);
+    const audio = new ProbeAudioModule({ context } as unknown as Game);
+
+    const synth = audio.synthFor("raffles");
+    expect(synth).toBeDefined();
+    expect(synth!.pitch.frequency).toBe(340);
+    expect(synth!.shape).toBeDefined();
+    expect(synth!.envelope).toBeDefined();
+    expect(synth!.volume).toBeGreaterThan(0);
+  });
+
+  it("a character with no authored voice still falls back to a builtin", () => {
+    // `crawshay` is never defined, so the lookup misses and the builtin
+    // character voice is used -- this is the path that always worked.
+    const context = compileContext(SCRIPT);
+    const audio = new ProbeAudioModule({ context } as unknown as Game);
+    const synth = audio.synthFor("character");
+    expect(synth).toBeDefined();
+    expect(synth!.envelope).toBeDefined();
+  });
+});


### PR DESCRIPTION
Fixes #268. Together with #207 this is what should make authored character voices audible — see "What this does and does not unblock".

**Scope note:** this started as a synth-only fix. Review asked whether other types inherit either, and they don't — so it now fixes the general case. Details below.

## Root cause

An authored `define x as <type>` reaches the runtime context carrying **only** the properties the author wrote. Nothing merges the type's defaults in. The builtin structs look complete only because they are built by calling their `default_*()` constructor.

Measured against the real compiler with `DEFAULT_BUILTIN_DEFINITIONS` supplied, exactly as the language server does — a define authoring one property loses:

| type | `$default` keys | missing |
| --- | --- | --- |
| synth | 18 | **17** |
| typewriter | 11 | **10** |
| transition | 2 | **2** |
| animation | 3 | **2** |
| image | 2 | 1 |

22 types have real defaults to lose. Six (`style`, `screen`, `component`, `theme`, `color`, `layer`) have `$default`s carrying no real properties at all — those are the structural UI types where being sparse *is* the semantics of a cascade, and they are unaffected either way.

## Why only synths looked broken

Synth was the type whose consumer failed *loudly*. `AudioModule` gated on `"shape" in resolvedAsset`, so a synth without that one property never got assigned to `d.synth` and the tone events played nothing — total silence. That explains the reported split exactly: characters *without* a defined voice beeped fine through the builtin fallback, while every character *with* an authored voice was mute.

The others fail quietly, through inline `?? fallback` reads — **and those fallbacks disagree with the defaults they stand in for**:

| typewriter property | builtin `$default` | inline fallback |
| --- | --- | --- |
| `phrase_pause_scale` | 5 | **1** |
| `em_dash_pause_scale` | 16 | **1** |
| `stressed_pause_scale` | 10 | **1** |
| `punctuated_pause_scale` | 15 | **1** |
| `min_syllable_length` | 3 | **0** |
| `animation_offset` | 0.06 | **0** |

So `define x as typewriter with letter_pause = 0.05 end` silently collapses every pause scale by 5–16×. No error, no silence, just wrong pacing that reads as a design choice. This is the same bug as #268; it just never got reported because it doesn't announce itself.

`InterpreterModule.getMinSynthDuration` was a third instance: it read `synth.envelope` raw and returned `0` when absent, sizing syllables against a zero-length note while AudioModule played that same synth with the default envelope.

## The fix

`Game` completes the context once, where it is built, before any module reads it. The type's `$default` is already sitting in the context beside the authored structs, so this needs no per-type knowledge and no constructor imports.

Semantics: authored values always win, and only at the leaf — authoring one field of a nested group keeps the rest of that group's defaults. Arrays are leaves (an authored list replaces the default list rather than merging element-wise). Inherited objects and arrays are cloned, or every define sharing a default would alias the builtin and corrupt its siblings.

**Why the runtime and not the compiler.** #268 suggests merging compiler-side and calls that "probably the right one". Doing it there would put a full default object on every define in `program.context` — the payload #221 just shrank 9.2MB → 600KB per keystroke. Synth defaults alone are ~20 nested groups per voice. Doing it at context-build time costs nothing in the compiled program, and leaves the authored define recording what the author actually wrote, which is what lets tooling tell authored from inherited.

With this in place the per-module patches are no longer load-bearing, so both are reverted to their simpler forms and the `interpreter -> audio` import is gone.

## Verification

`packages/spark-engine`: **217 passed, 0 failed.** 31 new tests.

Mutation-tested — four mutants, all killed:

| mutant | failures |
| --- | --- |
| `Game` doesn't apply defaults | `Game wires it in > completes authored defines in the context it builds` |
| defaults clobber authored values | 8 across the util and AudioModule |
| shallow merge (no recursion) | 4, incl. `gives a partial synth a complete envelope` |
| restore `"shape" in` gate | 2 in `synth detection is a question about type` |

**Two of those mutants initially survived, and both were my own test-design failures — worth recording:**

1. The `Game` mutant passed the *entire* 213-test suite. Every module test called `applyBuiltinDefaults` itself, so nothing pinned that `Game` actually calls it. Fixed by building a real `Game` from a compiled program and asserting its context.
2. The `"shape" in` mutant passed too — once defines inherit, every synth has `shape`, so the old gate works. That change is **defence in depth, not part of the repair**, and its tests now say so explicitly and construct an uncompleted context to exercise it. I'd rather label it than imply it carries the fix.

My own test also caught a real aliasing bug while I wrote it: inherited *arrays* were assigned by reference, so two defines sharing a default array would corrupt each other and the builtin.

**Live** in the editor: the repro script renders and advances cleanly with zero console errors.

Two environmental scares, both investigated rather than assumed, in case they cost someone else time:
- `ReferenceError: applyBuiltinDefaults is not defined` from the game worker — a **stale worker bundle**. The built bundle was 33 minutes older than the source; a clean restart fixes it. There is no import cycle.
- The preview rendering no dialogue text — the Browser pane was backgrounded, which throttles the render loop. Bisecting with the fix disabled showed identical empty output, so it was never a regression.

## What this does and does not unblock

**I have no audio, so I could not confirm audibility.** What I verified is that a complete synth now reaches the player instead of being dropped.

This is also only half of what the live preview needs: without #207 there is no AudioContext in preview mode, so nothing plays regardless. This PR is orthogonal and applies to `main` on its own (it fixes standalone-player and exported builds too), but **the editor preview needs both**.

Filed #273 for an AnalyserNode-based debug readout plus an offline-render regression gate, which would make "is it actually audible" verifiable by test rather than by ear.
