### PR TITLE
perf(workspace): stop reading every asset's bytes to enumerate a project

### DIFF
--- a/packages/opfs-workspace/src/opfs-workspace.ts
+++ b/packages/opfs-workspace/src/opfs-workspace.ts
@@ -611,12 +611,50 @@ const readDirectoryFiles = async (directoryUri: string) => {
     directoryEntries.map(async (entry) => {
       const uri = getUriFromPath(entry.path);
       if (!State.files.get(uri)) {
-        await readFile(uri);
+        // Enumerate binary assets from metadata; only read what needs text.
+        if (needsTextAtEnumeration(uri)) {
+          await readFile(uri);
+        } else {
+          await statFile(uri);
+        }
       }
       return State.files.get(uri)!;
     }),
   );
   return files;
+};
+
+/**
+ * Which files must have their BYTES read at enumeration time.
+ *
+ * Only text matters here: the compiler needs script and text contents, SVG
+ * source (it filters/recolors the markup rather than just showing the file),
+ * and a `.url` file's body IS its remote URL. Everything else -- images,
+ * audio, video, fonts -- is served straight from OPFS by the resource
+ * protocol, so reading it now buys nothing.
+ */
+const needsTextAtEnumeration = (fileUri: string) => {
+  const ext = getFileExtension(fileUri);
+  const type = getFileType(fileUri);
+  return type === "script" || type === "text" || ext === "svg" || ext === "url";
+};
+
+/**
+ * Records a file WITHOUT reading its contents (#227).
+ *
+ * `src` is derived from the uri (`getSrcFromUri`), never from the bytes, so a
+ * binary asset is fully usable from metadata alone -- the resource protocol
+ * fetches it from OPFS when something actually renders it. Size and mtime come
+ * off the file handle, which does not read the file either.
+ *
+ * On the real Raffles & Bunny project this is the difference between reading
+ * 187MB and 7.5MB to open a project: 539 of its 630 files are binary assets.
+ */
+const statFile = async (fileUri: string) => {
+  const root = await navigator.storage.getDirectory();
+  const fileHandle = await getFileHandleFromUri(root, fileUri, false);
+  const fileRef = await fileHandle.getFile();
+  return updateFileMetaCache(fileUri, fileRef.size, fileRef.lastModified);
 };
 
 const readFile = async (fileUri: string) => {
@@ -1243,6 +1281,49 @@ const enrichUrlAssetType = async (uri: string): Promise<void> => {
     file.type = category;
     State.files.set(uri, file);
   }
+};
+
+/**
+ * Cache entry for a file whose bytes were never read (#227).
+ *
+ * Deliberately mirrors the non-`.url` tail of `updateFileCache`, minus the
+ * text decode: `src` is uri-derived, `size`/`modified` come from the file
+ * handle. `text` stays undefined, which is what every consumer already
+ * expects for a binary asset -- `updateFileCache` only ever set it for
+ * script/text/svg.
+ *
+ * If this file is later read for real, `updateFileCache` overwrites the entry
+ * and preserves `src` (it reuses `existingFile.src`), so warming an asset does
+ * not change its identity or bust the resource URL.
+ */
+const updateFileMetaCache = (
+  uri: string,
+  size: number,
+  modified?: number,
+  version?: number,
+) => {
+  const existingFile = State.files.get(uri);
+  const name = getName(uri);
+  const ext = getFileExtension(uri);
+  const type = getFileType(uri);
+  let src = existingFile?.src || "";
+  if (name && !src) {
+    src = getSrcFromUri(uri) + `?v=${Date.now()}`;
+  }
+  const file = {
+    uri,
+    name,
+    ext,
+    type,
+    src,
+    version: version ?? existingFile?.version ?? 0,
+    size,
+    modified: modified ?? existingFile?.modified ?? Date.now(),
+    languageId: type === "script" ? LANGUAGE_ID : null,
+    text: existingFile?.text,
+  };
+  State.files.set(uri, file);
+  return file;
 };
 
 const updateFileCache = (


### PR DESCRIPTION
Addresses the core of #227.

## What changed

Opening a project read the contents of **every** file before anything else could proceed — `readDirectoryFiles` ran an unbounded `Promise.all` over all entries, each doing `arrayBuffer()`. And since `Workspace.ls.start(...)` is the last statement of `loadInitialFiles`, language-server startup queues behind all of it (#224).

Binary assets are now enumerated from metadata alone — size and mtime come off the file handle, which does not read contents. Only files whose **text** is actually needed are read: scripts, text, `.svg` (the compiler reads SVG source to support filtering) and `.url` (whose body *is* the remote url).

Measured on the real Raffles & Bunny project:

| | files | MB |
| --- | --- | --- |
| read eagerly before | 630 | **187** |
| read eagerly after | 91 | **7.5** |
| no longer read | 539 | **179.5** |

## The risky part of #227 doesn't exist

The ticket expected this to require making `src` lazy across `preloadFile`, the asset previews, the file manager, `SparkdownWorkspace.loadFile` and the player, and called that out as the reason it deserved its own review.

That premise is out of date. `src` is `getSrcFromUri(uri)` — derived from the **uri**, never from the bytes. A binary asset is fully usable from metadata, and the resource protocol reads OPFS when something actually renders it. **No consumer needed changing.**

## Verification — on the real project, not a synthetic one

- Asset browser lists correct sizes and modified times, and PNG thumbnails render.
- The game plays and a **lazily-enumerated** backdrop renders at full size: `bg_int_print_shop__prop_house.webp`, 1920×1080, via `/file:/local/assets/...`. A `.webp` is in the lazy set, so this exercises exactly the path this changes.
- Same 324 compile warnings as before — nothing lost text it needed.
- `tsc` error count on the package unchanged (54 before, 54 after; only a line-number shift).

## What I am NOT claiming

**A startup timing number.** I measured 11s → 8.1s one way and 17s/21s another; neither instrument is trustworthy, because my probe cannot start at navigation and tool-call latency lands inside the measurement. The structural claim — 179.5MB no longer read — stands on its own. #285 is where a proper measurement of editor load time belongs.

## Follow-up, deliberately not in this PR

Removing the eager read also removes the side effect that left every asset warm, so warming has to become deliberate. Filed as #287, with two consumers:

- the editor's completion previews (today warmed by an unbounded `new Image()` per file, inline during enumeration — 157 of them on this project)
- the engine runtime (nothing preloaded before play)

I attempted the editor half here and **reverted it**: the eager warming was successfully removed, but my deferred replacement never fired, which would have left previews cold — the opposite of the requirement. Rather than ship a warmer I had not seen work, I left it out and wrote up what I observed in #287.
