### PR TITLE
feat: composite layered image previews into one thumbnail (re-target #293 onto main)

### DIFF
--- a/impower-dev/src/workers/sw.ts
+++ b/impower-dev/src/workers/sw.ts
@@ -1,6 +1,13 @@
 export default null;
 declare var self: ServiceWorkerGlobalScope;
 
+import {
+  composeThumbnailBlob,
+  thumbnailCacheKey,
+  THUMB_MAX_WIDTH,
+  THUMB_MIN_WIDTH,
+} from "@impower/sparkdown/src/thumbnails/composeThumbnail";
+
 // Build-time values injected via Vite `define` (see getServiceWorkerDefine).
 // Read through a `typeof` guard so (a) an un-injected build falls back safely
 // instead of throwing, and (b) — crucially — the value can't be folded away by
@@ -17,10 +24,9 @@ const SW_CACHE_NAME: string = `cache-${SW_VERSION}`;
 // opfs-workspace worker can write into the same bucket at import time without
 // knowing the SW version, and so thumbnails survive SW updates (they're keyed
 // by file signature, so they stay valid until the file itself changes). Bump
-// THUMB_VERSION to invalidate every thumbnail when the generation logic
-// changes. Kept across `activate`'s cache sweep.
+// THUMB_VERSION (in the shared generator) to invalidate every thumbnail when
+// the generation logic changes. Kept across `activate`'s cache sweep.
 const SW_THUMB_CACHE_NAME: string = "asset-thumbnails";
-const THUMB_VERSION = 1;
 const SW_RESOURCES: string[] = JSON.parse(
   typeof SW_RESOURCES_INJECTED !== "undefined" ? SW_RESOURCES_INJECTED : "[]",
 );
@@ -29,12 +35,6 @@ const SW_NODE_ENV: string =
     ? SW_NODE_ENV_INJECTED
     : "development";
 const RESOURCE_PROTOCOL: string = "/file:/";
-
-// Thumbnail max-width bounds (px). A request for ?thumb=144 yields a webp no
-// wider than 144px; clamped so a hostile/garbage value can't ask for a huge
-// canvas. Images are never upscaled past their natural width.
-const THUMB_MIN_WIDTH = 16;
-const THUMB_MAX_WIDTH = 512;
 
 const RESOURCE_URL_REGEX =
   /.*[.](?:css|html|js|mjs|ico|svg|png|ttf|woff|woff2)$/;
@@ -119,34 +119,26 @@ async function getOrCreateThumbnail(
   if (!Number.isFinite(maxWidth) || maxWidth < THUMB_MIN_WIDTH) {
     return undefined;
   }
-  const cacheKey = `${RESOURCE_PROTOCOL}${path}?thumb=${maxWidth}&sig=${file.lastModified}-${file.size}&tv=${THUMB_VERSION}`;
+  const cacheKey = `${RESOURCE_PROTOCOL}${path}?${thumbnailCacheKey(
+    [{ path, lastModified: file.lastModified, size: file.size }],
+    maxWidth,
+  )}`;
   try {
     const cache = await caches.open(SW_THUMB_CACHE_NAME);
     const cached = await cache.match(cacheKey);
     if (cached) {
       return cached;
     }
-    // Decode AND downscale in one pass: `resizeWidth` makes the decoder emit a
-    // small bitmap directly (preserving aspect) instead of allocating the full
-    // multi-megapixel image and scaling it on a canvas afterwards — much less
-    // memory + CPU per thumbnail. (Sources narrower than maxWidth upscale
-    // slightly, which is harmless at thumbnail size.)
-    const bitmap = await createImageBitmap(file, {
-      resizeWidth: maxWidth,
-      resizeQuality: "low",
-    });
-    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
-    const ctx = canvas.getContext("2d");
-    if (!ctx) {
-      bitmap.close();
+    // Generation is shared with the language server's asset previews so the
+    // editor and the completion popup can't disagree about what an asset looks
+    // like. A single file is just the one-layer case of a composite.
+    const blob = await composeThumbnailBlob(
+      [{ path, blob: file, lastModified: file.lastModified, size: file.size }],
+      maxWidth,
+    );
+    if (!blob) {
       return undefined;
     }
-    ctx.drawImage(bitmap, 0, 0);
-    bitmap.close();
-    const blob = await canvas.convertToBlob({
-      type: "image/webp",
-      quality: 0.75,
-    });
     const response = new Response(blob, {
       status: 200,
       headers: new Headers({

--- a/impower-dev/src/workers/sw.ts
+++ b/impower-dev/src/workers/sw.ts
@@ -2,6 +2,7 @@ export default null;
 declare var self: ServiceWorkerGlobalScope;
 
 import { getOrCreateThumbnail as getOrCreateThumbnailShared } from "@impower/sparkdown/src/thumbnails/composeThumbnail";
+import { getStaleCacheNames } from "./swCaches";
 
 // Build-time values injected via Vite `define` (see getServiceWorkerDefine).
 // Read through a `typeof` guard so (a) an un-injected build falls back safely
@@ -169,12 +170,9 @@ self.addEventListener("activate", (e) => {
     (async () => {
       const names = await caches.keys();
       await Promise.all(
-        names.map((name) => {
-          if (name !== SW_CACHE_NAME && name !== SW_THUMB_CACHE_NAME) {
-            return caches.delete(name);
-          }
-          return false;
-        }),
+        getStaleCacheNames(names, [SW_CACHE_NAME, SW_THUMB_CACHE_NAME]).map(
+          (name) => caches.delete(name),
+        ),
       );
       await self.clients.claim();
     })(),

--- a/impower-dev/src/workers/sw.ts
+++ b/impower-dev/src/workers/sw.ts
@@ -1,12 +1,7 @@
 export default null;
 declare var self: ServiceWorkerGlobalScope;
 
-import {
-  composeThumbnailBlob,
-  thumbnailCacheKey,
-  THUMB_MAX_WIDTH,
-  THUMB_MIN_WIDTH,
-} from "@impower/sparkdown/src/thumbnails/composeThumbnail";
+import { getOrCreateThumbnail as getOrCreateThumbnailShared } from "@impower/sparkdown/src/thumbnails/composeThumbnail";
 
 // Build-time values injected via Vite `define` (see getServiceWorkerDefine).
 // Read through a `typeof` guard so (a) an un-injected build falls back safely
@@ -97,58 +92,30 @@ async function handleLocalAssetRequest(url: URL) {
 }
 
 /**
- * Return a cached or freshly-generated downscaled webp thumbnail for an image
- * file, or `undefined` if generation fails (caller serves the original).
+ * Cached-or-freshly-generated downscaled webp thumbnail for an image file, or
+ * `undefined` if generation fails (caller serves the original).
  *
- * Keyed by the file's STABLE signature — `path` + `lastModified` + `size` + the
- * requested width — NOT the request url. The request url carries a
- * `?v=${Date.now()}` cache-bust that the workspace re-stamps on every load, so
- * keying on it would regenerate every thumbnail on every page load (and leak
- * orphaned cache entries). The signature changes only when the file's bytes
- * actually change, so a real edit still invalidates the thumbnail.
+ * A thin adapter over the shared generator: this supplies Cache Storage, the
+ * generator owns sizing, encoding and the cache key. That key is the file's
+ * STABLE signature (path + lastModified + size + width), NOT the request url —
+ * the url carries a `?v=${Date.now()}` cache-bust the workspace re-stamps on
+ * every load, so keying on it would regenerate every thumbnail on every page
+ * load and leak orphaned entries.
  */
 async function getOrCreateThumbnail(
   path: string,
   file: File,
   thumbParam: string,
 ): Promise<Response | undefined> {
-  const maxWidth = Math.max(
-    THUMB_MIN_WIDTH,
-    Math.min(THUMB_MAX_WIDTH, Math.floor(Number(thumbParam)) || 0),
-  );
-  if (!Number.isFinite(maxWidth) || maxWidth < THUMB_MIN_WIDTH) {
-    return undefined;
-  }
-  const cacheKey = `${RESOURCE_PROTOCOL}${path}?${thumbnailCacheKey(
-    [{ path, lastModified: file.lastModified, size: file.size }],
-    maxWidth,
-  )}`;
   try {
     const cache = await caches.open(SW_THUMB_CACHE_NAME);
-    const cached = await cache.match(cacheKey);
-    if (cached) {
-      return cached;
-    }
-    // Generation is shared with the language server's asset previews so the
-    // editor and the completion popup can't disagree about what an asset looks
-    // like. A single file is just the one-layer case of a composite.
-    const blob = await composeThumbnailBlob(
-      [{ path, blob: file, lastModified: file.lastModified, size: file.size }],
-      maxWidth,
+    return await getOrCreateThumbnailShared(
+      cache,
+      path,
+      file,
+      thumbParam,
+      RESOURCE_PROTOCOL,
     );
-    if (!blob) {
-      return undefined;
-    }
-    const response = new Response(blob, {
-      status: 200,
-      headers: new Headers({
-        "Content-Type": "image/webp",
-        "Content-Length": String(blob.size),
-        "Cache-Control": "max-age=31536000, immutable",
-      }),
-    });
-    await cache.put(cacheKey, response.clone());
-    return response;
   } catch {
     return undefined;
   }

--- a/impower-dev/src/workers/swCaches.ts
+++ b/impower-dev/src/workers/swCaches.ts
@@ -1,0 +1,17 @@
+/**
+ * Which Cache Storage buckets an activating service worker should delete.
+ *
+ * Split out of `sw.ts` so it can actually be tested — a service worker module
+ * can't be imported under vitest without executing its event registrations.
+ *
+ * The sweep exists to drop caches belonging to SUPERSEDED sw versions
+ * (`cache-v1` once `cache-v2` is live). It must not touch buckets that are
+ * deliberately version-independent: generated thumbnails are keyed by file
+ * signature, so they stay valid across an sw update and regenerating them all
+ * on every deploy would be pure waste. Getting this filter wrong doesn't break
+ * correctness, which is exactly why it would go unnoticed.
+ */
+export const getStaleCacheNames = (
+  existing: readonly string[],
+  keep: readonly string[],
+) => existing.filter((name) => !keep.includes(name));

--- a/impower-dev/test/workers/swCaches.test.ts
+++ b/impower-dev/test/workers/swCaches.test.ts
@@ -1,0 +1,56 @@
+// What survives a service-worker version transition.
+//
+// The activate sweep drops caches belonging to superseded sw versions. The
+// generated-thumbnail bucket must survive it: thumbnails are keyed by file
+// signature, so they stay valid across a deploy, and wiping them would silently
+// make every asset row and asset preview regenerate on the next launch.
+//
+// This is a PERFORMANCE invariant, not a correctness one — nothing breaks if it
+// regresses, which is why it needs a test rather than a code review.
+
+import { describe, expect, it } from "vitest";
+import { getStaleCacheNames } from "../../src/workers/swCaches";
+
+const THUMBS = "asset-thumbnails";
+
+describe("service worker cache sweep", () => {
+  it("drops caches from superseded versions", () => {
+    const existing = ["cache-v1", "cache-v2", "cache-v3"];
+    expect(getStaleCacheNames(existing, ["cache-v3", THUMBS])).toEqual([
+      "cache-v1",
+      "cache-v2",
+    ]);
+  });
+
+  it("preserves generated thumbnails across a version bump", () => {
+    // The whole point of a fixed, non-version-scoped bucket name.
+    const existing = ["cache-v1", THUMBS];
+    expect(getStaleCacheNames(existing, ["cache-v2", THUMBS])).toEqual([
+      "cache-v1",
+    ]);
+  });
+
+  it("preserves the thumbnail bucket even on a first activation", () => {
+    // The opfs-workspace worker can populate thumbnails at import time, before
+    // any sw version has activated — so they can predate the current cache.
+    const existing = [THUMBS];
+    expect(getStaleCacheNames(existing, ["cache-v1", THUMBS])).toEqual([]);
+  });
+
+  it("keeps the currently-active cache", () => {
+    const existing = ["cache-v2"];
+    expect(getStaleCacheNames(existing, ["cache-v2", THUMBS])).toEqual([]);
+  });
+
+  it("drops unrelated leftovers", () => {
+    // An abandoned bucket from an older scheme should not linger forever.
+    const existing = ["cache-v2", THUMBS, "old-experiment"];
+    expect(getStaleCacheNames(existing, ["cache-v2", THUMBS])).toEqual([
+      "old-experiment",
+    ]);
+  });
+
+  it("does nothing when there is nothing to sweep", () => {
+    expect(getStaleCacheNames([], ["cache-v1", THUMBS])).toEqual([]);
+  });
+});

--- a/packages/codemirror-vscode-lsp-client/src/completion.ts
+++ b/packages/codemirror-vscode-lsp-client/src/completion.ts
@@ -220,6 +220,7 @@ export function serverCompletions(
             snippetSupport: true,
             documentationFormat: ["plaintext", "markdown"],
             insertReplaceSupport: false,
+            resolveSupport: { properties: ["documentation"] },
           },
           completionList: {
             itemDefaults: ["commitCharacters", "editRange", "insertTextFormat"],
@@ -314,6 +315,16 @@ export const serverCompletionSource: CompletionSource = (context) => {
           };
           if (item.documentation) {
             option.info = () => renderDocInfo(plugin, item.documentation!);
+          } else if (item.data && canResolveCompletions(plugin)) {
+            // Documentation was withheld by the server to keep the list cheap;
+            // fetch it only when this item is actually highlighted. CodeMirror
+            // accepts a promise here and drops it if the user moves on first.
+            option.info = () =>
+              resolveCompletionItem(plugin, item).then((resolved) =>
+                resolved?.documentation
+                  ? renderDocInfo(plugin, resolved.documentation)
+                  : null,
+              );
           }
           option.apply = (
             view: EditorView,
@@ -369,6 +380,27 @@ export const serverCompletionSource: CompletionSource = (context) => {
     },
   );
 };
+
+function canResolveCompletions(plugin: LSPPlugin) {
+  const provider = plugin.client.serverCapabilities?.completionProvider;
+  return provider?.resolveProvider === true;
+}
+
+/// Ask the server to fill in the expensive parts of a completion item
+/// (documentation). Resolves to null on failure so a dead request just
+/// means "no info panel" rather than a thrown error in the tooltip.
+function resolveCompletionItem(
+  plugin: LSPPlugin,
+  item: lsp.CompletionItem,
+): Promise<lsp.CompletionItem | null> {
+  return plugin.client
+    .request<
+      lsp.CompletionItem,
+      lsp.CompletionItem | null,
+      typeof lsp.CompletionResolveRequest.method
+    >("completionItem/resolve", item)
+    .catch((): null => null);
+}
 
 function renderDocInfo(plugin: LSPPlugin, doc: string | lsp.MarkupContent) {
   let elt = document.createElement("div");

--- a/packages/sparkdown-language-server/src/classes/SparkdownLanguageServerWorkspace.ts
+++ b/packages/sparkdown-language-server/src/classes/SparkdownLanguageServerWorkspace.ts
@@ -169,6 +169,13 @@ export class SparkdownLanguageServerWorkspace extends SparkdownWorkspace {
     });
   }
 
+  override async getFileBytes(uri: string): Promise<string | undefined> {
+    return this._connection?.sendRequest(ExecuteCommandRequest.type, {
+      command: "sparkdown.getFileBytes",
+      arguments: [uri],
+    });
+  }
+
   override async getFileVersion(uri: string): Promise<number> {
     return this._connection?.sendRequest(ExecuteCommandRequest.type, {
       command: "sparkdown.getFileVersion",

--- a/packages/sparkdown-language-server/src/sparkdown-language-server.ts
+++ b/packages/sparkdown-language-server/src/sparkdown-language-server.ts
@@ -45,6 +45,15 @@ try {
 
   const workspace = new SparkdownLanguageServerWorkspace(connection);
 
+  // Asset previews composite a layered image by reading its layers. impower-dev
+  // serves assets over http so the worker just fetches them; VS Code's srcs are
+  // workspace uris a worker can't fetch, so the bytes come back over the
+  // extension bridge instead. Hosts that implement neither fall back to the
+  // single-layer preview rather than failing.
+  const imageCompositeOptions = {
+    readFileBytes: (uri: string) => workspace.getFileBytes(uri),
+  };
+
   const capabilities: ServerCapabilities = {
     textDocumentSync: TextDocumentSyncKind.Incremental,
     foldingRangeProvider: true,
@@ -216,6 +225,7 @@ try {
       program,
       config,
       params.position,
+      imageCompositeOptions,
     );
     performance.mark(`lsp: onHover ${uri} end`);
     performance.measure(
@@ -276,7 +286,11 @@ try {
     }
     performance.mark(`lsp: onCompletionResolve ${item.label} start`);
     const program = workspace.program(data.uri);
-    const resolved = await resolveCompletion(item, program);
+    const resolved = await resolveCompletion(
+      item,
+      program,
+      imageCompositeOptions,
+    );
     performance.mark(`lsp: onCompletionResolve ${item.label} end`);
     performance.measure(
       `lsp: onCompletionResolve ${item.label}`,

--- a/packages/sparkdown-language-server/src/sparkdown-language-server.ts
+++ b/packages/sparkdown-language-server/src/sparkdown-language-server.ts
@@ -14,6 +14,10 @@ import { canRename } from "./utils/providers/canRename";
 import { getCodeLenses } from "./utils/providers/getCodeLenses";
 import { getColorPresentations } from "./utils/providers/getColorPresentations";
 import { getCompletions } from "./utils/providers/getCompletions";
+import {
+  resolveCompletion,
+  type CompletionItemResolveData,
+} from "./utils/providers/resolveCompletion";
 import { getDocumentColors } from "./utils/providers/getDocumentColors";
 import { getDocumentFormattingEdits } from "./utils/providers/getDocumentFormattingEdits";
 import { applyTextEdits } from "./utils/providers/getFormatDirtyRange";
@@ -78,6 +82,10 @@ try {
       completionItem: {
         labelDetailsSupport: true,
       },
+      // Asset previews are computed in `completionItem/resolve`, not up front:
+      // a project-wide asset list can be hundreds of items and only the one the
+      // user highlights ever needs its image.
+      resolveProvider: true,
     },
     documentFormattingProvider: true,
     documentRangeFormattingProvider: true,
@@ -246,7 +254,36 @@ try {
       `lsp: onCompletion ${uri} start`,
       `lsp: onCompletion ${uri} end`,
     );
+    // `workspace.program()` is keyed by the REQUESTED document uri, not by
+    // `program.uri` (which is the compiled root), so resolve has to be told
+    // which document it came from. Stamped here to keep uri plumbing out of
+    // the completion builders.
+    if (result) {
+      for (const item of result) {
+        if (item.data) {
+          (item.data as CompletionItemResolveData).uri = uri;
+        }
+      }
+    }
     return result;
+  });
+
+  // completionProvider.resolveProvider
+  connection.onCompletionResolve((item) => {
+    const data = item.data as CompletionItemResolveData | undefined;
+    if (!data?.uri) {
+      return item;
+    }
+    performance.mark(`lsp: onCompletionResolve ${item.label} start`);
+    const program = workspace.program(data.uri);
+    const resolved = resolveCompletion(item, program);
+    performance.mark(`lsp: onCompletionResolve ${item.label} end`);
+    performance.measure(
+      `lsp: onCompletionResolve ${item.label}`,
+      `lsp: onCompletionResolve ${item.label} start`,
+      `lsp: onCompletionResolve ${item.label} end`,
+    );
+    return resolved;
   });
 
   // documentFormattingProvider

--- a/packages/sparkdown-language-server/src/sparkdown-language-server.ts
+++ b/packages/sparkdown-language-server/src/sparkdown-language-server.ts
@@ -269,14 +269,14 @@ try {
   });
 
   // completionProvider.resolveProvider
-  connection.onCompletionResolve((item) => {
+  connection.onCompletionResolve(async (item) => {
     const data = item.data as CompletionItemResolveData | undefined;
     if (!data?.uri) {
       return item;
     }
     performance.mark(`lsp: onCompletionResolve ${item.label} start`);
     const program = workspace.program(data.uri);
-    const resolved = resolveCompletion(item, program);
+    const resolved = await resolveCompletion(item, program);
     performance.mark(`lsp: onCompletionResolve ${item.label} end`);
     performance.measure(
       `lsp: onCompletionResolve ${item.label}`,

--- a/packages/sparkdown-language-server/src/utils/providers/getCompletions.ts
+++ b/packages/sparkdown-language-server/src/utils/providers/getCompletions.ts
@@ -4,7 +4,6 @@ import { SparkdownDocument } from "@impower/sparkdown/src/compiler/classes/Spark
 import { SparkdownCompilerConfig } from "@impower/sparkdown/src/compiler/types/SparkdownCompilerConfig";
 import { SparkdownNodeName } from "@impower/sparkdown/src/compiler/types/SparkdownNodeName";
 import { type SparkProgram } from "@impower/sparkdown/src/compiler/types/SparkProgram";
-import { getImagePreviewMarkup } from "@impower/sparkdown/src/compiler/utils/getImagePreviewSrc";
 import { getProperty } from "@impower/sparkdown/src/compiler/utils/getProperty";
 import { type GrammarSyntaxNode } from "@impower/textmate-grammar-tree/src/tree/types/GrammarSyntaxNode";
 import { getDescendent } from "@impower/textmate-grammar-tree/src/tree/utils/getDescendent";
@@ -379,18 +378,12 @@ const addStructReferenceCompletions = (
               labelDetails: { description: type },
               kind: CompletionItemKind.Constructor,
             };
-            const struct = structs[name];
-            // `layered_image.assets` / `filtered_image.image` hold bare
-            // REFERENCES, not resolved structs, so the src has to be walked
-            // down to the underlying `image`.
-            const preview = IMAGE_TYPES.includes(type)
-              ? getImagePreviewMarkup(program.context, struct)
-              : undefined;
-            if (preview) {
-              completion.documentation = {
-                kind: MarkupKind.Markdown,
-                value: preview,
-              };
+            // The image preview is deliberately NOT built here — an asset list
+            // runs to hundreds of items and only the highlighted one is ever
+            // shown. `completionItem/resolve` builds it on demand; this just
+            // records where to find the struct again.
+            if (IMAGE_TYPES.includes(type)) {
+              completion.data = { type, name };
             }
             if (completion.label && !completions.has(completion.label)) {
               completions.set(completion.label, completion);

--- a/packages/sparkdown-language-server/src/utils/providers/getHover.ts
+++ b/packages/sparkdown-language-server/src/utils/providers/getHover.ts
@@ -4,7 +4,10 @@ import { SparkdownCompilerConfig } from "@impower/sparkdown/src/compiler/types/S
 import { type SparkProgram } from "@impower/sparkdown/src/compiler/types/SparkProgram";
 import { filterImage } from "@impower/sparkdown/src/compiler/utils/filterImage";
 import { getExpectedSelectorTypes } from "@impower/sparkdown/src/compiler/utils/getExpectedSelectorTypes";
-import { getImagePreviewMarkupComposited } from "@impower/sparkdown/src/compiler/utils/getImageComposite";
+import {
+  getImagePreviewMarkupComposited,
+  type ImageCompositeOptions,
+} from "@impower/sparkdown/src/compiler/utils/getImageComposite";
 import { resolveSelector } from "@impower/sparkdown/src/compiler/utils/resolveSelector";
 import {
   MarkupKind,
@@ -19,6 +22,7 @@ export const getHover = async (
   program: SparkProgram | undefined,
   config: SparkdownCompilerConfig | undefined,
   position: Position,
+  options?: ImageCompositeOptions,
 ): Promise<Hover | null> => {
   if (!document || !annotations || !program) {
     return null;
@@ -94,6 +98,7 @@ export const getHover = async (
   const preview = await getImagePreviewMarkupComposited(
     program.context,
     struct,
+    options,
   );
   if (!preview) {
     return null;

--- a/packages/sparkdown-language-server/src/utils/providers/getHover.ts
+++ b/packages/sparkdown-language-server/src/utils/providers/getHover.ts
@@ -4,25 +4,32 @@ import { SparkdownCompilerConfig } from "@impower/sparkdown/src/compiler/types/S
 import { type SparkProgram } from "@impower/sparkdown/src/compiler/types/SparkProgram";
 import { filterImage } from "@impower/sparkdown/src/compiler/utils/filterImage";
 import { getExpectedSelectorTypes } from "@impower/sparkdown/src/compiler/utils/getExpectedSelectorTypes";
-import { getImagePreviewMarkup } from "@impower/sparkdown/src/compiler/utils/getImagePreviewSrc";
+import { getImagePreviewMarkupComposited } from "@impower/sparkdown/src/compiler/utils/getImageComposite";
 import { resolveSelector } from "@impower/sparkdown/src/compiler/utils/resolveSelector";
-import { MarkupKind, type Hover, type Position } from "vscode-languageserver";
+import {
+  MarkupKind,
+  type Hover,
+  type Position,
+  type Range,
+} from "vscode-languageserver";
 
-export const getHover = (
+export const getHover = async (
   document: SparkdownDocument | undefined,
   annotations: SparkdownAnnotations | undefined,
   program: SparkProgram | undefined,
   config: SparkdownCompilerConfig | undefined,
   position: Position,
-): Hover | null => {
+): Promise<Hover | null> => {
   if (!document || !annotations || !program) {
     return null;
   }
-  let result: Hover | null = null;
+  // The annotation walk is synchronous, so pick the struct out first and build
+  // the (possibly composited, therefore async) markup afterwards.
+  let match: { struct: any; range: Range } | null = null;
   const searchFrom = document.offsetAt(position);
   const searchTo = document.offsetAt({ line: position.line + 1, character: 0 });
   annotations.references.between(searchFrom, searchTo, (from, to, value) => {
-    if (result != null) {
+    if (match != null) {
       return false;
     }
     const range = document.range(from, to);
@@ -63,20 +70,8 @@ export const getHover = (
                 );
               }
             }
-            const preview = getImagePreviewMarkup(
-              program.context,
-              resolvedValue,
-            );
-            if (preview) {
-              result = {
-                contents: {
-                  kind: MarkupKind.Markdown,
-                  value: preview,
-                },
-                range,
-              };
-              return false;
-            }
+            match = { struct: resolvedValue, range };
+            return false;
           }
           // TODO: const name: type
           // TODO: var name: type
@@ -92,5 +87,19 @@ export const getHover = (
     }
     return undefined;
   });
-  return result;
+  if (!match) {
+    return null;
+  }
+  const { struct, range } = match as { struct: any; range: Range };
+  const preview = await getImagePreviewMarkupComposited(
+    program.context,
+    struct,
+  );
+  if (!preview) {
+    return null;
+  }
+  return {
+    contents: { kind: MarkupKind.Markdown, value: preview },
+    range,
+  };
 };

--- a/packages/sparkdown-language-server/src/utils/providers/resolveCompletion.ts
+++ b/packages/sparkdown-language-server/src/utils/providers/resolveCompletion.ts
@@ -1,5 +1,5 @@
 import { type SparkProgram } from "@impower/sparkdown/src/compiler/types/SparkProgram";
-import { getImagePreviewMarkup } from "@impower/sparkdown/src/compiler/utils/getImagePreviewSrc";
+import { getImagePreviewMarkupComposited } from "@impower/sparkdown/src/compiler/utils/getImageComposite";
 import { MarkupKind, type CompletionItem } from "vscode-languageserver";
 
 /**
@@ -25,10 +25,10 @@ export interface CompletionItemResolveData {
  * to what is actually shown, which also leaves room for the preview to become
  * genuinely expensive later (see #292 — compositing layered images).
  */
-export const resolveCompletion = (
+export const resolveCompletion = async (
   item: CompletionItem,
   program: SparkProgram | undefined,
-): CompletionItem => {
+): Promise<CompletionItem> => {
   const data = item.data as CompletionItemResolveData | undefined;
   if (!data || item.documentation != null) {
     return item;
@@ -37,7 +37,10 @@ export const resolveCompletion = (
   if (!struct) {
     return item;
   }
-  const preview = getImagePreviewMarkup(program?.context, struct);
+  const preview = await getImagePreviewMarkupComposited(
+    program?.context,
+    struct,
+  );
   if (!preview) {
     return item;
   }

--- a/packages/sparkdown-language-server/src/utils/providers/resolveCompletion.ts
+++ b/packages/sparkdown-language-server/src/utils/providers/resolveCompletion.ts
@@ -1,5 +1,8 @@
 import { type SparkProgram } from "@impower/sparkdown/src/compiler/types/SparkProgram";
-import { getImagePreviewMarkupComposited } from "@impower/sparkdown/src/compiler/utils/getImageComposite";
+import {
+  getImagePreviewMarkupComposited,
+  type ImageCompositeOptions,
+} from "@impower/sparkdown/src/compiler/utils/getImageComposite";
 import { MarkupKind, type CompletionItem } from "vscode-languageserver";
 
 /**
@@ -28,6 +31,7 @@ export interface CompletionItemResolveData {
 export const resolveCompletion = async (
   item: CompletionItem,
   program: SparkProgram | undefined,
+  options?: ImageCompositeOptions,
 ): Promise<CompletionItem> => {
   const data = item.data as CompletionItemResolveData | undefined;
   if (!data || item.documentation != null) {
@@ -40,6 +44,7 @@ export const resolveCompletion = async (
   const preview = await getImagePreviewMarkupComposited(
     program?.context,
     struct,
+    options,
   );
   if (!preview) {
     return item;

--- a/packages/sparkdown-language-server/src/utils/providers/resolveCompletion.ts
+++ b/packages/sparkdown-language-server/src/utils/providers/resolveCompletion.ts
@@ -1,0 +1,48 @@
+import { type SparkProgram } from "@impower/sparkdown/src/compiler/types/SparkProgram";
+import { getImagePreviewMarkup } from "@impower/sparkdown/src/compiler/utils/getImagePreviewSrc";
+import { MarkupKind, type CompletionItem } from "vscode-languageserver";
+
+/**
+ * What `textDocument/completion` stashes on an asset item so
+ * `completionItem/resolve` can find the struct again without re-running the
+ * whole completion pass. Kept to plain data — it round-trips through the
+ * client untouched.
+ */
+export interface CompletionItemResolveData {
+  /** Document the completion was requested for; identifies the program. */
+  uri: string;
+  /** Context type + name of the struct to preview. */
+  type: string;
+  name: string;
+}
+
+/**
+ * Fill in the expensive half of a completion item.
+ *
+ * Asset previews are deliberately NOT computed in `textDocument/completion`: a
+ * project-wide asset list runs to hundreds of items and the user only ever
+ * looks at the highlighted one. Resolving on demand keeps the cost proportional
+ * to what is actually shown, which also leaves room for the preview to become
+ * genuinely expensive later (see #292 — compositing layered images).
+ */
+export const resolveCompletion = (
+  item: CompletionItem,
+  program: SparkProgram | undefined,
+): CompletionItem => {
+  const data = item.data as CompletionItemResolveData | undefined;
+  if (!data || item.documentation != null) {
+    return item;
+  }
+  const struct = program?.context?.[data.type]?.[data.name];
+  if (!struct) {
+    return item;
+  }
+  const preview = getImagePreviewMarkup(program?.context, struct);
+  if (!preview) {
+    return item;
+  }
+  return {
+    ...item,
+    documentation: { kind: MarkupKind.Markdown, value: preview },
+  };
+};

--- a/packages/sparkdown/src/compiler/utils/getImageComposite.ts
+++ b/packages/sparkdown/src/compiler/utils/getImageComposite.ts
@@ -4,7 +4,22 @@ import {
   type ThumbnailSource,
 } from "../../thumbnails/composeThumbnail";
 import { getImagePreviewMarkup, getImagePreviewSrc } from "./getImagePreviewSrc";
-import { resolveImageLayerSrcs } from "./resolveImageLayerSrcs";
+import { resolveImageLayers, type ImageLayer } from "./resolveImageLayers";
+
+/**
+ * Reads a workspace file's bytes as base64, for hosts where a layer's `src`
+ * isn't fetchable from the language server.
+ *
+ * VS Code is the case: its srcs are workspace uris (`file:`/`vscode-vfs:`)
+ * that a worker cannot `fetch`, and only the extension host can read them —
+ * so the bytes have to come back over the extension bridge. impower-dev
+ * serves its assets over http and never needs this.
+ */
+export type ReadFileBytes = (uri: string) => Promise<string | undefined>;
+
+export interface ImageCompositeOptions {
+  readFileBytes?: ReadFileBytes;
+}
 
 /**
  * Flatten a `layered_image`'s layers into a single thumbnail so previews show
@@ -74,27 +89,52 @@ const toDataUri = (bytes: Uint8Array, mime: string) => {
  * host needs bytes handed to it over the extension bridge (see #292), and
  * until then falls back to the single-layer preview.
  */
-const loadLayer = async (src: string): Promise<ThumbnailSource | undefined> => {
+const base64ToBlob = (base64: string) => {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Blob([bytes]);
+};
+
+const loadLayer = async (
+  layer: ImageLayer,
+  readFileBytes?: ReadFileBytes,
+): Promise<ThumbnailSource | undefined> => {
+  // Strip the `?v=` cache-buster from the key: it is re-stamped on load, so
+  // leaving it in would miss the cache every time.
+  const path = layer.src.split("?")[0] || layer.src;
   try {
-    const response = await fetch(src);
-    if (!response.ok) {
+    const response = await fetch(layer.src);
+    if (response.ok) {
+      const blob = await response.blob();
+      const lastModified = Date.parse(
+        response.headers.get("last-modified") || "",
+      );
+      return {
+        path,
+        blob,
+        lastModified: Number.isFinite(lastModified) ? lastModified : 0,
+        size: blob.size,
+      };
+    }
+  } catch {
+    // Fall through to the bridge — an un-fetchable src is expected in VS Code,
+    // not an error.
+  }
+  if (readFileBytes && layer.uri) {
+    try {
+      const base64 = await readFileBytes(layer.uri);
+      if (base64) {
+        const blob = base64ToBlob(base64);
+        return { path, blob, lastModified: 0, size: blob.size };
+      }
+    } catch {
       return undefined;
     }
-    const blob = await response.blob();
-    const lastModified = Date.parse(
-      response.headers.get("last-modified") || "",
-    );
-    return {
-      // Strip the `?v=` cache-buster: it is re-stamped on every load, so
-      // leaving it in would make the key miss every time.
-      path: src.split("?")[0] || src,
-      blob,
-      lastModified: Number.isFinite(lastModified) ? lastModified : 0,
-      size: blob.size,
-    };
-  } catch {
-    return undefined;
   }
+  return undefined;
 };
 
 /**
@@ -105,8 +145,9 @@ const loadLayer = async (src: string): Promise<ThumbnailSource | undefined> => {
 export const getImageCompositeSrc = async (
   context: { [type: string]: { [name: string]: any } } | undefined,
   struct: any,
+  options?: ImageCompositeOptions,
 ): Promise<string | undefined> => {
-  const layers = resolveImageLayerSrcs(context, struct);
+  const layers = resolveImageLayers(context, struct);
   if (layers.length < 2) {
     // Nothing to flatten — the plain resolver already returns the right thing.
     return undefined;
@@ -114,13 +155,15 @@ export const getImageCompositeSrc = async (
   // Provisional key from the srcs, to avoid re-fetching layers on every
   // keystroke's worth of resolves. Replaced below by the stable signature key
   // once the responses tell us each layer's real identity.
-  const provisionalKey = layers.join("|");
+  const provisionalKey = layers.map((l) => l.src).join("|");
   const provisional = cacheGet(provisionalKey);
   if (provisional !== undefined) {
     return provisional || undefined;
   }
 
-  const sources = await Promise.all(layers.map(loadLayer));
+  const sources = await Promise.all(
+    layers.map((layer) => loadLayer(layer, options?.readFileBytes)),
+  );
   if (sources.some((s) => !s)) {
     // Cache the failure: retrying a fetch that can't work in this host on
     // every resolve would be worse than one stale miss.
@@ -159,8 +202,9 @@ const escapeAttribute = (value: string) =>
 export const getImagePreviewMarkupComposited = async (
   context: { [type: string]: { [name: string]: any } } | undefined,
   struct: any,
+  options?: ImageCompositeOptions,
 ): Promise<string | undefined> => {
-  const composite = await getImageCompositeSrc(context, struct);
+  const composite = await getImageCompositeSrc(context, struct, options);
   if (composite) {
     const name = struct?.["$name"] ?? "";
     return `<img src="${escapeAttribute(composite)}" alt="${escapeAttribute(

--- a/packages/sparkdown/src/compiler/utils/getImageComposite.ts
+++ b/packages/sparkdown/src/compiler/utils/getImageComposite.ts
@@ -1,41 +1,35 @@
+import {
+  composeThumbnailBlob,
+  thumbnailCacheKey,
+  type ThumbnailSource,
+} from "../../thumbnails/composeThumbnail";
 import { getImagePreviewMarkup, getImagePreviewSrc } from "./getImagePreviewSrc";
 import { resolveImageLayerSrcs } from "./resolveImageLayerSrcs";
 
 /**
- * Composite a `layered_image`'s layers into a single thumbnail so previews can
- * show what the asset actually looks like.
+ * Flatten a `layered_image`'s layers into a single thumbnail so previews show
+ * what the asset actually looks like instead of just its base plate.
  *
- * Why a raster composite rather than stacked HTML: VS Code's markdown
- * sanitizer drops `style` and `class`, so any CSS-based stack silently
- * collapses there while working in the editor. The only markup both hosts
- * render identically is one `<img src>` — so the layers have to be flattened
- * before they reach the renderer.
+ * Why one flattened image rather than stacked HTML: VS Code's markdown
+ * sanitizer drops `style` and `class`, so a CSS stack works in the editor and
+ * silently collapses there. One `<img src>` is the only markup both hosts
+ * render identically.
  *
- * Why raster rather than an SVG wrapper: an SVG loaded through `<img>` runs in
- * secure static mode and cannot pull in external resources, and a markup splice
- * cannot mix an SVG layer with a PNG one. Canvas does not care what each layer
- * was, and its output is bounded by the thumbnail size rather than by how much
- * detail the artist drew.
- *
- * Everything here degrades to the existing single-layer preview rather than
- * failing: no canvas in this host, an un-fetchable layer, or an oversized
- * result all fall back to `getImagePreviewMarkup`.
+ * Generation itself is shared with the editor's service-worker thumbnails —
+ * see `composeThumbnail`. This module only adds the language-server concerns:
+ * resolving a struct to its layers, fetching them, and caching per session.
  */
 
-/** 2x the 180px the completion panel displays, so it stays sharp on retina. */
-const MAX_HEIGHT = 360;
+/** 2x the width the completion panel displays, so it stays sharp on retina. */
+const PREVIEW_WIDTH = 360;
 
 /**
- * Ceiling for the generated data URI. A composite over this is a sign
- * something is wrong (huge source art, a pathological layer count) and is not
- * worth risking against a host's string handling — fall back instead.
+ * Ceiling for the generated data URI. Anything past this suggests something
+ * pathological; fall back rather than risk a host's string handling.
  */
 const MAX_BYTES = 512 * 1024;
 
-const MIME = "image/webp";
-const QUALITY = 0.8;
-
-/** Bounded cache. Keyed by content, so no explicit invalidation is needed. */
+/** Per-session cache. Keyed by content, so nothing needs to invalidate it. */
 const MAX_CACHE_ENTRIES = 64;
 const cache = new Map<string, string>();
 
@@ -60,11 +54,6 @@ const cacheSet = (key: string, value: string) => {
   }
 };
 
-const canComposite = () =>
-  typeof OffscreenCanvas !== "undefined" &&
-  typeof createImageBitmap === "function" &&
-  typeof fetch === "function";
-
 const toDataUri = (bytes: Uint8Array, mime: string) => {
   // Chunked so a large buffer doesn't blow the argument limit on `apply`.
   let binary = "";
@@ -77,25 +66,41 @@ const toDataUri = (bytes: Uint8Array, mime: string) => {
   return `data:${mime};base64,${btoa(binary)}`;
 };
 
-const loadLayer = async (src: string) => {
+/**
+ * Fetch one layer's bytes along with the metadata its cache key needs.
+ *
+ * `fetch` covers impower-dev, where layer srcs are served urls. It does NOT
+ * cover VS Code, whose srcs are workspace uris a worker can't fetch — that
+ * host needs bytes handed to it over the extension bridge (see #292), and
+ * until then falls back to the single-layer preview.
+ */
+const loadLayer = async (src: string): Promise<ThumbnailSource | undefined> => {
   try {
     const response = await fetch(src);
     if (!response.ok) {
       return undefined;
     }
     const blob = await response.blob();
-    return await createImageBitmap(blob);
+    const lastModified = Date.parse(
+      response.headers.get("last-modified") || "",
+    );
+    return {
+      // Strip the `?v=` cache-buster: it is re-stamped on every load, so
+      // leaving it in would make the key miss every time.
+      path: src.split("?")[0] || src,
+      blob,
+      lastModified: Number.isFinite(lastModified) ? lastModified : 0,
+      size: blob.size,
+    };
   } catch {
-    // An un-fetchable layer is expected in some hosts (see #292) — the caller
-    // falls back to the single-layer preview rather than showing nothing.
     return undefined;
   }
 };
 
 /**
- * Build the composited data URI for a struct, or `undefined` when compositing
- * isn't possible or isn't worth it (fewer than two layers, no canvas, a layer
- * that won't load, or an oversized result).
+ * Composited data URI for a struct, or `undefined` when compositing isn't
+ * possible or isn't worth it (fewer than two layers, no canvas, an
+ * un-fetchable layer, or an oversized result).
  */
 export const getImageCompositeSrc = async (
   context: { [type: string]: { [name: string]: any } } | undefined,
@@ -106,66 +111,42 @@ export const getImageCompositeSrc = async (
     // Nothing to flatten — the plain resolver already returns the right thing.
     return undefined;
   }
-  // Layer srcs carry the workspace's `?v=` cache-buster, so the joined list is
-  // a content key: a changed layer or a changed definition changes the key and
-  // misses the cache on its own. No invalidation hook to keep in sync.
-  const key = layers.join("|");
+  // Provisional key from the srcs, to avoid re-fetching layers on every
+  // keystroke's worth of resolves. Replaced below by the stable signature key
+  // once the responses tell us each layer's real identity.
+  const provisionalKey = layers.join("|");
+  const provisional = cacheGet(provisionalKey);
+  if (provisional !== undefined) {
+    return provisional || undefined;
+  }
+
+  const sources = await Promise.all(layers.map(loadLayer));
+  if (sources.some((s) => !s)) {
+    // Cache the failure: retrying a fetch that can't work in this host on
+    // every resolve would be worse than one stale miss.
+    cacheSet(provisionalKey, "");
+    return undefined;
+  }
+  const loaded = sources as ThumbnailSource[];
+
+  const key = thumbnailCacheKey(loaded, PREVIEW_WIDTH);
   const cached = cacheGet(key);
   if (cached !== undefined) {
+    cacheSet(provisionalKey, cached);
     return cached || undefined;
   }
-  if (!canComposite()) {
-    return undefined;
-  }
 
-  const bitmaps = await Promise.all(layers.map(loadLayer));
-  if (bitmaps.some((b) => !b)) {
-    bitmaps.forEach((b) => b?.close());
-    // Cache the failure too — retrying a broken fetch on every keystroke's
-    // worth of completion resolves would be worse than one stale miss.
+  const blob = await composeThumbnailBlob(loaded, PREVIEW_WIDTH);
+  if (!blob) {
     cacheSet(key, "");
+    cacheSet(provisionalKey, "");
     return undefined;
   }
-
-  const loaded = bitmaps as ImageBitmap[];
-  const width = Math.max(...loaded.map((b) => b.width));
-  const height = Math.max(...loaded.map((b) => b.height));
-  if (!width || !height) {
-    loaded.forEach((b) => b.close());
-    cacheSet(key, "");
-    return undefined;
-  }
-  const scale = Math.min(1, MAX_HEIGHT / height);
-  const w = Math.max(1, Math.round(width * scale));
-  const h = Math.max(1, Math.round(height * scale));
-
-  try {
-    const canvas = new OffscreenCanvas(w, h);
-    const ctx = canvas.getContext("2d");
-    if (!ctx) {
-      return undefined;
-    }
-    // `assets` is ordered bottom-to-top: UIModule reverses it for CSS
-    // `background-image` (which paints its first layer on top), so drawing in
-    // array order reproduces what the game shows.
-    for (const bitmap of loaded) {
-      ctx.drawImage(bitmap, 0, 0, w, h);
-    }
-    const blob = await canvas.convertToBlob({ type: MIME, quality: QUALITY });
-    const bytes = new Uint8Array(await blob.arrayBuffer());
-    const uri = toDataUri(bytes, blob.type || MIME);
-    if (uri.length > MAX_BYTES) {
-      cacheSet(key, "");
-      return undefined;
-    }
-    cacheSet(key, uri);
-    return uri;
-  } catch {
-    cacheSet(key, "");
-    return undefined;
-  } finally {
-    loaded.forEach((b) => b.close());
-  }
+  const uri = toDataUri(new Uint8Array(await blob.arrayBuffer()), blob.type);
+  const value = uri.length > MAX_BYTES ? "" : uri;
+  cacheSet(key, value);
+  cacheSet(provisionalKey, value);
+  return value || undefined;
 };
 
 const escapeAttribute = (value: string) =>

--- a/packages/sparkdown/src/compiler/utils/getImageComposite.ts
+++ b/packages/sparkdown/src/compiler/utils/getImageComposite.ts
@@ -1,0 +1,194 @@
+import { getImagePreviewMarkup, getImagePreviewSrc } from "./getImagePreviewSrc";
+import { resolveImageLayerSrcs } from "./resolveImageLayerSrcs";
+
+/**
+ * Composite a `layered_image`'s layers into a single thumbnail so previews can
+ * show what the asset actually looks like.
+ *
+ * Why a raster composite rather than stacked HTML: VS Code's markdown
+ * sanitizer drops `style` and `class`, so any CSS-based stack silently
+ * collapses there while working in the editor. The only markup both hosts
+ * render identically is one `<img src>` — so the layers have to be flattened
+ * before they reach the renderer.
+ *
+ * Why raster rather than an SVG wrapper: an SVG loaded through `<img>` runs in
+ * secure static mode and cannot pull in external resources, and a markup splice
+ * cannot mix an SVG layer with a PNG one. Canvas does not care what each layer
+ * was, and its output is bounded by the thumbnail size rather than by how much
+ * detail the artist drew.
+ *
+ * Everything here degrades to the existing single-layer preview rather than
+ * failing: no canvas in this host, an un-fetchable layer, or an oversized
+ * result all fall back to `getImagePreviewMarkup`.
+ */
+
+/** 2x the 180px the completion panel displays, so it stays sharp on retina. */
+const MAX_HEIGHT = 360;
+
+/**
+ * Ceiling for the generated data URI. A composite over this is a sign
+ * something is wrong (huge source art, a pathological layer count) and is not
+ * worth risking against a host's string handling — fall back instead.
+ */
+const MAX_BYTES = 512 * 1024;
+
+const MIME = "image/webp";
+const QUALITY = 0.8;
+
+/** Bounded cache. Keyed by content, so no explicit invalidation is needed. */
+const MAX_CACHE_ENTRIES = 64;
+const cache = new Map<string, string>();
+
+const cacheGet = (key: string) => {
+  const hit = cache.get(key);
+  if (hit !== undefined) {
+    // Refresh recency so the working set survives eviction.
+    cache.delete(key);
+    cache.set(key, hit);
+  }
+  return hit;
+};
+
+const cacheSet = (key: string, value: string) => {
+  cache.set(key, value);
+  while (cache.size > MAX_CACHE_ENTRIES) {
+    const oldest = cache.keys().next();
+    if (oldest.done) {
+      break;
+    }
+    cache.delete(oldest.value);
+  }
+};
+
+const canComposite = () =>
+  typeof OffscreenCanvas !== "undefined" &&
+  typeof createImageBitmap === "function" &&
+  typeof fetch === "function";
+
+const toDataUri = (bytes: Uint8Array, mime: string) => {
+  // Chunked so a large buffer doesn't blow the argument limit on `apply`.
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(
+      ...(bytes.subarray(i, i + CHUNK) as unknown as number[]),
+    );
+  }
+  return `data:${mime};base64,${btoa(binary)}`;
+};
+
+const loadLayer = async (src: string) => {
+  try {
+    const response = await fetch(src);
+    if (!response.ok) {
+      return undefined;
+    }
+    const blob = await response.blob();
+    return await createImageBitmap(blob);
+  } catch {
+    // An un-fetchable layer is expected in some hosts (see #292) — the caller
+    // falls back to the single-layer preview rather than showing nothing.
+    return undefined;
+  }
+};
+
+/**
+ * Build the composited data URI for a struct, or `undefined` when compositing
+ * isn't possible or isn't worth it (fewer than two layers, no canvas, a layer
+ * that won't load, or an oversized result).
+ */
+export const getImageCompositeSrc = async (
+  context: { [type: string]: { [name: string]: any } } | undefined,
+  struct: any,
+): Promise<string | undefined> => {
+  const layers = resolveImageLayerSrcs(context, struct);
+  if (layers.length < 2) {
+    // Nothing to flatten — the plain resolver already returns the right thing.
+    return undefined;
+  }
+  // Layer srcs carry the workspace's `?v=` cache-buster, so the joined list is
+  // a content key: a changed layer or a changed definition changes the key and
+  // misses the cache on its own. No invalidation hook to keep in sync.
+  const key = layers.join("|");
+  const cached = cacheGet(key);
+  if (cached !== undefined) {
+    return cached || undefined;
+  }
+  if (!canComposite()) {
+    return undefined;
+  }
+
+  const bitmaps = await Promise.all(layers.map(loadLayer));
+  if (bitmaps.some((b) => !b)) {
+    bitmaps.forEach((b) => b?.close());
+    // Cache the failure too — retrying a broken fetch on every keystroke's
+    // worth of completion resolves would be worse than one stale miss.
+    cacheSet(key, "");
+    return undefined;
+  }
+
+  const loaded = bitmaps as ImageBitmap[];
+  const width = Math.max(...loaded.map((b) => b.width));
+  const height = Math.max(...loaded.map((b) => b.height));
+  if (!width || !height) {
+    loaded.forEach((b) => b.close());
+    cacheSet(key, "");
+    return undefined;
+  }
+  const scale = Math.min(1, MAX_HEIGHT / height);
+  const w = Math.max(1, Math.round(width * scale));
+  const h = Math.max(1, Math.round(height * scale));
+
+  try {
+    const canvas = new OffscreenCanvas(w, h);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return undefined;
+    }
+    // `assets` is ordered bottom-to-top: UIModule reverses it for CSS
+    // `background-image` (which paints its first layer on top), so drawing in
+    // array order reproduces what the game shows.
+    for (const bitmap of loaded) {
+      ctx.drawImage(bitmap, 0, 0, w, h);
+    }
+    const blob = await canvas.convertToBlob({ type: MIME, quality: QUALITY });
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    const uri = toDataUri(bytes, blob.type || MIME);
+    if (uri.length > MAX_BYTES) {
+      cacheSet(key, "");
+      return undefined;
+    }
+    cacheSet(key, uri);
+    return uri;
+  } catch {
+    cacheSet(key, "");
+    return undefined;
+  } finally {
+    loaded.forEach((b) => b.close());
+  }
+};
+
+const escapeAttribute = (value: string) =>
+  value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+
+/**
+ * Preview markup for an image-ish struct, compositing layered images when the
+ * host can and falling back to the single-layer preview when it can't.
+ */
+export const getImagePreviewMarkupComposited = async (
+  context: { [type: string]: { [name: string]: any } } | undefined,
+  struct: any,
+): Promise<string | undefined> => {
+  const composite = await getImageCompositeSrc(context, struct);
+  if (composite) {
+    const name = struct?.["$name"] ?? "";
+    return `<img src="${escapeAttribute(composite)}" alt="${escapeAttribute(
+      name,
+    )}" height="180" />`;
+  }
+  // Either a single-layer asset or a host/asset that can't be composited.
+  if (getImagePreviewSrc(context, struct)) {
+    return getImagePreviewMarkup(context, struct);
+  }
+  return undefined;
+};

--- a/packages/sparkdown/src/compiler/utils/getImageComposite.ts
+++ b/packages/sparkdown/src/compiler/utils/getImageComposite.ts
@@ -1,4 +1,5 @@
 import {
+  bytesToBase64,
   composeThumbnailBlob,
   thumbnailCacheKey,
   type ThumbnailSource,
@@ -69,17 +70,8 @@ const cacheSet = (key: string, value: string) => {
   }
 };
 
-const toDataUri = (bytes: Uint8Array, mime: string) => {
-  // Chunked so a large buffer doesn't blow the argument limit on `apply`.
-  let binary = "";
-  const CHUNK = 0x8000;
-  for (let i = 0; i < bytes.length; i += CHUNK) {
-    binary += String.fromCharCode(
-      ...(bytes.subarray(i, i + CHUNK) as unknown as number[]),
-    );
-  }
-  return `data:${mime};base64,${btoa(binary)}`;
-};
+const toDataUri = (bytes: Uint8Array, mime: string) =>
+  `data:${mime};base64,${bytesToBase64(bytes)}`;
 
 /**
  * Fetch one layer's bytes along with the metadata its cache key needs.

--- a/packages/sparkdown/src/compiler/utils/getImagePreviewSrc.ts
+++ b/packages/sparkdown/src/compiler/utils/getImagePreviewSrc.ts
@@ -1,4 +1,5 @@
 import { filterImage } from "./filterImage";
+import { resolveImageReference } from "./resolveImageReference";
 
 /**
  * Resolve an image-ish context struct down to something an `<img src>` can
@@ -105,27 +106,3 @@ export const getImagePreviewMarkup = (
   )}" height="180" />`;
 };
 
-/**
- * Look a `{ $type, $name }` reference up in the compiled context. A bare name
- * in a `.sd` table lowers to `$type: ""`, meaning "search every type by name",
- * so fall back to the image types in specificity order — `filtered_image`
- * first, because an SVG asset gets an implicit filtered_image declared for it
- * and that is the variant a preview should show.
- */
-const resolveImageReference = (
-  context: { [type: string]: { [name: string]: any } } | undefined,
-  ref: any,
-): any => {
-  if (!ref || typeof ref !== "object" || !ref["$name"]) {
-    return undefined;
-  }
-  const name = ref["$name"];
-  if (ref["$type"]) {
-    return context?.[ref["$type"]]?.[name];
-  }
-  return (
-    context?.["filtered_image"]?.[name] ??
-    context?.["image"]?.[name] ??
-    context?.["layered_image"]?.[name]
-  );
-};

--- a/packages/sparkdown/src/compiler/utils/resolveImageLayerSrcs.ts
+++ b/packages/sparkdown/src/compiler/utils/resolveImageLayerSrcs.ts
@@ -1,0 +1,74 @@
+import { filterImage } from "./filterImage";
+import { resolveImageReference } from "./resolveImageReference";
+
+/**
+ * Flatten an image-ish struct into the ordered list of layer sources that make
+ * it up, **bottom layer first**.
+ *
+ * That order is not arbitrary: `UIModule.createImage` reverses the asset list
+ * before joining it into CSS `background-image` (whose first layer paints on
+ * top), so `assets[0]` is the bottom-most layer in the running game. Anything
+ * compositing these has to draw in the same order or the preview won't match.
+ *
+ * Returns `[]` when nothing resolves, and a single entry for a plain image —
+ * callers treat "fewer than two layers" as "nothing to composite".
+ */
+export const resolveImageLayerSrcs = (
+  context: { [type: string]: { [name: string]: any } } | undefined,
+  struct: any,
+  visited = new Set<any>(),
+): string[] => {
+  if (!struct || typeof struct !== "object" || visited.has(struct)) {
+    return [];
+  }
+  visited.add(struct);
+
+  const type = struct["$type"];
+
+  if (type === "image") {
+    const src = struct["src"] || struct["data"] || struct["uri"];
+    return src ? [src] : [];
+  }
+
+  if (type === "filtered_image") {
+    if (context) {
+      filterImage(context, struct);
+    }
+    if (struct["filtered_src"]) {
+      // A filtered SVG is already a single flattened source.
+      return [struct["filtered_src"]];
+    }
+    return resolveImageLayerSrcs(
+      context,
+      resolveImageReference(context, struct["image"]),
+      visited,
+    );
+  }
+
+  if (type === "layered_image") {
+    const assets = struct["assets"];
+    const layers = Array.isArray(assets)
+      ? assets
+      : assets && typeof assets === "object"
+        ? Object.values(assets)
+        : [];
+    return layers.flatMap((layer) =>
+      resolveImageLayerSrcs(
+        context,
+        resolveImageReference(context, layer),
+        // Branch the guard per layer rather than sharing it: it exists to stop
+        // cycles along one path, and sharing it would silently drop a layer
+        // that legitimately reuses an asset an earlier layer already used.
+        new Set(visited),
+      ),
+    );
+  }
+
+  if (!type) {
+    const resolved = resolveImageReference(context, struct);
+    if (resolved && resolved !== struct) {
+      return resolveImageLayerSrcs(context, resolved, visited);
+    }
+  }
+  return [];
+};

--- a/packages/sparkdown/src/compiler/utils/resolveImageLayers.ts
+++ b/packages/sparkdown/src/compiler/utils/resolveImageLayers.ts
@@ -1,9 +1,25 @@
 import { filterImage } from "./filterImage";
 import { resolveImageReference } from "./resolveImageReference";
 
+/** One layer of a flattened image: how to display it, and how to read it. */
+export interface ImageLayer {
+  /**
+   * Directly usable source (a served url, or a `data:` uri for inlined SVG).
+   * Always present — this is what a preview renders when no compositing is
+   * needed.
+   */
+  src: string;
+  /**
+   * Workspace uri, when the layer came from a file. Hosts that can't `fetch`
+   * a layer's `src` (VS Code, whose srcs are workspace uris a worker cannot
+   * fetch) read the bytes through this instead.
+   */
+  uri?: string;
+}
+
 /**
- * Flatten an image-ish struct into the ordered list of layer sources that make
- * it up, **bottom layer first**.
+ * Flatten an image-ish struct into the ordered layers that make it up,
+ * **bottom layer first**.
  *
  * That order is not arbitrary: `UIModule.createImage` reverses the asset list
  * before joining it into CSS `background-image` (whose first layer paints on
@@ -13,11 +29,11 @@ import { resolveImageReference } from "./resolveImageReference";
  * Returns `[]` when nothing resolves, and a single entry for a plain image —
  * callers treat "fewer than two layers" as "nothing to composite".
  */
-export const resolveImageLayerSrcs = (
+export const resolveImageLayers = (
   context: { [type: string]: { [name: string]: any } } | undefined,
   struct: any,
   visited = new Set<any>(),
-): string[] => {
+): ImageLayer[] => {
   if (!struct || typeof struct !== "object" || visited.has(struct)) {
     return [];
   }
@@ -27,7 +43,7 @@ export const resolveImageLayerSrcs = (
 
   if (type === "image") {
     const src = struct["src"] || struct["data"] || struct["uri"];
-    return src ? [src] : [];
+    return src ? [{ src, uri: struct["uri"] }] : [];
   }
 
   if (type === "filtered_image") {
@@ -35,10 +51,11 @@ export const resolveImageLayerSrcs = (
       filterImage(context, struct);
     }
     if (struct["filtered_src"]) {
-      // A filtered SVG is already a single flattened source.
-      return [struct["filtered_src"]];
+      // A filtered SVG is already a single flattened source, inline in the
+      // context — there is no file to read behind it.
+      return [{ src: struct["filtered_src"] }];
     }
-    return resolveImageLayerSrcs(
+    return resolveImageLayers(
       context,
       resolveImageReference(context, struct["image"]),
       visited,
@@ -53,7 +70,7 @@ export const resolveImageLayerSrcs = (
         ? Object.values(assets)
         : [];
     return layers.flatMap((layer) =>
-      resolveImageLayerSrcs(
+      resolveImageLayers(
         context,
         resolveImageReference(context, layer),
         // Branch the guard per layer rather than sharing it: it exists to stop
@@ -67,7 +84,7 @@ export const resolveImageLayerSrcs = (
   if (!type) {
     const resolved = resolveImageReference(context, struct);
     if (resolved && resolved !== struct) {
-      return resolveImageLayerSrcs(context, resolved, visited);
+      return resolveImageLayers(context, resolved, visited);
     }
   }
   return [];

--- a/packages/sparkdown/src/compiler/utils/resolveImageReference.ts
+++ b/packages/sparkdown/src/compiler/utils/resolveImageReference.ts
@@ -1,0 +1,25 @@
+/**
+ * Look a `{ $type, $name }` reference up in the compiled context.
+ *
+ * A bare name in a `.sd` table lowers to `$type: ""`, meaning "search every
+ * type by name", so fall back to the image types in specificity order —
+ * `filtered_image` first, because an SVG asset gets an implicit filtered_image
+ * declared for it and that is the variant a preview should show.
+ */
+export const resolveImageReference = (
+  context: { [type: string]: { [name: string]: any } } | undefined,
+  ref: any,
+): any => {
+  if (!ref || typeof ref !== "object" || !ref["$name"]) {
+    return undefined;
+  }
+  const name = ref["$name"];
+  if (ref["$type"]) {
+    return context?.[ref["$type"]]?.[name];
+  }
+  return (
+    context?.["filtered_image"]?.[name] ??
+    context?.["image"]?.[name] ??
+    context?.["layered_image"]?.[name]
+  );
+};

--- a/packages/sparkdown/src/tests/compiler/ImageComposite.test.ts
+++ b/packages/sparkdown/src/tests/compiler/ImageComposite.test.ts
@@ -200,6 +200,60 @@ describe("getImageCompositeSrc", () => {
     expect(src).toBeUndefined();
   });
 
+  it("evicts old entries rather than growing without bound", async () => {
+    stubRasterizer();
+    const calls = stubFetch();
+    // Well past the 64-entry ceiling: each composite stores two entries (a
+    // provisional src key and the stable signature key).
+    const contexts = Array.from({ length: 60 }, (_, i) =>
+      makeContext(`evict${i}`, ["base", "prop"]),
+    );
+    for (const ctx of contexts) {
+      await getImageCompositeSrc(ctx, ctx.layered_image.bg);
+    }
+    const before = calls.length;
+    // The first one is long since evicted, so this must go back to the network.
+    await getImageCompositeSrc(contexts[0]!, contexts[0]!.layered_image.bg);
+    expect(calls.length).toBeGreaterThan(before);
+  });
+
+  it("keeps recently READ entries, evicting by use rather than by insertion", async () => {
+    // The distinction between an LRU and a plain FIFO: without the recency
+    // refresh on read, the entry below would be evicted despite being the most
+    // recently used, and a preview the user keeps returning to would
+    // recomposite every time.
+    stubRasterizer();
+    const calls = stubFetch();
+    const hot = makeContext("hot", ["base", "prop"]);
+    await getImageCompositeSrc(hot, hot.layered_image.bg);
+
+    const filler = Array.from({ length: 30 }, (_, i) =>
+      makeContext(`filler${i}`, ["base", "prop"]),
+    );
+    for (const ctx of filler) {
+      await getImageCompositeSrc(ctx, ctx.layered_image.bg);
+    }
+
+    // Touch it, making it the most recently used entry.
+    const beforeTouch = calls.length;
+    await getImageCompositeSrc(hot, hot.layered_image.bg);
+    expect(calls.length).toBe(beforeTouch);
+
+    // Now overflow the cache. A FIFO would drop `hot` (inserted first).
+    for (const ctx of Array.from({ length: 20 }, (_, i) =>
+      makeContext(`after${i}`, ["base", "prop"]),
+    )) {
+      await getImageCompositeSrc(ctx, ctx.layered_image.bg);
+    }
+
+    const beforeFinal = calls.length;
+    await getImageCompositeSrc(hot, hot.layered_image.bg);
+    expect(calls.length).toBe(beforeFinal);
+    // ...while an untouched early entry did get evicted.
+    await getImageCompositeSrc(filler[0]!, filler[0]!.layered_image.bg);
+    expect(calls.length).toBeGreaterThan(beforeFinal);
+  });
+
   it("degrades when the host cannot rasterize", async () => {
     // No OffscreenCanvas: an older host, or a worker without canvas support.
     stubFetch();

--- a/packages/sparkdown/src/tests/compiler/ImageComposite.test.ts
+++ b/packages/sparkdown/src/tests/compiler/ImageComposite.test.ts
@@ -1,0 +1,212 @@
+// Coverage for the compositing itself (#292) — the parts previously verified
+// only by hand in a running editor.
+//
+// `composeThumbnailBlob` needs OffscreenCanvas/createImageBitmap, which node
+// doesn't have, so those are stubbed. That is deliberate: the point of these
+// tests is the surrounding decision-making — draw order, the fetch/bridge
+// fallback, failure caching, and the byte cap — not the browser's rasterizer.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getImageCompositeSrc } from "../../compiler/utils/getImageComposite";
+import {
+  clampThumbnailWidth,
+  thumbnailCacheKey,
+  THUMB_MAX_WIDTH,
+  THUMB_MIN_WIDTH,
+} from "../../thumbnails/composeThumbnail";
+
+/**
+ * Build a context whose layered image stacks the given layer names.
+ * `salt` keeps each test's srcs unique — the composite cache is module-level
+ * and would otherwise leak results between tests.
+ */
+const makeContext = (salt: string, layerNames: string[]) => {
+  const image: Record<string, any> = {};
+  for (const name of layerNames) {
+    image[name] = {
+      $type: "image",
+      $name: name,
+      src: `/file:/local/${salt}/${name}.png?v=1`,
+      uri: `file://proj/${salt}/${name}.png`,
+    };
+  }
+  return {
+    image,
+    layered_image: {
+      bg: {
+        $type: "layered_image",
+        $name: "bg",
+        assets: layerNames.map((name) => ({ $type: "", $name: name })),
+      },
+    },
+  };
+};
+
+/** Records which bitmaps got drawn, in order, so draw order is assertable. */
+let drawn: string[] = [];
+
+const stubRasterizer = (blobBytes = 32) => {
+  drawn = [];
+  vi.stubGlobal("createImageBitmap", async (blob: Blob) => {
+    const tag = await blob.text();
+    return { width: 100, height: 50, close() {}, tag };
+  });
+  vi.stubGlobal(
+    "OffscreenCanvas",
+    class {
+      constructor(
+        public width: number,
+        public height: number,
+      ) {}
+      getContext() {
+        return {
+          drawImage: (bitmap: any) => drawn.push(bitmap.tag),
+        };
+      }
+      async convertToBlob() {
+        return new Blob([new Uint8Array(blobBytes)], { type: "image/webp" });
+      }
+    },
+  );
+};
+
+/** fetch that serves each layer's own name as its body, so draws are traceable. */
+const stubFetch = (opts: { fails?: boolean } = {}) => {
+  const calls: string[] = [];
+  vi.stubGlobal("fetch", async (url: string) => {
+    calls.push(url);
+    if (opts.fails) {
+      throw new TypeError("fetch not supported for this scheme");
+    }
+    const name = url.split("/").pop()!.split(".")[0]!;
+    return {
+      ok: true,
+      blob: async () => new Blob([name]),
+      headers: { get: () => null },
+    };
+  });
+  return calls;
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("thumbnail cache key", () => {
+  it("changes when a layer's bytes change, not when its url is re-stamped", () => {
+    const a = [{ path: "/x/a.png", lastModified: 10, size: 100 }];
+    const b = [{ path: "/x/a.png", lastModified: 20, size: 100 }];
+    const c = [{ path: "/x/a.png", lastModified: 10, size: 999 }];
+    expect(thumbnailCacheKey(a, 360)).toBe(thumbnailCacheKey([...a], 360));
+    expect(thumbnailCacheKey(a, 360)).not.toBe(thumbnailCacheKey(b, 360));
+    expect(thumbnailCacheKey(a, 360)).not.toBe(thumbnailCacheKey(c, 360));
+  });
+
+  it("distinguishes layer sets and widths", () => {
+    const one = [{ path: "/x/a.png", lastModified: 1, size: 2 }];
+    const two = [...one, { path: "/x/b.png", lastModified: 3, size: 4 }];
+    expect(thumbnailCacheKey(one, 360)).not.toBe(thumbnailCacheKey(two, 360));
+    expect(thumbnailCacheKey(one, 360)).not.toBe(thumbnailCacheKey(one, 144));
+  });
+
+  it("clamps requested widths into range", () => {
+    expect(clampThumbnailWidth(1)).toBe(THUMB_MIN_WIDTH);
+    expect(clampThumbnailWidth(99999)).toBe(THUMB_MAX_WIDTH);
+    expect(clampThumbnailWidth("garbage")).toBe(THUMB_MIN_WIDTH);
+    expect(clampThumbnailWidth(144)).toBe(144);
+  });
+});
+
+describe("getImageCompositeSrc", () => {
+  it("draws layers bottom-first, matching the order the game paints", async () => {
+    stubRasterizer();
+    stubFetch();
+    const ctx = makeContext("order", ["base", "prop", "light"]);
+    const src = await getImageCompositeSrc(ctx, ctx.layered_image.bg);
+    expect(src).toMatch(/^data:image\/webp;base64,/);
+    // Reversing this would silently invert every layered image.
+    expect(drawn).toEqual(["base", "prop", "light"]);
+  });
+
+  it("does not composite a single-layer asset", async () => {
+    stubRasterizer();
+    const calls = stubFetch();
+    const ctx = makeContext("single", ["only"]);
+    const src = await getImageCompositeSrc(ctx, ctx.image.only);
+    expect(src).toBeUndefined();
+    // Nothing to flatten, so nothing should have been fetched or drawn.
+    expect(calls).toEqual([]);
+    expect(drawn).toEqual([]);
+  });
+
+  it("falls back to the byte bridge when a layer can't be fetched", async () => {
+    stubRasterizer();
+    stubFetch({ fails: true });
+    const ctx = makeContext("bridge", ["base", "prop"]);
+    const asked: string[] = [];
+    const src = await getImageCompositeSrc(ctx, ctx.layered_image.bg, {
+      readFileBytes: async (uri) => {
+        asked.push(uri);
+        // base64 of the layer name, so draw order stays traceable.
+        return btoa(uri.split("/").pop()!.split(".")[0]!);
+      },
+    });
+    expect(src).toMatch(/^data:image\/webp;base64,/);
+    // Asked by URI, not src — the bridge reads workspace files.
+    expect(asked).toEqual([
+      "file://proj/bridge/base.png",
+      "file://proj/bridge/prop.png",
+    ]);
+    expect(drawn).toEqual(["base", "prop"]);
+  });
+
+  it("gives up when a layer is unreachable and no bridge is available", async () => {
+    stubRasterizer();
+    const calls = stubFetch({ fails: true });
+    const ctx = makeContext("unreachable", ["base", "prop"]);
+    const src = await getImageCompositeSrc(ctx, ctx.layered_image.bg);
+    expect(src).toBeUndefined();
+    expect(calls.length).toBe(2);
+  });
+
+  it("caches the failure so a dead fetch isn't retried on every resolve", async () => {
+    stubRasterizer();
+    const calls = stubFetch({ fails: true });
+    const ctx = makeContext("failcache", ["base", "prop"]);
+    await getImageCompositeSrc(ctx, ctx.layered_image.bg);
+    const afterFirst = calls.length;
+    await getImageCompositeSrc(ctx, ctx.layered_image.bg);
+    // Second call must be served from the cache, not re-fetched.
+    expect(calls.length).toBe(afterFirst);
+  });
+
+  it("reuses the cached composite instead of recompositing", async () => {
+    stubRasterizer();
+    const calls = stubFetch();
+    const ctx = makeContext("hit", ["base", "prop"]);
+    const first = await getImageCompositeSrc(ctx, ctx.layered_image.bg);
+    const afterFirst = calls.length;
+    const second = await getImageCompositeSrc(ctx, ctx.layered_image.bg);
+    expect(second).toBe(first);
+    expect(calls.length).toBe(afterFirst);
+  });
+
+  it("falls back rather than emitting an oversized data uri", async () => {
+    // Over the 512KB ceiling — a host might truncate it into a broken image.
+    stubRasterizer(600 * 1024);
+    stubFetch();
+    const ctx = makeContext("toobig", ["base", "prop"]);
+    const src = await getImageCompositeSrc(ctx, ctx.layered_image.bg);
+    expect(src).toBeUndefined();
+  });
+
+  it("degrades when the host cannot rasterize", async () => {
+    // No OffscreenCanvas: an older host, or a worker without canvas support.
+    stubFetch();
+    vi.stubGlobal("OffscreenCanvas", undefined);
+    vi.stubGlobal("createImageBitmap", undefined);
+    const ctx = makeContext("norender", ["base", "prop"]);
+    const src = await getImageCompositeSrc(ctx, ctx.layered_image.bg);
+    expect(src).toBeUndefined();
+  });
+});

--- a/packages/sparkdown/src/tests/compiler/ResolveImageLayerSrcs.test.ts
+++ b/packages/sparkdown/src/tests/compiler/ResolveImageLayerSrcs.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, it } from "vitest";
 import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
 import { File } from "../../compiler/types/File";
-import { resolveImageLayerSrcs } from "../../compiler/utils/resolveImageLayerSrcs";
+import { resolveImageLayers } from "../../compiler/utils/resolveImageLayers";
 
 const MAIN_URI = "file://proj/main.sd";
 
@@ -45,7 +45,7 @@ const compile = (text: string, assets: File[]) => {
 };
 
 const layersOf = (program: any, type: string, name: string) =>
-  resolveImageLayerSrcs(program.context, program.context?.[type]?.[name]);
+  resolveImageLayers(program.context, program.context?.[type]?.[name]).map((l) => l.src);
 
 describe("resolveImageLayerSrcs", () => {
   it("returns layers bottom-first, matching the order the game paints", () => {

--- a/packages/sparkdown/src/tests/compiler/ResolveImageLayerSrcs.test.ts
+++ b/packages/sparkdown/src/tests/compiler/ResolveImageLayerSrcs.test.ts
@@ -1,0 +1,186 @@
+// Compositing a layered preview (#292) needs the layers flattened in the same
+// order the game paints them. `UIModule.createImage` REVERSES the asset list
+// before joining it into CSS `background-image` (whose first entry paints on
+// top), so `assets[0]` is the BOTTOM layer. A compositor drawing in array order
+// therefore matches the running game; drawing reversed would silently invert
+// every layered image.
+
+import { describe, expect, it } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+import { File } from "../../compiler/types/File";
+import { resolveImageLayerSrcs } from "../../compiler/utils/resolveImageLayerSrcs";
+
+const MAIN_URI = "file://proj/main.sd";
+
+const assetFile = (uri: string, text?: string): File => {
+  const base = uri.split("/").slice(-1)[0]!;
+  const dot = base.lastIndexOf(".");
+  return {
+    uri,
+    type: "image",
+    name: dot >= 0 ? base.slice(0, dot) : base,
+    ext: dot >= 0 ? base.slice(dot + 1) : "",
+    src: `/file:/local/assets/${base}?v=1`,
+    text,
+  };
+};
+
+const compile = (text: string, assets: File[]) => {
+  const compiler = new SparkdownCompiler();
+  compiler.configure({
+    files: [
+      {
+        uri: MAIN_URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text,
+        version: 1,
+        languageId: "sparkdown",
+      },
+      ...assets,
+    ],
+  });
+  return compiler.compile({ textDocument: { uri: MAIN_URI } }).program;
+};
+
+const layersOf = (program: any, type: string, name: string) =>
+  resolveImageLayerSrcs(program.context, program.context?.[type]?.[name]);
+
+describe("resolveImageLayerSrcs", () => {
+  it("returns layers bottom-first, matching the order the game paints", () => {
+    const program = compile(
+      `define bg as layered_image with
+  assets = {
+    bg__base,
+    bg__prop,
+    bg__light,
+  }
+end
+`,
+      [
+        assetFile("file://proj/a/bg__base.png"),
+        assetFile("file://proj/a/bg__prop.png"),
+        assetFile("file://proj/a/bg__light.png"),
+      ],
+    );
+    expect(layersOf(program, "layered_image", "bg")).toEqual([
+      "/file:/local/assets/bg__base.png?v=1",
+      "/file:/local/assets/bg__prop.png?v=1",
+      "/file:/local/assets/bg__light.png?v=1",
+    ]);
+  });
+
+  it("flattens a keyed assets table in declaration order", () => {
+    const program = compile(
+      `define bg as layered_image with
+  assets = {
+    base = bg__base,
+    prop = bg__prop,
+  }
+end
+`,
+      [
+        assetFile("file://proj/a/bg__base.png"),
+        assetFile("file://proj/a/bg__prop.png"),
+      ],
+    );
+    expect(layersOf(program, "layered_image", "bg")).toEqual([
+      "/file:/local/assets/bg__base.png?v=1",
+      "/file:/local/assets/bg__prop.png?v=1",
+    ]);
+  });
+
+  it("returns a single entry for a plain image (nothing to composite)", () => {
+    const program = compile("", [assetFile("file://proj/a/photo.png")]);
+    expect(layersOf(program, "image", "photo")).toEqual([
+      "/file:/local/assets/photo.png?v=1",
+    ]);
+  });
+
+  it("treats a filtered svg as one already-flattened source", () => {
+    const program = compile("", [
+      assetFile(
+        "file://proj/a/portrait.svg",
+        `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="1" cy="1" r="1"/></svg>`,
+      ),
+    ]);
+    const layers = layersOf(program, "filtered_image", "portrait");
+    expect(layers).toHaveLength(1);
+    expect(layers[0]).toMatch(/^data:image\/svg\+xml,/);
+  });
+
+  it("descends through a filtered_image onto its layered root", () => {
+    const program = compile(
+      `define bg as layered_image with
+  assets = {
+    bg__base,
+    bg__prop,
+  }
+end
+
+define bg_dim as filtered_image with
+  image = bg
+end
+`,
+      [
+        assetFile("file://proj/a/bg__base.png"),
+        assetFile("file://proj/a/bg__prop.png"),
+      ],
+    );
+    expect(layersOf(program, "filtered_image", "bg_dim")).toEqual([
+      "/file:/local/assets/bg__base.png?v=1",
+      "/file:/local/assets/bg__prop.png?v=1",
+    ]);
+  });
+
+  it("keeps a layer that reuses an asset an earlier layer already used", () => {
+    // The cycle guard must be per-path, not global, or the repeat vanishes.
+    const program = compile(
+      `define bg as layered_image with
+  assets = {
+    bg__base,
+    bg__prop,
+    bg__base,
+  }
+end
+`,
+      [
+        assetFile("file://proj/a/bg__base.png"),
+        assetFile("file://proj/a/bg__prop.png"),
+      ],
+    );
+    expect(layersOf(program, "layered_image", "bg")).toHaveLength(3);
+  });
+
+  it("skips layers that do not resolve", () => {
+    const program = compile(
+      `define bg as layered_image with
+  assets = {
+    bg__missing,
+    bg__real,
+  }
+end
+`,
+      [assetFile("file://proj/a/bg__real.png")],
+    );
+    expect(layersOf(program, "layered_image", "bg")).toEqual([
+      "/file:/local/assets/bg__real.png?v=1",
+    ]);
+  });
+
+  it("terminates on a circular chain", () => {
+    const program = compile(
+      `define loop_a as filtered_image with
+  image = loop_b
+end
+
+define loop_b as filtered_image with
+  image = loop_a
+end
+`,
+      [],
+    );
+    expect(layersOf(program, "filtered_image", "loop_a")).toEqual([]);
+  });
+});

--- a/packages/sparkdown/src/tests/compiler/ThumbnailEndpoint.test.ts
+++ b/packages/sparkdown/src/tests/compiler/ThumbnailEndpoint.test.ts
@@ -1,0 +1,188 @@
+// Coverage for the thumbnail endpoint the editor's service worker serves
+// (`?thumb=<width>`) and the base64 encoding both hosts rely on.
+//
+// This logic used to live inside sw.ts, where nothing could reach it — a
+// service worker module can't be imported under vitest without executing its
+// event registrations. Cache Storage is a parameter here precisely so the
+// decisions around it are testable; the SW is now a thin adapter that supplies
+// the real cache.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  bytesToBase64,
+  getOrCreateThumbnail,
+  THUMB_MIN_WIDTH,
+  type ThumbnailCache,
+  type ThumbnailFile,
+} from "../../thumbnails/composeThumbnail";
+
+/** Minimal in-memory stand-in for Cache Storage, with call counts. */
+const makeCache = () => {
+  const entries = new Map<string, Response>();
+  const calls = { match: 0, put: 0 };
+  const cache: ThumbnailCache = {
+    async match(key) {
+      calls.match++;
+      const hit = entries.get(key);
+      return hit ? hit.clone() : undefined;
+    },
+    async put(key, response) {
+      calls.put++;
+      entries.set(key, response);
+    },
+  };
+  return { cache, entries, calls };
+};
+
+const makeFile = (
+  bytes = 64,
+  lastModified = 1000,
+): ThumbnailFile =>
+  Object.assign(new Blob([new Uint8Array(bytes)], { type: "image/png" }), {
+    lastModified,
+  }) as ThumbnailFile;
+
+let rasterizeCalls = 0;
+
+const stubRasterizer = () => {
+  rasterizeCalls = 0;
+  vi.stubGlobal("createImageBitmap", async () => {
+    rasterizeCalls++;
+    return { width: 100, height: 50, close() {} };
+  });
+  vi.stubGlobal(
+    "OffscreenCanvas",
+    class {
+      constructor(
+        public width: number,
+        public height: number,
+      ) {}
+      getContext() {
+        return { drawImage() {} };
+      }
+      async convertToBlob() {
+        return new Blob([new Uint8Array(16)], { type: "image/webp" });
+      }
+    },
+  );
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("bytesToBase64", () => {
+  it("round-trips", () => {
+    const bytes = new Uint8Array([0, 1, 2, 250, 255]);
+    expect(atob(bytesToBase64(bytes))).toBe(
+      String.fromCharCode(...Array.from(bytes)),
+    );
+  });
+
+  it("handles buffers far past the argument limit", () => {
+    // Deliberately past where an unchunked `String.fromCharCode(...bytes)`
+    // starts throwing RangeError — measured at somewhere between 100k and 130k
+    // elements on this runtime, so a chunk-sized buffer would NOT catch a
+    // regression here. Real assets are this big, which is the whole point.
+    const bytes = new Uint8Array(400_000);
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = i % 256;
+    }
+    const decoded = atob(bytesToBase64(bytes));
+    expect(decoded.length).toBe(bytes.length);
+    expect(decoded.charCodeAt(0)).toBe(0);
+    expect(decoded.charCodeAt(bytes.length - 1)).toBe(
+      (bytes.length - 1) % 256,
+    );
+  });
+});
+
+describe("thumbnail endpoint", () => {
+  it("generates, caches, and serves webp", async () => {
+    stubRasterizer();
+    const { cache, calls } = makeCache();
+    const res = await getOrCreateThumbnail(cache, "/a/x.png", makeFile(), "144");
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get("Content-Type")).toBe("image/webp");
+    expect(res?.headers.get("Cache-Control")).toContain("immutable");
+    expect(calls.put).toBe(1);
+  });
+
+  it("serves the cached copy instead of regenerating", async () => {
+    stubRasterizer();
+    const { cache, calls } = makeCache();
+    const file = makeFile();
+    await getOrCreateThumbnail(cache, "/a/x.png", file, "144");
+    const afterFirst = rasterizeCalls;
+    const res = await getOrCreateThumbnail(cache, "/a/x.png", file, "144");
+    expect(res?.status).toBe(200);
+    expect(rasterizeCalls).toBe(afterFirst);
+    expect(calls.put).toBe(1);
+  });
+
+  it("regenerates when the file's bytes change, not when its url is re-stamped", async () => {
+    stubRasterizer();
+    const { cache } = makeCache();
+    await getOrCreateThumbnail(cache, "/a/x.png", makeFile(64, 1000), "144");
+    const afterFirst = rasterizeCalls;
+    // Same signature — a re-stamped `?v=` must NOT cause a regeneration.
+    await getOrCreateThumbnail(cache, "/a/x.png", makeFile(64, 1000), "144");
+    expect(rasterizeCalls).toBe(afterFirst);
+    // Edited file — different mtime, so it must regenerate.
+    await getOrCreateThumbnail(cache, "/a/x.png", makeFile(64, 2000), "144");
+    expect(rasterizeCalls).toBe(afterFirst + 1);
+  });
+
+  it("keys separately per requested width", async () => {
+    stubRasterizer();
+    const { cache, entries } = makeCache();
+    const file = makeFile();
+    await getOrCreateThumbnail(cache, "/a/x.png", file, "144");
+    await getOrCreateThumbnail(cache, "/a/x.png", file, "360");
+    expect(entries.size).toBe(2);
+  });
+
+  it("declines a garbage or absurd width rather than guessing", async () => {
+    stubRasterizer();
+    const { cache } = makeCache();
+    const file = makeFile();
+    expect(
+      await getOrCreateThumbnail(cache, "/a/x.png", file, "garbage"),
+    ).toBeUndefined();
+    expect(await getOrCreateThumbnail(cache, "/a/x.png", file, "0")).toBeUndefined();
+    expect(
+      await getOrCreateThumbnail(cache, "/a/x.png", file, String(THUMB_MIN_WIDTH - 1)),
+    ).toBeUndefined();
+    expect(rasterizeCalls).toBe(0);
+  });
+
+  it("returns undefined so the caller can serve the original when generation fails", async () => {
+    // No rasterizer in this host.
+    vi.stubGlobal("OffscreenCanvas", undefined);
+    vi.stubGlobal("createImageBitmap", undefined);
+    const { cache, calls } = makeCache();
+    const res = await getOrCreateThumbnail(
+      cache,
+      "/a/x.png",
+      makeFile(),
+      "144",
+    );
+    expect(res).toBeUndefined();
+    // Nothing cached, so a later request in a capable host still works.
+    expect(calls.put).toBe(0);
+  });
+
+  it("survives a cache that throws", async () => {
+    stubRasterizer();
+    const cache: ThumbnailCache = {
+      async match() {
+        throw new Error("cache unavailable");
+      },
+      async put() {},
+    };
+    // A broken cache must degrade to "serve the original", not reject.
+    await expect(
+      getOrCreateThumbnail(cache, "/a/x.png", makeFile(), "144"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/sparkdown/src/thumbnails/composeThumbnail.ts
+++ b/packages/sparkdown/src/thumbnails/composeThumbnail.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared thumbnail generation for asset previews.
+ *
+ * Two callers, deliberately one implementation:
+ *  - impower-dev's service worker, answering `?thumb=<width>` with an HTTP
+ *    response it caches in Cache Storage.
+ *  - the language server, inlining the result as a `data:` URI for hosts with
+ *    no service worker to intercept a URL (VS Code, where the markdown
+ *    sanitizer also refuses any non-http(s) src).
+ *
+ * Only the DELIVERY differs between those two. Generation, sizing and the
+ * cache-key discipline are identical, so they live here — if they drift, the
+ * editor and the completion popup start disagreeing about what an asset looks
+ * like, which is exactly the class of bug this whole area keeps producing.
+ */
+
+/**
+ * Bump to invalidate every previously generated thumbnail when the generation
+ * logic changes (encoder, quality, sizing). Callers fold this into their cache
+ * key; nothing else needs to know.
+ */
+export const THUMB_VERSION = 1;
+
+export const THUMB_MIN_WIDTH = 16;
+export const THUMB_MAX_WIDTH = 512;
+
+const MIME = "image/webp";
+const QUALITY = 0.75;
+
+/** A layer's stable identity — NOT its url. See `thumbnailCacheKey`. */
+export interface ThumbnailSource {
+  /** Workspace path, used for the cache key. */
+  path: string;
+  /** Bytes to decode. A `Blob`/`File` is passed straight to the decoder. */
+  blob: Blob;
+  /** Last-modified stamp, used for the cache key. */
+  lastModified: number;
+  /** Byte length, used for the cache key. */
+  size: number;
+}
+
+export const clampThumbnailWidth = (requested: unknown) => {
+  const n = Math.floor(Number(requested)) || 0;
+  return Math.max(THUMB_MIN_WIDTH, Math.min(THUMB_MAX_WIDTH, n));
+};
+
+/**
+ * Cache key for a thumbnail of `sources` at `maxWidth`.
+ *
+ * Keyed by each layer's STABLE signature — path + lastModified + size — never
+ * by its url. Asset urls carry a `?v=${Date.now()}` cache-buster that the
+ * workspace re-stamps on load, so a url-derived key regenerates everything on
+ * every page load and leaks orphaned entries. The signature only moves when
+ * the bytes actually do, so a real edit still invalidates.
+ */
+export const thumbnailCacheKey = (
+  sources: readonly Pick<
+    ThumbnailSource,
+    "path" | "lastModified" | "size"
+  >[],
+  maxWidth: number,
+) => {
+  const sig = sources
+    .map((s) => `${s.path}:${s.lastModified}-${s.size}`)
+    .join("|");
+  return `thumb=${maxWidth}&sig=${sig}&tv=${THUMB_VERSION}`;
+};
+
+/**
+ * Decode `sources`, stack them, and encode one WebP thumbnail.
+ *
+ * A single source is just the degenerate case of a composite, so the editor's
+ * per-file thumbnails and a layered image's flattened preview take the same
+ * path.
+ *
+ * Order is BOTTOM-FIRST — `UIModule.createImage` reverses the asset list for
+ * CSS `background-image` (whose first entry paints on top), so array order here
+ * reproduces what the game shows. Reversing this silently inverts every
+ * layered image.
+ *
+ * Returns `undefined` if this host can't rasterize or anything fails to
+ * decode; callers fall back rather than showing a broken image.
+ */
+export const composeThumbnailBlob = async (
+  sources: readonly ThumbnailSource[],
+  maxWidth: number,
+): Promise<Blob | undefined> => {
+  if (!sources.length || !canRasterize()) {
+    return undefined;
+  }
+  const width = clampThumbnailWidth(maxWidth);
+  let bitmaps: ImageBitmap[] = [];
+  try {
+    // Decode AND downscale in one pass: `resizeWidth` makes the decoder emit a
+    // small bitmap directly instead of allocating the full multi-megapixel
+    // image and scaling it on a canvas afterwards — much less memory and CPU,
+    // which matters most here because a composite decodes several layers at
+    // once. (Sources narrower than maxWidth upscale slightly, harmless at
+    // thumbnail size.)
+    bitmaps = await Promise.all(
+      sources.map((s) =>
+        createImageBitmap(s.blob, {
+          resizeWidth: width,
+          resizeQuality: "low",
+        }),
+      ),
+    );
+    const w = Math.max(...bitmaps.map((b) => b.width));
+    const h = Math.max(...bitmaps.map((b) => b.height));
+    if (!w || !h) {
+      return undefined;
+    }
+    const canvas = new OffscreenCanvas(w, h);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return undefined;
+    }
+    for (const bitmap of bitmaps) {
+      // Each layer keeps its own decoded size rather than being stretched to
+      // the canvas: same-size layers (the convention) are unaffected, and an
+      // odd-sized one is better anchored than distorted.
+      ctx.drawImage(bitmap, 0, 0);
+    }
+    return await canvas.convertToBlob({ type: MIME, quality: QUALITY });
+  } catch {
+    return undefined;
+  } finally {
+    bitmaps.forEach((b) => b?.close());
+  }
+};
+
+const canRasterize = () =>
+  typeof OffscreenCanvas !== "undefined" &&
+  typeof createImageBitmap === "function";

--- a/packages/sparkdown/src/thumbnails/composeThumbnail.ts
+++ b/packages/sparkdown/src/thumbnails/composeThumbnail.ts
@@ -132,3 +132,85 @@ export const composeThumbnailBlob = async (
 const canRasterize = () =>
   typeof OffscreenCanvas !== "undefined" &&
   typeof createImageBitmap === "function";
+
+/**
+ * Base64-encode bytes in chunks.
+ *
+ * Chunked because `String.fromCharCode(...bytes)` on a whole image throws
+ * RangeError past roughly 100k elements — and a real asset is far bigger than
+ * that, so the unchunked form fails on exactly the files a thumbnail is most
+ * wanted for.
+ */
+export const bytesToBase64 = (bytes: Uint8Array) => {
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(
+      ...(bytes.subarray(i, i + CHUNK) as unknown as number[]),
+    );
+  }
+  return btoa(binary);
+};
+
+/** The subset of Cache Storage this needs, so callers can pass a fake. */
+export interface ThumbnailCache {
+  match(key: string): Promise<Response | undefined>;
+  put(key: string, response: Response): Promise<void>;
+}
+
+/** A file to thumbnail: its bytes plus the identity its cache key needs. */
+export interface ThumbnailFile extends Blob {
+  lastModified: number;
+}
+
+/**
+ * Cached-or-freshly-generated thumbnail response for one file, or `undefined`
+ * if it can't be generated (caller serves the original).
+ *
+ * The cache is a parameter rather than reached for directly so this is
+ * testable outside a service worker — and so the same logic could be backed by
+ * something other than Cache Storage (VS Code would use extension storage).
+ */
+export const getOrCreateThumbnail = async (
+  cache: ThumbnailCache,
+  path: string,
+  file: ThumbnailFile,
+  thumbParam: string,
+  keyPrefix = "",
+): Promise<Response | undefined> => {
+  const requested = Math.floor(Number(thumbParam)) || 0;
+  if (!Number.isFinite(requested) || requested < THUMB_MIN_WIDTH) {
+    // Garbage or absurdly small: not a thumbnail request worth honouring.
+    return undefined;
+  }
+  const maxWidth = clampThumbnailWidth(requested);
+  const key = `${keyPrefix}${path}?${thumbnailCacheKey(
+    [{ path, lastModified: file.lastModified, size: file.size }],
+    maxWidth,
+  )}`;
+  try {
+    const cached = await cache.match(key);
+    if (cached) {
+      return cached;
+    }
+    const blob = await composeThumbnailBlob(
+      [{ path, blob: file, lastModified: file.lastModified, size: file.size }],
+      maxWidth,
+    );
+    if (!blob) {
+      return undefined;
+    }
+    const response = new Response(blob, {
+      status: 200,
+      headers: new Headers({
+        "Content-Type": MIME,
+        "Content-Length": String(blob.size),
+        "Cache-Control": "max-age=31536000, immutable",
+      }),
+    });
+    await cache.put(key, response.clone());
+    return response;
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/sparkdown/src/workspace/classes/SparkdownWorkspace.ts
+++ b/packages/sparkdown/src/workspace/classes/SparkdownWorkspace.ts
@@ -1002,4 +1002,14 @@ export abstract class SparkdownWorkspace {
   abstract getFileVersion(uri: string): Promise<number>;
 
   abstract getFileLanguageId(uri: string): Promise<string>;
+
+  /**
+   * Read a file's raw bytes as base64, for hosts where the file's `src` isn't
+   * fetchable from this worker (VS Code). Deliberately NOT abstract: hosts
+   * that serve their assets over http never need it, and returning undefined
+   * degrades to the non-composited preview rather than breaking them.
+   */
+  async getFileBytes(_uri: string): Promise<string | undefined> {
+    return undefined;
+  }
 }

--- a/vscode-sparkdown/src/utils/executeLanguageCommand.ts
+++ b/vscode-sparkdown/src/utils/executeLanguageCommand.ts
@@ -10,6 +10,26 @@ const getFileText = async (uri: string) => {
   return text;
 };
 
+/**
+ * Raw bytes as base64, for the language server's asset previews.
+ *
+ * The server runs in a worker and cannot `fetch` a workspace uri, and VS
+ * Code's markdown sanitizer refuses any non-http(s) `<img src>` — so previews
+ * there are inlined `data:` URIs built from bytes read here. Base64 because
+ * the LSP transport is JSON.
+ */
+const getFileBytes = async (uri: string) => {
+  const buffer = await vscode.workspace.fs.readFile(vscode.Uri.parse(uri));
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < buffer.length; i += CHUNK) {
+    binary += String.fromCharCode(
+      ...(buffer.subarray(i, i + CHUNK) as unknown as number[]),
+    );
+  }
+  return btoa(binary);
+};
+
 const getFileSrc = (uri: string) => {
   if (SparkdownPreviewGamePanelManager.instance.panel?.webview) {
     return SparkdownPreviewGamePanelManager.instance.panel.webview
@@ -50,6 +70,12 @@ export const executeLanguageCommand = async <T>(params: {
     const [uri] = params.arguments || [];
     if (uri && typeof uri === "string") {
       return getFileSrc(uri) as T;
+    }
+  }
+  if (params.command === "sparkdown.getFileBytes") {
+    const [uri] = params.arguments || [];
+    if (uri && typeof uri === "string") {
+      return getFileBytes(uri) as T;
     }
   }
   if (params.command === "sparkdown.getFileVersion") {

--- a/vscode-sparkdown/src/utils/executeLanguageCommand.ts
+++ b/vscode-sparkdown/src/utils/executeLanguageCommand.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { LSPAny } from "vscode-languageserver-protocol";
 import { SparkdownPreviewGamePanelManager } from "../managers/SparkdownPreviewGamePanelManager";
+import { bytesToBase64 } from "@impower/sparkdown/src/thumbnails/composeThumbnail";
 import { getEditor } from "./getEditor";
 import { getOpenTextDocument } from "./getOpenTextDocument";
 
@@ -20,14 +21,7 @@ const getFileText = async (uri: string) => {
  */
 const getFileBytes = async (uri: string) => {
   const buffer = await vscode.workspace.fs.readFile(vscode.Uri.parse(uri));
-  let binary = "";
-  const CHUNK = 0x8000;
-  for (let i = 0; i < buffer.length; i += CHUNK) {
-    binary += String.fromCharCode(
-      ...(buffer.subarray(i, i + CHUNK) as unknown as number[]),
-    );
-  }
-  return btoa(binary);
+  return bytesToBase64(buffer);
 };
 
 const getFileSrc = (uri: string) => {


### PR DESCRIPTION
Re-targets #293 onto `main`.

## Why this exists

#293 was stacked on `fix/asset-completion-preview-290` (the #290 fix, #291). The two merged in the order that orphans a stack:

1. **#291 merged first**, while its branch was still just the single fix commit — so `main` received only that.
2. **#293 then merged into `fix/asset-completion-preview-290`**, its base, rather than into `main`.

Both PRs correctly report `MERGED`, but the eight commits from #293 landed only on the intermediate branch. They are not on `main`, and deleting that branch would have discarded them.

This PR merges the branch's remaining commits into `main`. No new work — the content is exactly what was reviewed and approved in #293.

## What it contains

Implements #292: a `layered_image` previewed as its base layer only, so a background made of `base + props + lighting` showed the plate and nothing that makes it that background. These composite the layers into a single WebP thumbnail, working identically in the impower-dev editor and in VS Code.

- `perf(lsp)` — asset previews move into `completionItem/resolve` instead of being built for every asset up front
- `feat(lsp)` — the composite itself, lazy and cached, degrading to the single-layer preview when it can't run
- `refactor(thumbnails)` — one thumbnail generator shared with the editor's service worker, replacing a full-size decode with a single-pass `resizeWidth` decode
- `feat(vscode)` — `sparkdown.getFileBytes` on the extension bridge, since a worker can't `fetch` VS Code's workspace uris
- four test commits — compositing decisions, the service-worker endpoint and base64, service-worker version transitions, and the preview cache's eviction policy

Full rationale, verification and known gaps are in #293; nothing there has changed.

## Verification

Unchanged from #293: driven by hand in both hosts (completion and hover in VS Code via a real extension host), plus 479 compiler and 160 impower-dev tests, each new test checked against a deliberate mutant.

## After merging

Once `main` contains all nine commits, both `fix/asset-completion-preview-290` and `feat/composite-asset-previews-292` are safe to delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
