### PR TITLE
fix(lsp): resolve asset references so completion previews render

### DIFF
--- a/packages/sparkdown-language-server/src/utils/providers/getCompletions.ts
+++ b/packages/sparkdown-language-server/src/utils/providers/getCompletions.ts
@@ -4,7 +4,7 @@ import { SparkdownDocument } from "@impower/sparkdown/src/compiler/classes/Spark
 import { SparkdownCompilerConfig } from "@impower/sparkdown/src/compiler/types/SparkdownCompilerConfig";
 import { SparkdownNodeName } from "@impower/sparkdown/src/compiler/types/SparkdownNodeName";
 import { type SparkProgram } from "@impower/sparkdown/src/compiler/types/SparkProgram";
-import { filterImage } from "@impower/sparkdown/src/compiler/utils/filterImage";
+import { getImagePreviewMarkup } from "@impower/sparkdown/src/compiler/utils/getImagePreviewSrc";
 import { getProperty } from "@impower/sparkdown/src/compiler/utils/getProperty";
 import { type GrammarSyntaxNode } from "@impower/textmate-grammar-tree/src/tree/types/GrammarSyntaxNode";
 import { getDescendent } from "@impower/textmate-grammar-tree/src/tree/utils/getDescendent";
@@ -374,30 +374,22 @@ const addStructReferenceCompletions = (
               (Array.isArray(exclude) && !exclude.includes(name)) ||
               (!Array.isArray(exclude) && !exclude(name)))
           ) {
-            if (type === "filtered_image" && program.context) {
-              filterImage(
-                program.context,
-                program.context?.["filtered_image"]?.[name],
-              );
-            }
             const completion: CompletionItem = {
               label: name,
               labelDetails: { description: type },
               kind: CompletionItemKind.Constructor,
             };
             const struct = structs[name];
-            const src =
-              type === "filtered_image"
-                ? struct?.filtered_src
-                : type === "layered_image"
-                  ? struct?.assets?.[0]?.src || struct?.assets?.[0]?.uri
-                  : type === "image"
-                    ? struct?.src || struct?.uri
-                    : undefined;
-            if (src) {
+            // `layered_image.assets` / `filtered_image.image` hold bare
+            // REFERENCES, not resolved structs, so the src has to be walked
+            // down to the underlying `image`.
+            const preview = IMAGE_TYPES.includes(type)
+              ? getImagePreviewMarkup(program.context, struct)
+              : undefined;
+            if (preview) {
               completion.documentation = {
                 kind: MarkupKind.Markdown,
-                value: `<img src="${src}" alt="${name}" height="180" />`,
+                value: preview,
               };
             }
             if (completion.label && !completions.has(completion.label)) {

--- a/packages/sparkdown-language-server/src/utils/providers/getHover.ts
+++ b/packages/sparkdown-language-server/src/utils/providers/getHover.ts
@@ -4,47 +4,9 @@ import { SparkdownCompilerConfig } from "@impower/sparkdown/src/compiler/types/S
 import { type SparkProgram } from "@impower/sparkdown/src/compiler/types/SparkProgram";
 import { filterImage } from "@impower/sparkdown/src/compiler/utils/filterImage";
 import { getExpectedSelectorTypes } from "@impower/sparkdown/src/compiler/utils/getExpectedSelectorTypes";
+import { getImagePreviewMarkup } from "@impower/sparkdown/src/compiler/utils/getImagePreviewSrc";
 import { resolveSelector } from "@impower/sparkdown/src/compiler/utils/resolveSelector";
 import { MarkupKind, type Hover, type Position } from "vscode-languageserver";
-
-const resolveRootImage = (
-  ref: { $type: string; $name: string },
-  context: { [type: string]: { [name: string]: any } } | undefined,
-  stack: Set<{ $type: string; $name: string }>,
-):
-  | { $type: "image"; $name: string; src: string; uri: string; data: string }
-  | {
-      $type: "filtered_image";
-      $name: string;
-      filtered_src: string;
-    }
-  | "circular"
-  | undefined => {
-  const referencedValue = ref?.$type
-    ? context?.[ref?.$type]?.[ref.$name]
-    : (context?.["filtered_image"]?.[ref.$name] ??
-      context?.["image"]?.[ref.$name] ??
-      context?.["layered_image"]?.[ref.$name]);
-
-  if (stack.has(referencedValue)) {
-    return "circular";
-  }
-  stack.add(referencedValue);
-
-  if (referencedValue?.$type === "filtered_image") {
-    return referencedValue;
-  }
-
-  if (referencedValue?.$type === "image") {
-    return referencedValue;
-  }
-
-  if (referencedValue?.$type === "layered_image") {
-    return resolveRootImage(referencedValue?.assets?.[0], context, stack);
-  }
-
-  return undefined;
-};
 
 export const getHover = (
   document: SparkdownDocument | undefined,
@@ -101,29 +63,19 @@ export const getHover = (
                 );
               }
             }
-            const stack = new Set<{ $type: string; $name: string }>();
-            const rootImage = resolveRootImage(
-              resolvedValue,
+            const preview = getImagePreviewMarkup(
               program.context,
-              stack,
+              resolvedValue,
             );
-            if (rootImage !== "circular") {
-              const src =
-                rootImage?.$type === "filtered_image"
-                  ? rootImage?.filtered_src
-                  : rootImage?.$type === "image"
-                    ? rootImage?.src || rootImage?.uri
-                    : undefined;
-              if (src) {
-                result = {
-                  contents: {
-                    kind: MarkupKind.Markdown,
-                    value: `<img src="${src}" alt="${name}" height="180" />`,
-                  },
-                  range,
-                };
-                return false;
-              }
+            if (preview) {
+              result = {
+                contents: {
+                  kind: MarkupKind.Markdown,
+                  value: preview,
+                },
+                range,
+              };
+              return false;
             }
           }
           // TODO: const name: type

--- a/packages/sparkdown/src/compiler/utils/filterImage.ts
+++ b/packages/sparkdown/src/compiler/utils/filterImage.ts
@@ -4,9 +4,13 @@ import { filterSVG } from "./filterSVG";
 const getNestedFilters = (
   name: string,
   context: { [type: string]: { [name: string]: any } },
+  // `a -> b -> a` would otherwise recurse until the stack blows. The
+  // self-reference check below only catches a chain of length one.
+  seen = new Set<string>(),
 ): { includes: unknown[]; excludes: unknown[] }[] => {
   const filteredImage = context?.["filtered_image"]?.[name];
-  if (filteredImage) {
+  if (filteredImage && !seen.has(name)) {
+    seen.add(name);
     const filters: { includes: unknown[]; excludes: unknown[] }[] =
       filteredImage?.["filters"]?.map?.(
         (reference: { $type: "filtered_image"; $name: string }) =>
@@ -14,7 +18,7 @@ const getNestedFilters = (
       ) || [];
     const imageToFilterName = filteredImage?.["image"]?.["$name"];
     if (imageToFilterName !== name) {
-      filters.push(...getNestedFilters(imageToFilterName, context));
+      filters.push(...getNestedFilters(imageToFilterName, context, seen));
     }
     return filters;
   }

--- a/packages/sparkdown/src/compiler/utils/getImagePreviewSrc.ts
+++ b/packages/sparkdown/src/compiler/utils/getImagePreviewSrc.ts
@@ -1,0 +1,131 @@
+import { filterImage } from "./filterImage";
+
+/**
+ * Resolve an image-ish context struct down to something an `<img src>` can
+ * actually load.
+ *
+ * Only plain `image` structs carry a `src` — `populateAssets` copies it off the
+ * workspace file. `layered_image.assets` and `filtered_image.image` hold bare
+ * REFERENCES (`{ $type, $name }`, and `$type` is the empty string for a bare
+ * name), so reading `.src` straight off one always yields `undefined`. Anything
+ * wanting a preview has to walk the reference chain to the underlying `image`.
+ *
+ * A `layered_image` previews as its first layer: `assets` may be an array
+ * (`assets = { a, b }`) or a keyed table (`assets = { base = a, prop = b }`),
+ * so take the first VALUE either way rather than indexing `[0]`.
+ */
+export const getImagePreviewSrc = (
+  context: { [type: string]: { [name: string]: any } } | undefined,
+  struct: any,
+  visited = new Set<any>(),
+): string | undefined => {
+  if (!struct || typeof struct !== "object") {
+    return undefined;
+  }
+  if (visited.has(struct)) {
+    // Circular reference chain — bail rather than recurse forever.
+    return undefined;
+  }
+  visited.add(struct);
+
+  const type = struct["$type"];
+
+  if (type === "image") {
+    return struct["src"] || struct["data"] || struct["uri"] || undefined;
+  }
+
+  if (type === "filtered_image") {
+    // Computes `filtered_src` when the root is an SVG (the only case that can
+    // be filtered into a standalone source). No-op if already computed.
+    if (context) {
+      filterImage(context, struct);
+    }
+    if (struct["filtered_src"]) {
+      return struct["filtered_src"];
+    }
+    // Raster or layered root: nothing to filter, so preview the root itself.
+    return getImagePreviewSrc(
+      context,
+      resolveImageReference(context, struct["image"]),
+      visited,
+    );
+  }
+
+  if (type === "layered_image") {
+    const assets = struct["assets"];
+    const layers = Array.isArray(assets)
+      ? assets
+      : assets && typeof assets === "object"
+        ? Object.values(assets)
+        : [];
+    for (const layer of layers) {
+      const src = getImagePreviewSrc(
+        context,
+        resolveImageReference(context, layer),
+        visited,
+      );
+      if (src) {
+        return src;
+      }
+    }
+    return undefined;
+  }
+
+  if (!type) {
+    // A bare reference (`{ $type: "", $name }`) that still needs resolving.
+    // A struct with a real non-image `$type` is deliberately NOT chased by
+    // name — a `character` named `hero` must not preview an image `hero`.
+    const resolved = resolveImageReference(context, struct);
+    if (resolved && resolved !== struct) {
+      return getImagePreviewSrc(context, resolved, visited);
+    }
+  }
+  return undefined;
+};
+
+const escapeAttribute = (value: string) =>
+  value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+
+/**
+ * Markdown/HTML preview for an image-ish struct, shared by hover and
+ * completion so the two never disagree about what an asset looks like.
+ * Returns `undefined` when nothing loadable could be resolved.
+ */
+export const getImagePreviewMarkup = (
+  context: { [type: string]: { [name: string]: any } } | undefined,
+  struct: any,
+): string | undefined => {
+  const src = getImagePreviewSrc(context, struct);
+  if (!src) {
+    return undefined;
+  }
+  const name = struct?.["$name"] ?? "";
+  return `<img src="${escapeAttribute(src)}" alt="${escapeAttribute(
+    name,
+  )}" height="180" />`;
+};
+
+/**
+ * Look a `{ $type, $name }` reference up in the compiled context. A bare name
+ * in a `.sd` table lowers to `$type: ""`, meaning "search every type by name",
+ * so fall back to the image types in specificity order — `filtered_image`
+ * first, because an SVG asset gets an implicit filtered_image declared for it
+ * and that is the variant a preview should show.
+ */
+const resolveImageReference = (
+  context: { [type: string]: { [name: string]: any } } | undefined,
+  ref: any,
+): any => {
+  if (!ref || typeof ref !== "object" || !ref["$name"]) {
+    return undefined;
+  }
+  const name = ref["$name"];
+  if (ref["$type"]) {
+    return context?.[ref["$type"]]?.[name];
+  }
+  return (
+    context?.["filtered_image"]?.[name] ??
+    context?.["image"]?.[name] ??
+    context?.["layered_image"]?.[name]
+  );
+};

--- a/packages/sparkdown/src/tests/compiler/ImagePreviewSrc.test.ts
+++ b/packages/sparkdown/src/tests/compiler/ImagePreviewSrc.test.ts
@@ -1,0 +1,191 @@
+// Asset completions/hovers show a thumbnail by resolving the struct down to a
+// loadable `<img src>`. Only a plain `image` carries `src` (copied off the
+// workspace file by `populateAssets`); `layered_image.assets` and
+// `filtered_image.image` hold bare REFERENCES (`{ $type, $name }`, with an
+// empty `$type` for a bare name), so reading `.src` straight off one always
+// yields undefined and the preview silently disappears (issue #290).
+
+import { describe, expect, it } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+import { File } from "../../compiler/types/File";
+import {
+  getImagePreviewMarkup,
+  getImagePreviewSrc,
+} from "../../compiler/utils/getImagePreviewSrc";
+
+const MAIN_URI = "file://proj/main.sd";
+
+const assetFile = (uri: string, text?: string): File => {
+  const base = uri.split("/").slice(-1)[0]!;
+  const dot = base.lastIndexOf(".");
+  return {
+    uri,
+    type: "image",
+    name: dot >= 0 ? base.slice(0, dot) : base,
+    ext: dot >= 0 ? base.slice(dot + 1) : "",
+    src: `/file:/local/assets/${base}?v=1`,
+    text,
+  };
+};
+
+const SVG = `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="1" cy="1" r="1"/></svg>`;
+
+const compile = (text: string, assets: File[]) => {
+  const compiler = new SparkdownCompiler();
+  compiler.configure({
+    files: [
+      {
+        uri: MAIN_URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text,
+        version: 1,
+        languageId: "sparkdown",
+      },
+      ...assets,
+    ],
+  });
+  return compiler.compile({ textDocument: { uri: MAIN_URI } }).program;
+};
+
+const previewOf = (program: any, type: string, name: string) =>
+  getImagePreviewSrc(program.context, program.context?.[type]?.[name]);
+
+describe("image preview src resolution", () => {
+  it("resolves a plain image to its workspace src", () => {
+    const program = compile("", [assetFile("file://proj/a/photo.jpg")]);
+    expect(previewOf(program, "image", "photo")).toBe(
+      "/file:/local/assets/photo.jpg?v=1",
+    );
+  });
+
+  it("resolves a layered_image through its first layer reference", () => {
+    const program = compile(
+      `define bg_danbys as layered_image with
+  assets = {
+    bg_danbys__base,
+    bg_danbys__prop,
+  }
+end
+`,
+      [
+        assetFile("file://proj/a/bg_danbys__base.png"),
+        assetFile("file://proj/a/bg_danbys__prop.png"),
+      ],
+    );
+    // Regression guard: `assets[0].src` is undefined — these are references.
+    expect(
+      program.context?.["layered_image"]?.["bg_danbys"]?.["assets"]?.[0]?.[
+        "src"
+      ],
+    ).toBeUndefined();
+    expect(previewOf(program, "layered_image", "bg_danbys")).toBe(
+      "/file:/local/assets/bg_danbys__base.png?v=1",
+    );
+  });
+
+  it("resolves a layered_image whose assets are a keyed table, not an array", () => {
+    const program = compile(
+      `define bg_shop as layered_image with
+  assets = {
+    base = bg_shop__base,
+    prop = bg_shop__prop,
+  }
+end
+`,
+      [
+        assetFile("file://proj/a/bg_shop__base.png"),
+        assetFile("file://proj/a/bg_shop__prop.png"),
+      ],
+    );
+    expect(previewOf(program, "layered_image", "bg_shop")).toBe(
+      "/file:/local/assets/bg_shop__base.png?v=1",
+    );
+  });
+
+  it("resolves an svg's implicit filtered_image to its filtered source", () => {
+    const program = compile("", [
+      assetFile("file://proj/a/portrait.svg", SVG),
+    ]);
+    const src = previewOf(program, "filtered_image", "portrait");
+    expect(src).toMatch(/^data:image\/svg\+xml,/);
+  });
+
+  it("falls back to the root image when a filtered_image has no filtered_src", () => {
+    // A filtered_image over a RASTER layered_image can't produce a filtered
+    // svg source, so it must preview the underlying layer instead of nothing.
+    const program = compile(
+      `define bg_town as layered_image with
+  assets = {
+    bg_town__base,
+  }
+end
+
+define bg_town_dim as filtered_image with
+  image = bg_town
+end
+`,
+      [assetFile("file://proj/a/bg_town__base.png")],
+    );
+    expect(
+      program.context?.["filtered_image"]?.["bg_town_dim"]?.["filtered_src"],
+    ).toBeUndefined();
+    expect(previewOf(program, "filtered_image", "bg_town_dim")).toBe(
+      "/file:/local/assets/bg_town__base.png?v=1",
+    );
+  });
+
+  it("skips missing layers instead of giving up on the whole image", () => {
+    const program = compile(
+      `define bg_partial as layered_image with
+  assets = {
+    bg_missing_layer,
+    bg_partial__real,
+  }
+end
+`,
+      [assetFile("file://proj/a/bg_partial__real.png")],
+    );
+    expect(previewOf(program, "layered_image", "bg_partial")).toBe(
+      "/file:/local/assets/bg_partial__real.png?v=1",
+    );
+  });
+
+  it("terminates on a circular reference chain", () => {
+    const program = compile(
+      `define loop_a as filtered_image with
+  image = loop_b
+end
+
+define loop_b as filtered_image with
+  image = loop_a
+end
+`,
+      [],
+    );
+    expect(previewOf(program, "filtered_image", "loop_a")).toBeUndefined();
+  });
+
+  it("does not chase a non-image struct that shares an image's name", () => {
+    const program = compile(
+      `define hero as character with
+  name = "HERO"
+end
+`,
+      [assetFile("file://proj/a/hero.png")],
+    );
+    expect(previewOf(program, "character", "hero")).toBeUndefined();
+  });
+
+  it("escapes the markup it builds", () => {
+    const program = compile("", [assetFile('file://proj/a/we"ird.png')]);
+    const markup = getImagePreviewMarkup(
+      program.context,
+      program.context?.["image"]?.['we"ird'],
+    );
+    expect(markup).toBe(
+      `<img src="/file:/local/assets/we&quot;ird.png?v=1" alt="we&quot;ird" height="180" />`,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #290.

## Root cause

Confirmed by dumping `program.context` after a compile (the diagnostic the issue asked for): **`layered_image.assets` holds bare references, not resolved structs.**

```json
{
  "$type": "layered_image",
  "$name": "bg_danbys",
  "assets": [
    { "$type": "", "$name": "bg_danbys__base" },
    { "$type": "", "$name": "bg_danbys__prop" }
  ]
}
```

So `struct.assets[0].src` in `getCompletions` was *always* `undefined`, `documentation` was never set, and no info panel rendered. `$type` is the empty string for a bare name in a `.sd` table, meaning "search every type by name" — the reference has to be looked up in the context before it has a `src`.

Two related holes fell out of the same investigation:

- `filtered_image` only gets a `filtered_src` when its root is an SVG (that is the only thing `filterImage` can filter into a standalone source). A raster or layered root produced nothing at all, which is why layered portraits had no preview either.
- `assets` can be a keyed table (`assets = { base = a, prop = b }`) as well as an array, and `[0]` cannot index the keyed form.

Plain `image` structs *do* carry `src` — `populateAssets` copies it off the workspace file — so those already worked. The "SVG portraits fail too" report was the implicit `filtered_image` variant winning the completion slot ahead of the `image` one.

## Fix

Adds `getImagePreviewSrc` / `getImagePreviewMarkup`, which walk the reference chain down to the underlying `image`, with a cycle guard. Both `getCompletions` and `getHover` now go through it, so the two cannot disagree about what an asset looks like — `getHover` had its own near-duplicate resolver carrying the same `assets[0]` assumption, so it was broken for the keyed-table form and for filtered images over a non-SVG root.

Also handles the keyed-table `assets` form, and escapes the markup (the client renders it via `innerHTML`).

Separately: `getNestedFilters` in `filterImage.ts` recursed until the stack blew on a circular `filtered_image` chain — `getRootImage` right next to it already had that guard. It was reachable from completions before this change, since `addStructReferenceCompletions` called `filterImage` on every `filtered_image` in the project.

## Verification

- 9 new tests in `ImagePreviewSrc.test.ts`, including a regression guard asserting `assets[0].src` is undefined so the old shape can't quietly come back.
- 443 compiler tests and 299 runtime tests pass.
- Driven live in the editor against a project of colour-coded test assets:
  - `bg_danbys` (`layered_image`) renders its base-layer thumbnail — the exact reported case
  - arrowing through the list swaps the panel per item, so previews track the selection
  - `portrait` (SVG `filtered_image`) renders the filtered SVG
  - hover previews work too, including a layered image using the keyed-table `assets` form that `[0]` could never have resolved

## Note

A `layered_image` previews as its **first layer** rather than a composite of all layers. That matches what hover already did and keeps the two consistent; a stacked composite would be a nice follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
