### PR TITLE
fix(screenplay-pdf): drop the exports map blocking deep src imports

### DIFF
--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -1,0 +1,54 @@
+name: Build VS Code Extension
+
+# Guards the extension's production build on pull requests.
+#
+# "Publish VS Code Extension" only runs on push to main, so a build break can
+# only be discovered AFTER it has merged -- and since the publish step is the
+# build, a break means no extension ships at all. That is exactly what
+# happened in #272: a deep `src/` import that the bundler could not resolve
+# landed on main and every run failed for days before anyone connected the
+# failure emails to the cause.
+#
+# This runs the same production build the publish does (`vscode:prepublish` ->
+# `npm run package`), minus anything that touches the Marketplace, so the same
+# class of break fails on the PR instead.
+
+on:
+  pull_request:
+    paths:
+      - "vscode-sparkdown/**"
+      - "packages/**"
+      - ".github/workflows/build-vscode-extension.yml"
+
+# A superseded PR build is of no interest; keep only the newest per branch.
+concurrency:
+  group: build-vscode-extension-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          # >= 23.6 required: the esbuild build scripts are run as .ts via
+          # Node's native type-stripping (node scripts/esbuild.ts).
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The build alone is what breaks in practice (module resolution, missing
+      # sources), and it is the step the publish would run. No VSCE_PAT is
+      # used or needed here -- nothing is published.
+      - name: Build extension
+        working-directory: vscode-sparkdown
+        run: npm run package

--- a/packages/sparkdown-screenplay-pdf/package.json
+++ b/packages/sparkdown-screenplay-pdf/package.json
@@ -7,16 +7,6 @@
   "engines": {
     "node": "*"
   },
-  "exports": {
-    ".": {
-      "require": "./dist/sparkdown-screenplay-pdf.js",
-      "import": "./dist/sparkdown-screenplay-pdf.js"
-    },
-    "./*": {
-      "require": "./dist/*",
-      "import": "./dist/*"
-    }
-  },
   "main": "dist/sparkdown-screenplay-pdf.js",
   "bin": {
     "sparkdown-pdf": "./dist/cli/buildPdfCli.cjs"


### PR DESCRIPTION
Fixes #272 — the source of the failure emails. This should be the last one.

## Confirmed still live

The diagnosis in #272 is a week old, so I re-checked before acting on it. Every run of `Publish VS Code Extension` is still failing, including the merges of #207, #261, #262, #267, #270 and #271 from the last few hours, all with the identical error. Reproduced locally byte-for-byte with `cd vscode-sparkdown && node scripts/esbuild.ts --production`:

```
✘ [ERROR] Could not resolve "@impower/sparkdown-screenplay-pdf/src/emoji/emojiHtml"
  The module "./dist/src/emoji/emojiHtml" was not found on the file system:
    ../node_modules/@impower/sparkdown-screenplay-pdf/package.json:17:16:
      17 │       "import": "./dist/*"
```

**No extension has shipped to the Marketplace since 2026-07-05**, because in this workflow the publish step *is* the build.

## The fix: remove the `exports` map

Deep `@impower/<pkg>/src/...` imports are the house convention and work everywhere else because no other `@impower` package declares `exports`. This one did, so `"./*": "./dist/*"` rewrote the src path into `dist/`, where sources don't live. The emoji import added in `9ac24c6db` followed the convention onto the one package where it can't work.

**Nothing depended on that map.** I checked every reference to the package in the repo:

| reference | resolves via |
| --- | --- |
| `exportHtml.ts` (the broken import) | the map — the only bare-specifier import anywhere |
| `impower-dev/vite.config.ts` | relative path to `src/` |
| `vscode-sparkdown/scripts/esbuild.ts` | file glob over `dist/*` |
| `sparkdown-pdf` CLI | `bin`, which does not resolve through `exports` |

`main` already points at the same dist bundle the `.` entry did, so `require.resolve("@impower/sparkdown-screenplay-pdf")` still returns `dist/sparkdown-screenplay-pdf.js` — verified.

## Why not widen the map

#272 offered widening as option 1 and flagged an open question about extension probing. I tested it, and the question resolves against it:

| attempt | result |
| --- | --- |
| `"./src/*": "./src/*"` | **still fails** — esbuild maps the path correctly (`./src/emoji/emojiHtml`) but does not probe extensions through an `exports` map |
| `"./src/*": "./src/*.ts"` | builds, but hard-codes a source extension into the manifest |
| remove `exports` | builds |

The `.ts` variant works only by accident of every file under `src/` currently being `.ts`. It breaks for `.tsx`, `.json` and directory-index imports, and mangles any specifier that already carries an extension (`foo.ts` → `foo.ts.ts`). Removing the map makes this package consistent with its siblings instead of adding a special case to the anomaly.

## Recurrence guard

Adds `.github/workflows/build-vscode-extension.yml`: the same production build, on PRs touching the same paths, publishing nothing.

The publish workflow only triggers on push to main, so a build break is undiscoverable until after it merges — and then the extension silently stops shipping while the failures look like an infrastructure problem. That's the actual cost here: the resolution bug was a one-line mistake, but it went 35+ runs and three weeks without a green publish.

## Verification

- Failure reproduces byte-for-byte before the change; `npm run package` exits 0 after it (all 8 sub-builds finish).
- The package's own `npm run build` still succeeds.
- Package-root resolution unchanged.
- The emoji code is genuinely **in** the extension bundle, not merely resolving: its `spark-emoji-char` and `spark-emoji se-` literals survive minification and appear in `out/extension.js`.

I have not published from this branch — the first green run on main will pick it up, and since the patch version is the workflow run number it'll ship as the next increment automatically.
