### PR TITLE
fix(player): only retract the audio probe this manager published

### DIFF
--- a/packages/spark-web-player/src/app/managers/AudioManager.ts
+++ b/packages/spark-web-player/src/app/managers/AudioManager.ts
@@ -60,11 +60,14 @@ export default class AudioManager extends Manager {
    * without first having to find and enable a setting. It starts the sampler
    * on first use, so it costs nothing until asked.
    */
+  /** The exact function this manager published, so it can tell its own apart. */
+  protected _exposedProbe?: () => unknown;
+
   protected exposeAudioProbe(): void {
     if (typeof window === "undefined") {
       return;
     }
-    (window as any).__audioProbe = () => {
+    this._exposedProbe = () => {
       if (!this._audioProbe.running) {
         this._audioProbe.start();
       }
@@ -75,11 +78,20 @@ export default class AudioManager extends Manager {
         mixers: this._audioProbe.sample(),
       };
     };
+    (window as any).__audioProbe = this._exposedProbe;
   }
 
   override onDispose() {
     this._audioProbe.stop();
-    if (typeof window !== "undefined") {
+    // Only retract our own. In preview the Application is rebuilt on every
+    // edit, so the outgoing manager's dispose can land AFTER the incoming
+    // one has published its probe -- deleting unconditionally would then wipe
+    // a live probe and leave `window.__audioProbe` undefined for the rest of
+    // the session, which is exactly what it looked like when this was found.
+    if (
+      typeof window !== "undefined" &&
+      (window as any).__audioProbe === this._exposedProbe
+    ) {
       delete (window as any).__audioProbe;
     }
     this._audioMixers.clear();


### PR DESCRIPTION
Follow-up to #274, which is already merged.

## The bug

`AudioManager.onDispose` deleted `window.__audioProbe` unconditionally. In preview the Application is rebuilt on **every edit**, so the outgoing manager's dispose can land *after* the incoming one has published its probe — deleting a live probe and leaving `window.__audioProbe` undefined for the rest of the session.

It now retracts only the function this instance installed, which is the same identity check as the `SingletonPromise` fix in #265.

## How it surfaced

While A/B-ing #207 I saw the probe present in one build and missing in the next with no relevant code difference between them. That pattern — the same code behaving differently across rebuilds — is the signature of teardown racing setup, not of anything to do with audio. Worth recording because the symptom looks exactly like "the probe is broken" and sends you hunting in the wrong place.

## Verification

`spark-web-player`: 13 passed.

Honest limit: the failure needs a preview Application reconstruction to land in a specific order, which I could not force deterministically in the browser, so this is reasoned from the code and from the observed symptom rather than from a reproduced race. The change can only ever *avoid* deleting something, never delete more, so the downside is bounded — worst case a stale probe outlives its manager, which is strictly better than a live one being wiped.
