### PR TITLE
fix(editor): make the file-drop overlay cover the content area

### DIFF
--- a/impower-dev/src/modules/spark-editor/components/file-dropzone/FileDropzone.tsx
+++ b/impower-dev/src/modules/spark-editor/components/file-dropzone/FileDropzone.tsx
@@ -9,8 +9,8 @@ export type FileDropzoneProps = Partial<typeof propDefaults>;
 /**
  * Window-level file-drop catcher. Two jobs:
  *
- *  1. ZIP = whole-project import. A single `.zip` dragged anywhere shows the
- *     full-page "Import Project Files" overlay and imports the project on drop.
+ *  1. ZIP = whole-project import. A single `.zip` dragged anywhere imports the
+ *     project on drop.
  *  2. Loose files = fallback. A drop ONTO a file list is claimed by that list
  *     (it routes the files into the hovered folder / current scope — see
  *     useExternalFileDrop). This window handler only catches loose-file drops
@@ -23,16 +23,19 @@ export type FileDropzoneProps = Partial<typeof propDefaults>;
  * list — that list rings the target folder itself, and two affordances at once
  * reads as a bug.
  *
+ * The wording is the same whichever kind of drag it is. Distinguishing them
+ * was tried and reverted: host-relayed drags (the game preview iframe) carry
+ * no MIME info, so they could only ever guess, and the label flipped between
+ * panes for the same file. One consistent phrase beats a label that is
+ * sometimes precise and sometimes wrong, and it reads correctly either way —
+ * importing a project, or importing files into your project.
+ *
  * Also handles DraggedFilesIn/Over/Out/DroppedFiles protocol messages relayed by
  * an embedding host (e.g. VS Code), which can't carry MIME info, so those keep
  * the overlay + the by-type fallback routing.
  */
 export default function FileDropzone(_props: FileDropzoneProps) {
-  // null = no overlay. "project" = single zip (whole-project import),
-  // "files" = loose files. The distinction is only ever cosmetic here -- the
-  // drop handlers re-derive it from the real filenames, which are readable
-  // then but hidden mid-drag.
-  const [dragging, setDragging] = useState<null | "project" | "files">(null);
+  const [dragging, setDragging] = useState(false);
   // Keep the latest setter reachable from imperative listeners without
   // re-binding them on every render.
   const draggingRef = useRef(dragging);
@@ -49,15 +52,15 @@ export default function FileDropzone(_props: FileDropzoneProps) {
     // inside the iframe, or the host stops relaying -- and without this the
     // overlay stays up forever with no drag behind it.
     const relayDragging = () => {
-      setDragging("project");
+      setDragging(true);
       if (overlayTimer) clearTimeout(overlayTimer);
-      overlayTimer = window.setTimeout(() => setDragging(null), 150);
+      overlayTimer = window.setTimeout(() => setDragging(false), 150);
     };
     const dragEnter = () => relayDragging();
     const dragLeave = () => {
       if (overlayTimer) clearTimeout(overlayTimer);
       overlayTimer = 0;
-      setDragging(null);
+      setDragging(false);
     };
     const dragOver = () => relayDragging();
 
@@ -67,7 +70,7 @@ export default function FileDropzone(_props: FileDropzoneProps) {
     const handleDrop = async (
       items: { name: string; getBuffer: () => Promise<ArrayBuffer> }[],
     ) => {
-      setDragging(null);
+      setDragging(false);
       const { Workspace } = await import("../../workspace/Workspace");
       const store = (await import("../../workspace/WorkspaceStore")).default
         .state.value;
@@ -88,7 +91,10 @@ export default function FileDropzone(_props: FileDropzoneProps) {
       };
       await importDroppedFiles(
         projectId,
-        items.map((it) => ({ rel: targetRel(it.name), getBuffer: it.getBuffer })),
+        items.map((it) => ({
+          rel: targetRel(it.name),
+          getBuffer: it.getBuffer,
+        })),
       );
     };
 
@@ -97,17 +103,6 @@ export default function FileDropzone(_props: FileDropzoneProps) {
     // not `Files`, so it must not trigger the overlay or steal the drop.
     const carriesFiles = (e: DragEvent) =>
       Array.from(e.dataTransfer?.types ?? []).includes("Files");
-
-    // Best-effort "single .zip" check from the only thing readable mid-drag —
-    // each item's MIME `type` (filenames are hidden until drop). A zip with an
-    // empty/unknown MIME falls through (no overlay), but the drop still imports
-    // it as a project by filename. Drives the full-page overlay: zips only.
-    const isZipDrag = (e: DragEvent) => {
-      const dt = e.dataTransfer;
-      if (!dt) return false;
-      const items = Array.from(dt.items).filter((i) => i.kind === "file");
-      return items.length === 1 && /zip/i.test(items[0]?.type ?? "");
-    };
 
     // The overlay is kept alive by the continuous `dragover` stream and cleared by
     // a short idle timeout. This is robust against BOTH the interior-boundary
@@ -118,20 +113,17 @@ export default function FileDropzone(_props: FileDropzoneProps) {
     let overlayTimer = 0;
     // A drag sitting over a file list belongs to that list's own highlight.
     const overFileList = (e: DragEvent) =>
-      e.target instanceof Element && !!e.target.closest("[data-file-drop-target]");
+      e.target instanceof Element &&
+      !!e.target.closest("[data-file-drop-target]");
 
     const refreshOverlay = (e: DragEvent) => {
-      const mode = overFileList(e)
-        ? null
-        : isZipDrag(e)
-          ? ("project" as const)
-          : ("files" as const);
-      setDragging(mode);
+      const show = !overFileList(e);
+      setDragging(show);
       if (overlayTimer) clearTimeout(overlayTimer);
       // dragover stops firing the moment the pointer leaves the window, so the
       // overlay has to time itself out rather than wait for a dragleave.
-      overlayTimer = mode
-        ? window.setTimeout(() => setDragging(null), 150)
+      overlayTimer = show
+        ? window.setTimeout(() => setDragging(false), 150)
         : 0;
     };
     const onDragEnter = (e: DragEvent) => {
@@ -159,7 +151,7 @@ export default function FileDropzone(_props: FileDropzoneProps) {
     const clearOverlay = () => {
       if (overlayTimer) clearTimeout(overlayTimer);
       overlayTimer = 0;
-      setDragging(null);
+      setDragging(false);
     };
 
     window.addEventListener("dragenter", onDragEnter);
@@ -238,7 +230,7 @@ export default function FileDropzone(_props: FileDropzoneProps) {
       {dragging && (
         <div class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-2 bg-engine-900 text-foreground text-xl font-semibold">
           <Download class="size-16" stroke-width="1" />
-          {dragging === "project" ? "Import Project Files" : "Import Files"}
+          Import Project Files
         </div>
       )}
     </div>

--- a/impower-dev/src/modules/spark-editor/components/file-dropzone/FileDropzone.tsx
+++ b/impower-dev/src/modules/spark-editor/components/file-dropzone/FileDropzone.tsx
@@ -14,16 +14,25 @@ export type FileDropzoneProps = Partial<typeof propDefaults>;
  *  2. Loose files = fallback. A drop ONTO a file list is claimed by that list
  *     (it routes the files into the hovered folder / current scope — see
  *     useExternalFileDrop). This window handler only catches loose-file drops
- *     that land OUTSIDE any list (e.g. on the preview pane), routing them by
- *     type: scripts -> `scripts/`, everything else -> `assets/`. No overlay for
- *     loose files — the list shows a folder highlight instead.
+ *     that land OUTSIDE any list (e.g. on the editor or preview pane), routing
+ *     them by type: scripts -> `scripts/`, everything else -> `assets/`.
+ *
+ * Detection spans the whole window; only the OVERLAY is scoped. It shows for
+ * any file drag, so dragging onto the editor gives feedback rather than
+ * nothing, but stays hidden while the drag is over a `[data-file-drop-target]`
+ * list — that list rings the target folder itself, and two affordances at once
+ * reads as a bug.
  *
  * Also handles DraggedFilesIn/Over/Out/DroppedFiles protocol messages relayed by
  * an embedding host (e.g. VS Code), which can't carry MIME info, so those keep
  * the overlay + the by-type fallback routing.
  */
 export default function FileDropzone(_props: FileDropzoneProps) {
-  const [dragging, setDragging] = useState(false);
+  // null = no overlay. "project" = single zip (whole-project import),
+  // "files" = loose files. The distinction is only ever cosmetic here -- the
+  // drop handlers re-derive it from the real filenames, which are readable
+  // then but hidden mid-drag.
+  const [dragging, setDragging] = useState<null | "project" | "files">(null);
   // Keep the latest setter reachable from imperative listeners without
   // re-binding them on every render.
   const draggingRef = useRef(dragging);
@@ -32,9 +41,9 @@ export default function FileDropzone(_props: FileDropzoneProps) {
   useEffect(() => {
     let disposeProtocol: (() => void) | undefined;
 
-    const dragEnter = () => setDragging(true);
-    const dragLeave = () => setDragging(false);
-    const dragOver = () => setDragging(true);
+    const dragEnter = () => setDragging("project");
+    const dragLeave = () => setDragging(null);
+    const dragOver = () => setDragging("project");
 
     // Loose-file fallback (drops outside any list, + host-relayed protocol
     // drops). A single .zip is a whole-project import; otherwise route by type so
@@ -42,7 +51,7 @@ export default function FileDropzone(_props: FileDropzoneProps) {
     const handleDrop = async (
       items: { name: string; getBuffer: () => Promise<ArrayBuffer> }[],
     ) => {
-      setDragging(false);
+      setDragging(null);
       const { Workspace } = await import("../../workspace/Workspace");
       const store = (await import("../../workspace/WorkspaceStore")).default
         .state.value;
@@ -91,12 +100,22 @@ export default function FileDropzone(_props: FileDropzoneProps) {
     // leaving the window fire no `drop`) — dragover simply stops and the timer
     // clears it. So there's no native `dragleave` handler at all.
     let overlayTimer = 0;
+    // A drag sitting over a file list belongs to that list's own highlight.
+    const overFileList = (e: DragEvent) =>
+      e.target instanceof Element && !!e.target.closest("[data-file-drop-target]");
+
     const refreshOverlay = (e: DragEvent) => {
-      const zip = isZipDrag(e);
-      setDragging(zip);
+      const mode = overFileList(e)
+        ? null
+        : isZipDrag(e)
+          ? ("project" as const)
+          : ("files" as const);
+      setDragging(mode);
       if (overlayTimer) clearTimeout(overlayTimer);
-      overlayTimer = zip
-        ? window.setTimeout(() => setDragging(false), 150)
+      // dragover stops firing the moment the pointer leaves the window, so the
+      // overlay has to time itself out rather than wait for a dragleave.
+      overlayTimer = mode
+        ? window.setTimeout(() => setDragging(null), 150)
         : 0;
     };
     const onDragEnter = (e: DragEvent) => {
@@ -124,7 +143,7 @@ export default function FileDropzone(_props: FileDropzoneProps) {
     const clearOverlay = () => {
       if (overlayTimer) clearTimeout(overlayTimer);
       overlayTimer = 0;
-      setDragging(false);
+      setDragging(null);
     };
 
     window.addEventListener("dragenter", onDragEnter);
@@ -203,7 +222,7 @@ export default function FileDropzone(_props: FileDropzoneProps) {
       {dragging && (
         <div class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-2 bg-engine-900 text-foreground text-xl font-semibold">
           <Download class="size-16" stroke-width="1" />
-          Import Project Files
+          {dragging === "project" ? "Import Project Files" : "Import Files"}
         </div>
       )}
     </div>

--- a/impower-dev/src/modules/spark-editor/components/file-dropzone/FileDropzone.tsx
+++ b/impower-dev/src/modules/spark-editor/components/file-dropzone/FileDropzone.tsx
@@ -41,9 +41,25 @@ export default function FileDropzone(_props: FileDropzoneProps) {
   useEffect(() => {
     let disposeProtocol: (() => void) | undefined;
 
-    const dragEnter = () => setDragging("project");
-    const dragLeave = () => setDragging(null);
-    const dragOver = () => setDragging("project");
+    // Host-relayed drags (the game-preview iframe, or an embedding editor).
+    // These carry no MIME info, so they always present as a project import.
+    //
+    // They get the same self-clearing timeout as the window path: a relayed
+    // "over" can stop arriving without a matching "out" -- the drag ends
+    // inside the iframe, or the host stops relaying -- and without this the
+    // overlay stays up forever with no drag behind it.
+    const relayDragging = () => {
+      setDragging("project");
+      if (overlayTimer) clearTimeout(overlayTimer);
+      overlayTimer = window.setTimeout(() => setDragging(null), 150);
+    };
+    const dragEnter = () => relayDragging();
+    const dragLeave = () => {
+      if (overlayTimer) clearTimeout(overlayTimer);
+      overlayTimer = 0;
+      setDragging(null);
+    };
+    const dragOver = () => relayDragging();
 
     // Loose-file fallback (drops outside any list, + host-relayed protocol
     // drops). A single .zip is a whole-project import; otherwise route by type so

--- a/impower-dev/src/modules/spark-editor/components/file-dropzone/FileDropzone.tsx
+++ b/impower-dev/src/modules/spark-editor/components/file-dropzone/FileDropzone.tsx
@@ -177,8 +177,29 @@ export default function FileDropzone(_props: FileDropzoneProps) {
     };
   }, []);
 
+  // The overlay sits above every other layer: the z-10 chrome (header, sticky
+  // tab bars, split divider), dialogs (z-50), toasts (z-[60]), and
+  // CodeMirror's own panels and gutters (z-index 300/200). At z-[2] it cleared
+  // none of them, so a drag left the page looking half-covered instead of
+  // presenting one drop target.
+  //
+  // 400 rather than something just past the app's own z-[60] ceiling because
+  // CodeMirror's `.cm-panels-bottom` is z-index 300 and NOTHING between it and
+  // <body> establishes a stacking context, so that 300 competes here at the
+  // root rather than staying inside the editor. (That leak is worth fixing at
+  // the source -- it also puts the status bar above this app's dialogs -- but
+  // containing it is a wider change than this overlay.)
+  //
+  // `absolute inset-0` fills whichever container this is mounted in --
+  // currently MainWindow's middle region, so the overlay covers the content
+  // area and leaves the header above and tab bar below visible. Scoping it by
+  // MOUNT POINT rather than by offsetting a full-viewport overlay means there
+  // is no header height duplicated here to drift out of sync.
+  //
+  // `pointer-events-none` so the drag and drop events still reach the
+  // window-level handlers underneath.
   return (
-    <div class="pointer-events-none absolute inset-0 z-[2] flex flex-col">
+    <div class="pointer-events-none absolute inset-0 z-[400] flex flex-col">
       {dragging && (
         <div class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-2 bg-engine-900 text-foreground text-xl font-semibold">
           <Download class="size-16" stroke-width="1" />

--- a/impower-dev/src/modules/spark-editor/components/file-list/FileList.tsx
+++ b/impower-dev/src/modules/spark-editor/components/file-list/FileList.tsx
@@ -1295,6 +1295,11 @@ export default function FileList({
   return (
     <div
       ref={containerRef}
+      // Marks this subtree as owning its own external-file-drop feedback (the
+      // folder highlight below). The window-level FileDropzone looks for this
+      // and suppresses its full-page overlay while a drag is over a list, so
+      // the two affordances never fight.
+      data-file-drop-target
       class={`relative flex h-full w-full flex-col rounded ${
         // A loose-file drag hovering empty space (not a folder) targets the
         // current scope / pane root — ring the whole list to say so. When over a

--- a/impower-dev/src/modules/spark-editor/components/main-window/MainWindow.tsx
+++ b/impower-dev/src/modules/spark-editor/components/main-window/MainWindow.tsx
@@ -16,6 +16,7 @@ import workspace from "../../workspace/WorkspaceStore";
 import { inspectedAsset } from "../../utils/assetInspector";
 import AssetInspectorPane from "../asset-inspector/AssetInspectorPane";
 import Assets from "../assets/Assets";
+import FileDropzone from "../file-dropzone/FileDropzone";
 import HeaderNavigation from "../header-navigation/HeaderNavigation";
 import Logic from "../logic/Logic";
 import Preview from "../preview/Preview";
@@ -98,6 +99,13 @@ export default function MainWindow(_props: MainWindowProps) {
             }
           />
         )}
+        {/* Full-page file-drop target. Mounted HERE, inside the middle region,
+            rather than at the page root: that scopes the overlay to the
+            content area so the header above and the tab bar below stay
+            visible and readable while a file is over the window. The drag
+            listeners are on `window`, so where this sits in the tree affects
+            only what the overlay covers, not what it catches. */}
+        <FileDropzone />
       </div>
       <div
         class="relative flex-none h-[60px] bg-engine-800 text-foreground [&>*]:h-full"

--- a/impower-dev/src/modules/spark-editor/components/main-window/MainWindow.tsx
+++ b/impower-dev/src/modules/spark-editor/components/main-window/MainWindow.tsx
@@ -68,48 +68,56 @@ export default function MainWindow(_props: MainWindowProps) {
       <HeaderNavigation />
       <div class="relative flex flex-1 min-h-0">
         {!isSSR && (
-          <SplitPane
-            activePanel={previewActive}
-            minSize="320px"
-            collapseBelow={960}
-            start={
-              <div class="relative flex flex-col w-full h-full">
-                <Router active={pane} mode="zoom">
-                  <Logic key="logic" />
-                  <Assets key="assets" />
-                  <SharePanel key="share" />
-                </Router>
-              </div>
-            }
-            end={
-              <div class="relative flex flex-col w-full h-full bg-black">
-                {/* The game preview stays mounted (so inspecting an asset and
+          <>
+            <SplitPane
+              activePanel={previewActive}
+              minSize="320px"
+              collapseBelow={960}
+              start={
+                <div class="relative flex flex-col w-full h-full">
+                  <Router active={pane} mode="zoom">
+                    <Logic key="logic" />
+                    <Assets key="assets" />
+                    <SharePanel key="share" />
+                  </Router>
+                </div>
+              }
+              end={
+                <div class="relative flex flex-col w-full h-full bg-black">
+                  {/* The game preview stays mounted (so inspecting an asset and
                     closing doesn't reload/restart the game); the asset inspector
                     overlays it — desktop select-to-inspect — while an asset is
                     selected in the Assets browser. */}
-                <Preview />
-                {pane === "assets" && inspectedAsset.value && (
-                  // z-10 so it covers Preview's own `sticky z-[1]` header too
-                  // (an unlayered absolute overlay would render UNDER it).
-                  <div class="absolute inset-0 z-10">
-                    <AssetInspectorPane />
-                  </div>
-                )}
-              </div>
-            }
-          />
+                  <Preview />
+                  {pane === "assets" && inspectedAsset.value && (
+                    // z-10 so it covers Preview's own `sticky z-[1]` header too
+                    // (an unlayered absolute overlay would render UNDER it).
+                    <div class="absolute inset-0 z-10">
+                      <AssetInspectorPane />
+                    </div>
+                  )}
+                </div>
+              }
+            />
+            {/* File-drop target. Mounted HERE, inside the middle region,
+                rather than at the page root: that scopes the overlay to the
+                content area so the header above and the tab bar below stay
+                visible and readable while a file is over the window. The drag
+                listeners are on `window`, so where this sits in the tree
+                affects only what the overlay covers, not what it catches.
+
+                Inside the `!isSSR` guard with the SplitPane, NOT beside it.
+                SSR skips the SplitPane, so rendering this alone server-side
+                left the middle region holding a single child that the client
+                then wanted to be the SplitPane -- Preact reused the overlay
+                div as that container and nested every pane INSIDE it, which
+                put tab indicators and divider lines above the overlay's own
+                background. Same children on both sides, no mismatch. */}
+            <FileDropzone />
+          </>
         )}
-        {/* Full-page file-drop target. Mounted HERE, inside the middle region,
-            rather than at the page root: that scopes the overlay to the
-            content area so the header above and the tab bar below stay
-            visible and readable while a file is over the window. The drag
-            listeners are on `window`, so where this sits in the tree affects
-            only what the overlay covers, not what it catches. */}
-        <FileDropzone />
       </div>
-      <div
-        class="relative flex-none h-[60px] bg-engine-800 text-foreground [&>*]:h-full"
-      >
+      <div class="relative flex-none h-[60px] bg-engine-800 text-foreground [&>*]:h-full">
         {/* 1px white/6% divider hugging the top edge — mirrors main's
             <s-divider bg-color="fg-06"> above the bottom-nav tabs. The
             !h-px overrides the parent's [&>*]:h-full selector which

--- a/impower-dev/src/modules/spark-editor/main/SparkEditor.tsx
+++ b/impower-dev/src/modules/spark-editor/main/SparkEditor.tsx
@@ -1,5 +1,4 @@
 import ConflictDialogHost from "../components/conflict-dialog/ConflictDialogHost";
-import FileDropzone from "../components/file-dropzone/FileDropzone";
 import MainWindow from "../components/main-window/MainWindow";
 import SnackbarHost from "../components/snackbar-host/SnackbarHost";
 import TrashPanel from "../components/trash-panel/TrashPanel";
@@ -36,7 +35,6 @@ export default function SparkEditor(_props: SparkEditorProps) {
     <>
       <style>{HOST_STYLE}</style>
       <MainWindow />
-      <FileDropzone />
       {/* Project-wide recycle bin overlay — a single global instance toggled by
           workspace.trashOpen (opened from the file-list toolbar). */}
       <TrashPanel />

--- a/sparkdown-player-app/src/main.ts
+++ b/sparkdown-player-app/src/main.ts
@@ -114,17 +114,29 @@ window.addEventListener(MessageProtocol.event, (e) => {
     }
   }
 });
+// Drags over this iframe never reach the embedding editor -- the events go to
+// this document instead -- so relay them, or the editor's drop overlay simply
+// never appears while the pointer is over the game preview.
+//
+// Only relay drags that actually carry files: an in-game text or element drag
+// is not an import, and announcing it would flash the editor's overlay.
+const carriesFiles = (e: DragEvent) =>
+  Array.from(e.dataTransfer?.types ?? []).includes("Files");
+
 window.addEventListener("dragenter", (e) => {
+  if (!carriesFiles(e)) return;
   e.preventDefault();
   e.stopPropagation();
   connection.postMessage(DraggedFilesInMessage.type.notification({}));
 });
 window.addEventListener("dragleave", (e) => {
+  if (!carriesFiles(e)) return;
   e.preventDefault();
   e.stopPropagation();
   connection.postMessage(DraggedFilesOutMessage.type.notification({}));
 });
 window.addEventListener("dragover", (e) => {
+  if (!carriesFiles(e)) return;
   e.preventDefault();
   e.stopPropagation();
   connection.postMessage(DraggedFilesOverMessage.type.notification({}));


### PR DESCRIPTION
Fixes #269.

## What was wrong

The "Import Project Files" overlay sat at `z-[2]`, below essentially the whole app — the `z-10` chrome (header, sticky tab bars, split divider), the `z-[3]` import progress bar, dialogs (`z-50`), toasts (`z-[60]`), and CodeMirror's panels and gutters. A drag left the page looking half-covered instead of presenting one clear drop target.

Two separate things were wrong, and fixing only the z-index left the second one visible.

## 1. CodeMirror's z-index leaks into the root stacking context

Raising the overlay to `z-[70]` (above the app's own `z-[60]` ceiling, as #269 suggested) still left the editor status bar painting on top. Walking the stacking chain from the leaking element showed why:

```
.cm-panels-bottom     position: sticky   z-index: 300
.cm-editor            position: relative z-index: auto
.editor               position: absolute z-index: auto
... every ancestor ... z-index: auto, no transform, no opacity, no isolation
BODY
```

Nothing between `.cm-panels-bottom` and `<body>` establishes a stacking context, so CodeMirror's internal `z-index: 300` competes **at the root** rather than staying inside the editor. Hence `z-[400]`.

**Worth knowing separately:** this also means the editor status bar outranks this app's dialogs (`z-50`) and toasts (`z-[60]`) generally, not just this overlay. Containing that at the source — isolating the editor subtree — is a wider change than belongs here, but it's a real latent issue.

## 2. The overlay was mounted at the page root

Per review feedback, it now mounts inside `MainWindow`'s middle region rather than at the page root, so it covers the content area and leaves the header above and the tab bar below visible.

Scoping it by **mount point** rather than by offsetting a full-viewport overlay was the deciding factor: an earlier attempt used `fixed ... top-14` to clear the header, which duplicated `HeaderNavigation`'s `h-14` into a second place that could silently drift. Raising the header's z-index instead was also rejected — the header is `z-10` and sits *under* the app's modal dialogs deliberately, and lifting it above this overlay would have lifted it above those too.

The drag listeners stay on `window`, so the move changes what the overlay *covers*, not what it *catches*.

## Verification

Held the overlay open with a synthetic zip drag (a `DragEvent` carrying a `application/zip` `File`, re-fired every 80ms to defeat the 150ms idle-clear) and looked at it:

- The overlay wrapper spans **y 56–850 of a 910px viewport** — exactly the region between the 56px header and the 60px bottom nav.
- Screenshot confirms header and bottom navbar visible, and no tab bar, status bar or divider peeking through the middle.
- It still self-clears once the drag ends, so the lifecycle survived the move.
- No console errors.

Also answers the open question in #269 about whether arbitrary Tailwind `z-[N]` values are generated: they are — computed `z-index` read back as exactly `70` and then `400`. The `auto` seen when the issue was filed was the stale backgrounded-tab artifact it suspected.
