### PR TITLE
feat: make audio verifiable — analyser probe + offline render gate

### DIFF
--- a/packages/spark-dom/src/classes/AudioMixer.ts
+++ b/packages/spark-dom/src/classes/AudioMixer.ts
@@ -1,3 +1,13 @@
+/** An instantaneous reading of what a mixer is actually outputting. */
+export interface AudioLevels {
+  /** Loudest sample magnitude in the current window. Catches a single click. */
+  peak: number;
+  /** Root mean square over the window. Catches sustained tone. */
+  rms: number;
+}
+
+const SILENT: AudioLevels = { peak: 0, rms: 0 };
+
 export default class AudioMixer {
   protected _audioContext: AudioContext;
   public get context(): AudioContext {
@@ -8,6 +18,24 @@ export default class AudioMixer {
   public get volumeNode(): GainNode {
     return this._volumeNode;
   }
+
+  /**
+   * Sits between the gain node and the destination, so what it reads is what
+   * this mixer is actually sending on -- AFTER its own gain. Reading before
+   * the gain would report a healthy signal for a mixer muted to zero, which
+   * is exactly the failure worth catching.
+   *
+   * An AnalyserNode is a pass-through: it observes without altering the
+   * signal, so this is safe to leave in place rather than wiring it up only
+   * when something is watching.
+   */
+  protected _analyser: AnalyserNode;
+  public get analyser(): AnalyserNode {
+    return this._analyser;
+  }
+
+  /** Scratch buffer, reused so that polling every frame allocates nothing. */
+  protected _samples: Float32Array;
 
   protected _gain = 1;
   public get gain() {
@@ -21,6 +49,31 @@ export default class AudioMixer {
   constructor(audioContext: AudioContext, destination?: AudioNode) {
     this._audioContext = audioContext;
     this._volumeNode = this._audioContext.createGain();
-    this._volumeNode.connect(destination ?? this._audioContext.destination);
+    this._analyser = this._audioContext.createAnalyser();
+    // Small enough to respond to a short beep rather than smearing it across
+    // a long window; large enough to be a stable reading.
+    this._analyser.fftSize = 2048;
+    this._samples = new Float32Array(this._analyser.fftSize);
+    this._volumeNode.connect(this._analyser);
+    this._analyser.connect(destination ?? this._audioContext.destination);
+  }
+
+  /** Measures what is passing through this mixer right now. */
+  readLevels(): AudioLevels {
+    if (!this._analyser.getFloatTimeDomainData) {
+      return SILENT;
+    }
+    this._analyser.getFloatTimeDomainData(this._samples);
+    let peak = 0;
+    let sumOfSquares = 0;
+    for (let i = 0; i < this._samples.length; i += 1) {
+      const sample = this._samples[i]!;
+      const magnitude = Math.abs(sample);
+      if (magnitude > peak) {
+        peak = magnitude;
+      }
+      sumOfSquares += sample * sample;
+    }
+    return { peak, rms: Math.sqrt(sumOfSquares / this._samples.length) };
   }
 }

--- a/packages/spark-engine/src/game/modules/audio/audioOutput.test.ts
+++ b/packages/spark-engine/src/game/modules/audio/audioOutput.test.ts
@@ -1,0 +1,243 @@
+import { SparkdownCompiler } from "@impower/sparkdown/src/compiler/classes/SparkdownCompiler";
+import { describe, expect, it } from "vitest";
+import { Game } from "../../core/classes/Game";
+import { DEFAULT_BUILTIN_DEFINITIONS } from "../DEFAULT_BUILTIN_DEFINITIONS";
+import { audioBuiltinDefinitions } from "./audioBuiltinDefinitions";
+import { SynthBuffer } from "./classes/helpers/SynthBuffer";
+import { LoadAudioPlayerParams } from "./types/LoadAudioPlayerParams";
+import { parseTones } from "./utils/parseTones";
+
+/**
+ * The audio regression gate (#273).
+ *
+ * Audio was the one part of the engine that could only be checked by
+ * listening to it, which is why #268 -- every character with an authored
+ * voice silent -- survived long enough to be mistaken for a problem with
+ * the missing preview AudioContext. Nothing threw and nothing logged; the
+ * synth was quietly dropped and the tone events played nothing.
+ *
+ * `SynthBuffer` is a pure renderer -- `Synth` + `Tone[]` + sample rate into a
+ * `Float32Array` -- so the actual samples can be measured headlessly, with no
+ * Web Audio API, no AudioContext and no speakers. That makes "did this make a
+ * sound" an ordinary assertion.
+ *
+ * These tests run a REAL `Game` over a script, capture the `audio/load`
+ * notifications it emits, and render them exactly the way `AudioManager` does
+ * in the player. So they cover the whole chain: compiler -> context ->
+ * inherited defaults -> interpreter -> AudioModule -> renderable samples.
+ *
+ * KNOWN LIMIT, worth stating plainly so this gate is not over-trusted: it
+ * measures the synthesised WAVEFORM, which is everything up to the point the
+ * player hands samples to Web Audio. It cannot see anything downstream of
+ * that. `synth.volume` in particular is not baked into these samples -- it
+ * travels as `params.volume` and is applied by gain nodes -- so a regression
+ * that zeroes a gain, mutes a mixer or wires the graph to the wrong
+ * destination renders identically here and is inaudible in practice. That
+ * territory belongs to the AnalyserNode tap in the other half of #273, which
+ * reads the real graph after gain. What can be checked at this layer is that
+ * the request itself asks for an audible level, which the last test does.
+ */
+
+const SAMPLE_RATE = 44100;
+
+/**
+ * Silence is exactly 0 here, and speech renders around 0.26 RMS, so this
+ * threshold is three orders of magnitude clear of both. It exists to catch
+ * "renders nothing", not to pin a mix level -- retuning the synths must not
+ * churn this file.
+ */
+const AUDIBLE_RMS = 0.01;
+
+const measure = (buffer: Float32Array) => {
+  let peak = 0;
+  let sumOfSquares = 0;
+  for (const sample of buffer) {
+    const magnitude = Math.abs(sample);
+    if (magnitude > peak) {
+      peak = magnitude;
+    }
+    sumOfSquares += sample * sample;
+  }
+  return {
+    peak,
+    rms: Math.sqrt(sumOfSquares / (buffer.length || 1)),
+    durationInSeconds: buffer.length / SAMPLE_RATE,
+  };
+};
+
+/** Renders one `audio/load` payload the way `AudioManager` does. */
+const render = (params: LoadAudioPlayerParams) => {
+  if (!params.synth || !params.tones) {
+    // The player takes the same branch: with no synth it falls through to a
+    // single empty sample, which is precisely how #268 sounded.
+    throw new Error(
+      `audio/load for "${params.key}" carries no ${
+        params.synth ? "tones" : "synth"
+      } -- the player would produce an empty buffer`,
+    );
+  }
+  return new SynthBuffer(params.synth, params.tones, SAMPLE_RATE).soundBuffer;
+};
+
+const MAIN_URI = "file://proj/main.sd";
+
+/** Runs a script through a real game and returns what it asked to play. */
+const audioEmittedBy = async (script: string) => {
+  const compiler = new SparkdownCompiler();
+  compiler.configure({
+    definitions: { builtins: DEFAULT_BUILTIN_DEFINITIONS },
+    files: [
+      {
+        uri: MAIN_URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text: script,
+        version: 1,
+        languageId: "sparkdown",
+      },
+    ],
+  } as any);
+  const program = compiler.compile({
+    textDocument: { uri: MAIN_URI },
+  } as any).program;
+
+  const game = new Game({
+    program,
+    now: () => 0,
+    setTimeout: (handler: Function) => {
+      handler();
+      return 0;
+    },
+  } as never);
+
+  const loads: LoadAudioPlayerParams[] = [];
+  game.connection.outgoing.addListener("*", (message: any) => {
+    if (message?.method === "audio/load") {
+      loads.push(message.params);
+    }
+  });
+
+  await game.start();
+  game.step();
+  game.continue();
+
+  return loads;
+};
+
+const AUTHORED_VOICE = [
+  "define raffles as character with",
+  '  name = "RAFFLES"',
+  "end",
+  "",
+  "define raffles as synth with",
+  "  pitch = {",
+  "    frequency = 340",
+  "  }",
+  "end",
+  "",
+  "RAFFLES:",
+  "\tDo I make a sound now?",
+  "",
+].join("\n");
+
+const NO_AUTHORED_VOICE = ["CRAWSHAY:", "\tI always did.", ""].join("\n");
+
+describe("a character speaking produces audible output", () => {
+  it("renders a non-silent buffer for an authored voice", async () => {
+    // The #268 regression: a voice authored with only a pitch was dropped
+    // before it ever reached the renderer, and the character was mute.
+    const loads = await audioEmittedBy(AUTHORED_VOICE);
+    expect(loads.length).toBeGreaterThan(0);
+
+    const { rms, peak } = measure(render(loads[0]!));
+    expect(rms).toBeGreaterThan(AUDIBLE_RMS);
+    expect(peak).toBeGreaterThan(AUDIBLE_RMS);
+  });
+
+  it("renders a non-silent buffer for a character with no authored voice", async () => {
+    // The builtin fallback path -- this one always worked, and it is what
+    // made #268 look like it only affected some characters.
+    const loads = await audioEmittedBy(NO_AUTHORED_VOICE);
+    expect(loads.length).toBeGreaterThan(0);
+    expect(measure(render(loads[0]!)).rms).toBeGreaterThan(AUDIBLE_RMS);
+  });
+
+  it("carries both a synth and tones, which is what the player requires", async () => {
+    // `AudioManager` gates on `params.synth && params.tones`; failing either
+    // silently yields a one-sample empty buffer rather than an error.
+    const loads = await audioEmittedBy(AUTHORED_VOICE);
+    for (const load of loads) {
+      expect(load.synth, load.key).toBeDefined();
+      expect(load.tones?.length, load.key).toBeGreaterThan(0);
+    }
+  });
+
+  it("asks the player for an audible level", async () => {
+    // The waveform above is measured BEFORE gain, so a synth silenced by
+    // volume alone would still render at full amplitude here. This is the
+    // part of that gap this layer can close: the load request itself must
+    // not ask for silence.
+    const loads = await audioEmittedBy(AUTHORED_VOICE);
+    for (const load of loads) {
+      expect(load.volume, load.key).toBeGreaterThan(0);
+    }
+  });
+
+  it("sounds for as long as the tones say it should", async () => {
+    // Guards the other way a note can be inaudible: it fires, but is cut to
+    // nothing. A sparse synth used to report a zero-length envelope.
+    const loads = await audioEmittedBy(AUTHORED_VOICE);
+    const { durationInSeconds } = measure(render(loads[0]!));
+    const lastToneAt = Math.max(...loads[0]!.tones!.map((t) => t.time ?? 0));
+    expect(durationInSeconds).toBeGreaterThan(lastToneAt);
+  });
+});
+
+describe("silence is distinguishable from breakage", () => {
+  /**
+   * Without this, "asserts non-silent" would be satisfied by a gate that
+   * cannot detect silence at all. `synth.none` is the builtin that is
+   * SUPPOSED to be inaudible.
+   */
+  it("renders the `none` synth as exactly silent", () => {
+    const tones = parseTones("t0s1b0~t0.075s1b0", "~");
+    const buffer = new SynthBuffer(
+      audioBuiltinDefinitions().synth.none,
+      tones,
+      SAMPLE_RATE,
+    );
+    const { rms, peak } = measure(buffer.soundBuffer);
+    expect(rms).toBe(0);
+    expect(peak).toBe(0);
+  });
+
+  it("renders an ordinary synth well above the threshold", () => {
+    const tones = parseTones("t0s1b0~t0.075s1b0", "~");
+    const buffer = new SynthBuffer(
+      audioBuiltinDefinitions().synth.character,
+      tones,
+      SAMPLE_RATE,
+    );
+    // Confirms the threshold has real headroom rather than sitting on the
+    // edge of what the synths happen to output.
+    expect(measure(buffer.soundBuffer).rms).toBeGreaterThan(AUDIBLE_RMS * 10);
+  });
+});
+
+describe("an incomplete synth never reaches the renderer", () => {
+  it("throws rather than rendering, if one ever does", () => {
+    // Found while building this gate: `SynthBuffer` does not degrade to
+    // silence on a sparse synth, it dereferences a missing envelope and
+    // throws. #268 was silent only because AudioModule dropped the struct
+    // earlier. Pinning it means a future regression is loud, not quiet.
+    const sparse: any = {
+      $type: "synth",
+      $name: "raffles",
+      pitch: { frequency: 340 },
+    };
+    expect(() =>
+      new SynthBuffer(sparse, parseTones("t0s1b0", "~"), SAMPLE_RATE),
+    ).toThrow();
+  });
+});

--- a/packages/spark-web-player/package.json
+++ b/packages/spark-web-player/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "node ./scripts/bundle-globals.ts",
     "watch": "node ./scripts/bundle-globals.ts --watch",
-    "package": "node ./scripts/bundle-globals.ts --production"
+    "package": "node ./scripts/bundle-globals.ts --production",
+    "test": "vitest run"
   },
   "dependencies": {
     "@impower/impower-ui": "file:../impower-ui",

--- a/packages/spark-web-player/src/app/managers/AudioManager.ts
+++ b/packages/spark-web-player/src/app/managers/AudioManager.ts
@@ -1,6 +1,7 @@
 import { RequestMessage } from "@impower/jsonrpc/src/common/types/RequestMessage";
 import AudioMixer from "../../../../spark-dom/src/classes/AudioMixer";
 import AudioPlayer from "../../../../spark-dom/src/classes/AudioPlayer";
+import AudioProbe from "./AudioProbe";
 import { SynthBuffer } from "../../../../spark-engine/src/game/modules/audio/classes/helpers/SynthBuffer";
 import { ConfigureAudioMixerMessage } from "../../../../spark-engine/src/game/modules/audio/classes/messages/ConfigureAudioMixerMessage";
 import { LoadAudioPlayerMessage } from "../../../../spark-engine/src/game/modules/audio/classes/messages/LoadAudioPlayerMessage";
@@ -35,7 +36,52 @@ export default class AudioManager extends Manager {
 
   protected _audioChannels = new Map<string, Map<string, AudioPlayer>>();
 
+  /**
+   * Measures what each mixer is actually outputting (#273). Audio is the one
+   * part of the engine that otherwise can only be checked by listening to it,
+   * which is how #268 -- every authored character voice silent -- went
+   * unnoticed. Started on demand; it costs nothing until someone asks.
+   */
+  protected _audioProbe = new AudioProbe(() => this._audioMixers.entries());
+  get audioProbe() {
+    return this._audioProbe;
+  }
+
+  override async onInit(): Promise<void> {
+    this.exposeAudioProbe();
+  }
+
+  /**
+   * Publishes the probe as `window.__audioProbe()` (#273).
+   *
+   * Deliberately a plain global rather than something behind the debugging
+   * toggle: the whole point is that anyone -- a developer at a console, or an
+   * agent that cannot hear -- can ask "is this making a sound?" in one call,
+   * without first having to find and enable a setting. It starts the sampler
+   * on first use, so it costs nothing until asked.
+   */
+  protected exposeAudioProbe(): void {
+    if (typeof window === "undefined") {
+      return;
+    }
+    (window as any).__audioProbe = () => {
+      if (!this._audioProbe.running) {
+        this._audioProbe.start();
+      }
+      return {
+        // Null means the game has no audio graph yet, which is a different
+        // problem from "the graph is silent" and worth telling apart.
+        audioContext: this.app.audioContext ? this.app.audioContext.state : null,
+        mixers: this._audioProbe.sample(),
+      };
+    };
+  }
+
   override onDispose() {
+    this._audioProbe.stop();
+    if (typeof window !== "undefined") {
+      delete (window as any).__audioProbe;
+    }
     this._audioMixers.clear();
     this._audioBuffers.clear();
     for (const c of this._audioChannels.values()) {
@@ -124,6 +170,12 @@ export default class AudioManager extends Manager {
         audioMixer.gain = gain;
       }
       this._audioMixers.set(mixer, audioMixer);
+      // Begin sampling as soon as there is an audio graph at all. Starting it
+      // lazily on the first `__audioProbe()` call would be too late to be
+      // useful: by the time anyone thinks to ask whether a line beeped, the
+      // beep is over, and `lastNonSilentAt` -- the field that exists to answer
+      // exactly that -- would still read null.
+      this._audioProbe.start();
       return audioMixer;
     }
     return undefined;

--- a/packages/spark-web-player/src/app/managers/AudioProbe.test.ts
+++ b/packages/spark-web-player/src/app/managers/AudioProbe.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import type AudioMixer from "../../../../spark-dom/src/classes/AudioMixer";
+import AudioProbe from "./AudioProbe";
+
+/**
+ * The probe is what makes audio answerable by someone who cannot hear it
+ * (#273), so its bookkeeping had better be right. `AudioProbe` takes its
+ * mixers by injection and only ever calls `readLevels()`, so none of this
+ * needs Web Audio -- a fake mixer is enough.
+ */
+
+/** A mixer whose output we drive by hand. */
+const fakeMixer = (levels: { rms: number; peak: number }) =>
+  ({
+    readLevels: () => levels,
+  }) as unknown as AudioMixer;
+
+/** A probe over mixers we can swap between samples, with a clock we control. */
+const createProbe = () => {
+  const mixers = new Map<string, AudioMixer>();
+  let now = 1000;
+  const probe = new AudioProbe(() => mixers.entries(), () => now);
+  return {
+    probe,
+    mixers,
+    set: (name: string, rms: number, peak = rms) =>
+      mixers.set(name, fakeMixer({ rms, peak })),
+    advance: (ms: number) => {
+      now += ms;
+    },
+    at: () => now,
+  };
+};
+
+describe("AudioProbe", () => {
+  describe("levels", () => {
+    it("reports each mixer separately", () => {
+      const h = createProbe();
+      h.set("main", 0.3);
+      h.set("music", 0.1);
+
+      const reading = h.probe.sample();
+
+      expect(reading["main"]!.rms).toBeCloseTo(0.3);
+      expect(reading["music"]!.rms).toBeCloseTo(0.1);
+    });
+
+    it("passes peak through alongside rms", () => {
+      // Peak catches a single click that barely moves the rms average.
+      const h = createProbe();
+      h.set("main", 0.001, 0.9);
+
+      const reading = h.probe.sample();
+
+      expect(reading["main"]!.peak).toBeCloseTo(0.9);
+    });
+  });
+
+  describe("lastNonSilentAt", () => {
+    it("is null before a mixer has ever made a sound", () => {
+      const h = createProbe();
+      h.set("main", 0);
+
+      expect(h.probe.sample()["main"]!.lastNonSilentAt).toBeNull();
+    });
+
+    it("records when a mixer became audible", () => {
+      const h = createProbe();
+      h.set("main", 0.3);
+
+      expect(h.probe.sample()["main"]!.lastNonSilentAt).toBe(h.at());
+    });
+
+    it("survives the mixer falling silent again", () => {
+      // The whole point of the field: a level read a moment too late is zero,
+      // but this still says the sound happened, and when.
+      const h = createProbe();
+      h.set("main", 0.3);
+      h.probe.sample();
+      const playedAt = h.at();
+
+      h.advance(500);
+      h.set("main", 0);
+      const reading = h.probe.sample()["main"]!;
+
+      expect(reading.rms).toBe(0);
+      expect(reading.lastNonSilentAt).toBe(playedAt);
+    });
+
+    it("moves forward each time the mixer sounds again", () => {
+      const h = createProbe();
+      h.set("main", 0.3);
+      h.probe.sample();
+
+      h.advance(500);
+      const secondTime = h.at();
+      h.probe.sample();
+
+      expect(h.probe.sample()["main"]!.lastNonSilentAt).toBe(secondTime);
+    });
+
+    it("treats denormal noise as silence", () => {
+      // Guards against a probe that calls anything above literal zero a
+      // sound, which would make `lastNonSilentAt` meaningless.
+      const h = createProbe();
+      h.set("main", 1e-9);
+
+      expect(h.probe.sample()["main"]!.lastNonSilentAt).toBeNull();
+    });
+
+    it("tracks each mixer's history independently", () => {
+      const h = createProbe();
+      h.set("voice", 0.3);
+      h.set("music", 0);
+      h.probe.sample();
+
+      const reading = h.probe.sample();
+      expect(reading["voice"]!.lastNonSilentAt).not.toBeNull();
+      expect(reading["music"]!.lastNonSilentAt).toBeNull();
+    });
+  });
+
+  describe("snapshot", () => {
+    it("does not hand out live internals", () => {
+      const h = createProbe();
+      h.set("main", 0.3);
+      h.probe.sample();
+
+      const snapshot = h.probe.snapshot();
+      snapshot["main"]!.rms = 999;
+
+      expect(h.probe.snapshot()["main"]!.rms).toBeCloseTo(0.3);
+    });
+
+    it("is empty before anything has been sampled", () => {
+      expect(createProbe().probe.snapshot()).toEqual({});
+    });
+  });
+
+  describe("lifecycle", () => {
+    it("is not running until started", () => {
+      expect(createProbe().probe.running).toBe(false);
+    });
+
+    it("can be sampled without starting the frame loop", () => {
+      // How a one-off console query works: no rAF, just a reading.
+      const h = createProbe();
+      h.set("main", 0.3);
+
+      expect(h.probe.sample()["main"]!.rms).toBeCloseTo(0.3);
+      expect(h.probe.running).toBe(false);
+    });
+
+    it("stopping an unstarted probe is harmless", () => {
+      expect(() => createProbe().probe.stop()).not.toThrow();
+    });
+  });
+});

--- a/packages/spark-web-player/src/app/managers/AudioProbe.ts
+++ b/packages/spark-web-player/src/app/managers/AudioProbe.ts
@@ -1,0 +1,95 @@
+import type AudioMixer from "../../../../spark-dom/src/classes/AudioMixer";
+import type { AudioLevels } from "../../../../spark-dom/src/classes/AudioMixer";
+
+export interface AudioProbeReading extends AudioLevels {
+  /**
+   * `performance.now()` of the last frame this mixer was audible, or null if
+   * it has not made a sound yet. This is the field that makes the probe
+   * useful after the fact: a level read a moment too late is zero, but this
+   * still says "it played, 40ms ago".
+   */
+  lastNonSilentAt: number | null;
+}
+
+export type AudioProbeSnapshot = Record<string, AudioProbeReading>;
+
+/**
+ * Anything below this is treated as silence. Digital silence is exactly 0
+ * and speech renders around 0.26 RMS, so this is far clear of both; it exists
+ * to ignore denormal noise, not to set a meaningful floor.
+ */
+const SILENCE_THRESHOLD = 1e-4;
+
+/**
+ * Samples every mixer's output once a frame and remembers when each last made
+ * a sound (#273).
+ *
+ * The point is that the readings are NUMBERS, not a drawing. A waveform can
+ * only be eyeballed by whoever is sitting in front of it; a number can be
+ * asserted on, polled from the console, and compared between runs -- which is
+ * what makes "are the beeps playing?" answerable by someone (or something)
+ * that cannot hear.
+ *
+ * Reading an AnalyserNode is a copy of its current window, so this is cheap
+ * and allocation-free per frame, but it still only runs while started.
+ */
+export default class AudioProbe {
+  protected _readings: AudioProbeSnapshot = {};
+
+  protected _frame: number | null = null;
+
+  protected _getMixers: () => Iterable<[string, AudioMixer]>;
+
+  protected _now: () => number;
+
+  constructor(
+    getMixers: () => Iterable<[string, AudioMixer]>,
+    now: () => number = () => performance.now(),
+  ) {
+    this._getMixers = getMixers;
+    this._now = now;
+  }
+
+  get running(): boolean {
+    return this._frame != null;
+  }
+
+  /** The latest reading for every mixer that has existed since `start()`. */
+  snapshot(): AudioProbeSnapshot {
+    return JSON.parse(JSON.stringify(this._readings));
+  }
+
+  /** Takes one reading. Exposed so a caller can poll without the rAF loop. */
+  sample(): AudioProbeSnapshot {
+    const now = this._now();
+    for (const [name, mixer] of this._getMixers()) {
+      const levels = mixer.readLevels();
+      const previous = this._readings[name];
+      const audible = levels.rms > SILENCE_THRESHOLD;
+      this._readings[name] = {
+        peak: levels.peak,
+        rms: levels.rms,
+        lastNonSilentAt: audible ? now : (previous?.lastNonSilentAt ?? null),
+      };
+    }
+    return this._readings;
+  }
+
+  start(): void {
+    if (this._frame != null || typeof requestAnimationFrame !== "function") {
+      return;
+    }
+    const tick = () => {
+      this.sample();
+      this._frame = requestAnimationFrame(tick);
+    };
+    this._frame = requestAnimationFrame(tick);
+  }
+
+  stop(): void {
+    if (this._frame != null) {
+      cancelAnimationFrame(this._frame);
+      this._frame = null;
+    }
+  }
+}

--- a/packages/spark-web-player/vitest.config.ts
+++ b/packages/spark-web-player/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    exclude: ["**/node_modules/**", "**/dist/**", "**/out/**"],
+  },
+});


### PR DESCRIPTION
Addresses #273 — makes audio verifiable without listening to it.

**Not the whole ticket:** the measurement layer and the regression gate are here; the *visual* meter in the Debugging overlay is not. See "What's left" at the bottom.

## Why

Audio was the one part of the engine that could only be checked by ear. That's how #268 — every character with an authored voice silent — survived long enough to be mistaken for a symptom of #207's missing AudioContext. Nothing threw, nothing logged; the synth was quietly dropped and the tone events played nothing.

## Part 2 — the regression gate (`audioOutput.test.ts`)

`SynthBuffer` turns out to be a **pure renderer**: `Synth` + `Tone[]` + sample rate → `Float32Array`, no Web Audio involved. So the samples can be measured headlessly, in CI, with no speakers.

These tests run a **real `Game`** over a script, capture the `audio/load` notifications it emits, and render them exactly the way `AudioManager` does — covering compiler → context → inherited defaults → interpreter → AudioModule → renderable samples.

**Verified against the bug it exists for.** Reintroducing #268 (drop the inherited defaults, restore the `"shape" in` gate) fails three of these with:

```
audio/load for "synth.raffles~t0s1b0~..." carries no synth
  -- the player would produce an empty buffer
```

…while the builtin-fallback test keeps passing — which is exactly the reported symptom, where only authored voices were mute.

Silence is asserted in **both** directions, so the gate can't be satisfied by something that has stopped detecting silence at all: `synth.none` must render to exactly zero, and an ordinary voice must clear the threshold tenfold. Thresholds come from measurement (silence 0.0, speech ~0.26 RMS), so 0.01 sits three orders of magnitude clear of both and doesn't pin a mix level.

Also pins a thing found while building it: a **sparse synth throws** rather than rendering quietly. #268 was silent only because AudioModule dropped the struct before it reached the renderer.

## Part 1 — the measurement layer

`AudioMixer` now carries an `AnalyserNode` **between its gain node and its destination**, so a reading reflects what that mixer actually sends on, *after* its own gain. That's deliberate: reading before the gain would report a healthy signal for a mixer muted to zero — and that's precisely the gap the offline gate cannot see, since `synth.volume` is applied by gain nodes and never reaches the sample buffer.

`AudioProbe` samples every mixer once a frame and records `lastNonSilentAt`. That field is the useful one — a level read a moment too late reads zero, but this still says the sound happened, and when.

Published as **`window.__audioProbe()`**, a plain global rather than something behind the debugging toggle, so anyone (or any agent that can't hear) can ask in one call without first finding a setting. It also reports AudioContext state, so "no audio graph yet" is distinguishable from "the graph is silent".

```js
window.__audioProbe()
// { audioContext: "running",
//   mixers: { main: { peak, rms, lastNonSilentAt }, sound: {...}, voice: {...}, ... } }
```

**A design bug I hit and fixed:** the probe originally started sampling on first query. Live, that meant `lastNonSilentAt` was always `null` — by the time you think to ask whether a line beeped, the beep is over. It now starts as soon as an audio graph exists.

## Verification

- `spark-engine`: **225 passed** (8 new).
- `spark-web-player`: **13 passed** — this package had no test setup, so this adds a vitest config. `AudioProbe` takes its mixers by injection and only calls `readLevels()`, so its bookkeeping is testable without Web Audio.

**Live, and this is the part worth reading:** playing a character whose voice is authored as a partial synth define — the exact #268 case — the probe measured

| mixer | peak | rms | lastNonSilentAt |
| --- | --- | --- | --- |
| `main` | 0.286 | 0.033 | 22503 |
| `sound` | non-zero | non-zero | 22503 |
| `voice`, `music`, `typewriter` | 0 | 0 | null |

That is the first direct confirmation that authored voices produce signal, rather than an inference from the data being correctly shaped. Also worth noting: `audioContext` reported `"running"` in the **editor preview**, which is worth a second look against #207's premise that preview has no context.

**Caveat, unchanged:** this proves signal reaches the destination node. It does not prove your speakers make noise — a muted system or wrong output device still reads as playing.

## What's left

The **visual meter in the Debugging overlay** is not built. The toolbar has a Debugging toggle, but it drives the engine's debug flag; there is no player-side overlay to hang a meter on, so it needs a small component plus wiring the debug state through to the player. I'd rather land the measurement layer — which is what actually unblocks verification, and what the gate depends on — than rush a UI I can't verify properly in the same pass.

Happy to do it next; the tap and readings it would draw from are all here.
