### PR TITLE
fix(script-editor): stop editor chrome outranking the host app's layers

### DIFF
--- a/packages/sparkdown-document-views/src/modules/script-editor/constants/EDITOR_THEME.ts
+++ b/packages/sparkdown-document-views/src/modules/script-editor/constants/EDITOR_THEME.ts
@@ -95,6 +95,14 @@ const EDITOR_THEME: {
     color: EDITOR_COLORS.lineNumber,
     border: "none",
     opacity: 0.7,
+    // CodeMirror ships these at z-index 200, and nothing between them and
+    // <body> establishes a stacking context, so that 200 competed against the
+    // HOST app's layers rather than staying inside the editor -- putting the
+    // gutters above dialogs and toasts. Editor CHROME belongs under the app's
+    // UI; only editor POPUPS (`.cm-tooltip`, the LSP context menu) deliberately
+    // stay high, because they must overhang neighbouring panes. Positioned, so
+    // this also contains anything nested inside.
+    zIndex: "1",
   },
   "kbd, code, pre": {
     fontFamily: "Courier Prime Sans",
@@ -289,6 +297,10 @@ const EDITOR_THEME: {
   },
   "& .cm-panels": {
     backgroundColor: EDITOR_COLORS.panel,
+    // Same reason as `.cm-gutters` above -- CodeMirror's default is 300, which
+    // put the status bar over the host's dialogs. Kept one above the gutters
+    // to preserve CodeMirror's own relative order (300 > 200).
+    zIndex: "2",
   },
   "& .cm-panels.cm-panels-bottom": {
     borderTop: `1px solid ${EDITOR_COLORS.panelBorder}`,


### PR DESCRIPTION
Fixes #278 — the "Replace / Keep both / Skip" dialog rendering under the editor's status bar.

## Root cause

CodeMirror ships `.cm-panels` at `z-index: 300` and `.cm-gutters` at `200`. Those are meant to be *internal* to the editor — but nothing between them and `<body>` establishes a stacking context, so they competed directly against the host app's layers, which top out at `z-50` (dialogs) and `z-[60]` (toasts).

## The fix

Pin the editor's **chrome** low in its own theme — gutters `1`, panels `2`, preserving CodeMirror's relative order. Editor chrome belongs under the app's UI.

Editor **popups** deliberately stay high: `.cm-tooltip` keeps its explicit `300` and the LSP context menu its `1000`, because those must overhang neighbouring panes. Both targets are positioned, so giving them a z-index also contains anything nested inside them (the keyboard toolbar's `100`, for one).

## Two alternatives I tried and rejected

**`isolation: isolate` on `.sparkdown-script-editor-root`** — the obvious containment fix, and it does work: verified a z-50 probe beating the status bar with it applied. But it also traps `.cm-tooltip`, so autocomplete could no longer overhang the preview pane — measured, not assumed. Containing the whole subtree is too blunt when part of it is meant to escape.

**Raising the app's nine `z-50`/`z-[60]` sites above 300** — works, but it's a number picked to beat another number, spread across nine files, and leaves the editor able to outrank anything that later forgets to opt in.

## Verification

Re-measured on a **freshly restarted** dev server. That mattered: the previous one had been through dozens of edits and branch switches and was reporting DOM the source cannot produce (two copies of a singleton component; an element appearing as its own sibling's ancestor). #278's original table came from that polluted state and was wrong — it claimed a z-301 probe still lost, implying some contributor above 300. On a clean server the threshold is exactly 300, as theory predicts.

A `position: fixed` probe at z-50 (the app's dialog layer), hit-tested over the editor:

| target | before | after |
| --- | --- | --- |
| status bar | probe loses | **probe wins** |
| gutters | probe loses | **probe wins** |

Editor rendering is unaffected — gutters, line numbers, highlighting, diagnostics squiggle, sticky header and status bar all render as before, and the autocomplete popup still paints above editor content.

## Two things I did not resolve

**1. Autocomplete over the game preview.** Raised in review: it should sit above every panel, including the preview iframe. I could not confirm the at-rest behaviour, but I did find the mechanism.

`.sparkdown-script-editor-root .editor` is `opacity: 0` with a `0.25s` fade, and `revealEditor()` sets inline `opacity: 1`. **`opacity < 1` creates a stacking context; exactly `1` does not.** So during the fade the editor traps its own tooltips (measured: the tooltip paints below the iframe, with `.editor` at computed opacity 0), and once revealed it should not.

Every measurement I could take was in the pre-reveal state, because the browser pane wasn't compositing and the reveal never ran. So: if autocomplete really does render under the preview *at rest*, the fade is not the cause and something else is; if it only happens briefly on load, this is it. Worth confirming with real typing before changing anything — the fix would differ.

**2. Pre-existing flakiness in `sparkdown-document-views`.** The full suite fails one test per run, a *different* one each time (`dialogue-squish` with my change, `dual-after-single-incremental` without it), and both pass in isolation. Not caused by this change — I checked by stashing it — but worth a ticket.
