### PR TITLE
fix(editor): state flex-direction explicitly on the remaining editor popups

### DIFF
--- a/packages/codemirror-vscode-lsp-client/src/lens.ts
+++ b/packages/codemirror-vscode-lsp-client/src/lens.ts
@@ -21,6 +21,10 @@ export const CODELENS_SEPARATOR_CLASS_NAME = "cm-codeLens-separator";
 export const codeLensWidgetTheme = EditorView.baseTheme({
   [`.${CODELENS_WRAPPER_CLASS_NAME}`]: {
     display: "flex",
+    // Explicit: a host may normalize `flex-direction` across its subtree
+    // (spark-editor forces `column` on every descendant of the editor root),
+    // and a direction-less flex container silently stacks when it does.
+    flexDirection: "row",
     alignItems: "center",
     color: "#999999",
     fontSize: "14px",

--- a/packages/codemirror-vscode-lsp-client/src/references.ts
+++ b/packages/codemirror-vscode-lsp-client/src/references.ts
@@ -27,11 +27,6 @@ export const referencesTheme = EditorView.baseTheme({
       "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
     fontSize: "13px",
   },
-  ".cm-lsp-reference-container": {
-    display: "flex",
-    flex: 1,
-    overflow: "hidden",
-  },
   ".cm-lsp-reference-list": {
     overflowY: "auto",
     backgroundColor: "inherit",
@@ -40,6 +35,11 @@ export const referencesTheme = EditorView.baseTheme({
   ".cm-lsp-reference-file": {
     padding: "4px 8px",
     display: "flex",
+    // Explicit: a host may normalize `flex-direction` across its subtree
+    // (spark-editor forces `column` on every descendant of the editor root),
+    // and a direction-less flex container silently stacks when it does. This
+    // one is `[collapse icon][file name]`.
+    flexDirection: "row",
     alignItems: "center",
     position: "sticky",
     top: 0,
@@ -57,6 +57,9 @@ export const referencesTheme = EditorView.baseTheme({
     overflow: "clip",
     textOverflow: "ellipsis",
     display: "flex",
+    // Same reason as `.cm-lsp-reference-file` above; this one is
+    // `[line number][code snippet]`.
+    flexDirection: "row",
     gap: "8px",
     "&[aria-selected]": {
       backgroundColor: "#04395e",

--- a/packages/codemirror-vscode-lsp-client/src/rename.ts
+++ b/packages/codemirror-vscode-lsp-client/src/rename.ts
@@ -14,6 +14,10 @@ import { LSPPlugin } from "./plugin";
 export const renameTheme = EditorView.baseTheme({
   ".cm-lsp-rename-tooltip": {
     display: "flex",
+    // Explicit: a host may normalize `flex-direction` across its subtree
+    // (spark-editor forces `column` on every descendant of the editor root),
+    // and a direction-less flex container silently stacks when it does.
+    flexDirection: "row",
     alignItems: "stretch",
     gap: "4px",
     padding: "8px",

--- a/packages/sparkdown-document-views/src/modules/script-editor/constants/EDITOR_THEME.ts
+++ b/packages/sparkdown-document-views/src/modules/script-editor/constants/EDITOR_THEME.ts
@@ -319,6 +319,10 @@ const EDITOR_THEME: {
     backgroundColor: EDITOR_COLORS.panel,
     padding: "8px",
     display: "flex",
+    // Explicit: a host may normalize `flex-direction` across its subtree
+    // (spark-editor forces `column` on every descendant of the editor root),
+    // and a direction-less flex container silently stacks when it does.
+    flexDirection: "row",
     gap: "8px",
     "& .cm-textfield": {
       height: "32px",
@@ -357,6 +361,7 @@ const EDITOR_THEME: {
       right: "186px",
       height: "30px",
       display: "flex",
+      flexDirection: "row",
       padding: "0 8px",
       justifyContent: "center",
       alignItems: "center",
@@ -535,6 +540,10 @@ const EDITOR_THEME: {
     fontSize: "14px",
     marginRight: "16px",
     display: "flex",
+    // Explicit: a host may normalize `flex-direction` across its subtree
+    // (spark-editor forces `column` on every descendant of the editor root),
+    // and a direction-less flex container silently stacks when it does.
+    flexDirection: "row",
   },
   "& .cm-diagnosticAction": {
     backgroundColor: "transparent",


### PR DESCRIPTION
Fixes #266.

Fourth instance of the same class, after `.cm-scroller`, #247 and #263: a theme sets `display: flex` and leans on the browser's `row` default, but spark-editor's normalize forces `flex-direction: column` on every descendant of the editor root. A direction-less flex container silently stacks — and only in the web editor, since the vscode webview has no such normalize.

Fixed at each theme rather than by extending the host's re-assertion list, so the components are correct under any embedder.

## What I verified, and how far

Honest split, because the ticket asked for each to be looked at rather than blanket-fixed:

| rule | status |
| --- | --- |
| `.cm-panel.cm-gotoLine` | **visibly broken, now fixed** — screenshotted |
| `.cm-diagnosticText` | on screen, `row`, **no visible difference** |
| `.cm-search-matches` | on screen, `row`, **no visible difference** |
| `.cm-lsp-reference-file` | not on screen — derived from its DOM |
| `.cm-lsp-reference` | not on screen — derived from its DOM |
| code-lens wrapper | not on screen — derived from its DOM |
| `.cm-lsp-rename-tooltip` | not on screen — derived from its DOM |
| `.cm-lsp-reference-container` | **deleted** — dead rule |

**Goto-line was genuinely broken.** Forcing the pre-fix direction reproduces it: the panel becomes **128px** of stacked `[×]` / input / `[→]` instead of a **48px** row, shoving the editor down. That's the one real bug in the batch.

**Two are defensive, not fixes.** `.cm-diagnosticText` and `.cm-search-matches` each wrap a single child ("1 of 3", one message), so direction changes nothing measurable — A/B'd both at identical boxes. They're stated for robustness. Saying so rather than letting the diff imply eight bugs.

**Four were reasoned from the DOM, not seen.** Each places two or more children side by side, so they would stack the same way as goto-line:

- `.cm-lsp-reference-file` → `[collapse icon][file name]`
- `.cm-lsp-reference` → `[line number][code snippet]`
- code-lens wrapper → lens items and separators, `white-space: nowrap`
- `.cm-lsp-rename-tooltip` → input with `flex-grow: 1` plus controls

I couldn't get the references panel, a code lens or the rename tooltip on screen in this session. The reasoning is from the element construction in each file, which is solid, but it isn't the same as looking.

## The "ambiguous" one was a dead rule

#266 flagged `.cm-lsp-reference-container` as ambiguous — "wraps a single list; direction may not matter visually". It doesn't matter because **nothing ever gets that class**. It appears exactly once in the whole repo, in its own style rule; the panel builds `cm-lsp-reference-panel`, `-list`, `-file`, `-group`, `-reference` and `-match`, never `-container`.

Deleted rather than given a direction. Picking one for a rule nothing uses would have been the wrong answer to the ticket's question.

## On the underlying cause

#266 suggests a lint or a mount-test to end this class rather than catching instances. Worth doing — this is the fourth round. The other half of it is the normalize itself: `* { flex-direction: column }` across an entire subtree is what makes every third-party component's implicit `row` a latent bug. Scoping that more tightly would remove the trap instead of documenting it.

`packages/sparkdown-document-views`: 60 passed, 4 skipped. (That suite is intermittently flaky — see #281 — so a single green run is weaker evidence than it looks.)
