### PR TITLE
perf: long-script editing waves 1+2 — keystroke 136ms→16ms, reveal 11s→3.7s

### DIFF
--- a/impower-dev/src/modules/spark-editor/components/preview-game/PreviewGame.tsx
+++ b/impower-dev/src/modules/spark-editor/components/preview-game/PreviewGame.tsx
@@ -288,13 +288,17 @@ export default function PreviewGame(_props: PreviewGameProps) {
           if (!(e instanceof CustomEvent)) return;
           const message = e.detail;
 
-          // Forward editor → iframe for game/preview/workspace/textDocument
+          // Forward editor → iframe for game/preview/workspace/textDocument.
+          // (Except didSave: nothing in the player consumes it, and it carries
+          // the entire document text on every change -- a 200KB+ clone per
+          // keystroke on a large script.)
           if (
             typeof message.method === "string" &&
             (message.method.startsWith("game/") ||
               message.method.startsWith("preview/") ||
               message.method.startsWith("workspace/") ||
-              message.method.startsWith("textDocument/"))
+              (message.method.startsWith("textDocument/") &&
+                message.method !== "textDocument/didSave"))
           ) {
             if (!initializedRef.current) {
               await initializingRef.current;

--- a/impower-dev/src/modules/spark-editor/workspace/WorkspaceFileSystem.ts
+++ b/impower-dev/src/modules/spark-editor/workspace/WorkspaceFileSystem.ts
@@ -70,7 +70,6 @@ export default class WorkspaceFileSystem {
     this.loadInitialFiles.bind(this),
   );
 
-  protected _preloaded: Record<string, HTMLElement> = {};
 
   protected _scheme = "file://";
   get scheme() {
@@ -153,7 +152,6 @@ export default class WorkspaceFileSystem {
       this._files ??= {};
       this._files[file.uri] = { ...file };
       result[file.uri] = file;
-      this.preloadFile(file);
     });
     if (!files.some((f) => f.name === "main" && f.type === "script")) {
       // Create a default empty main script if one doesn't exist
@@ -265,7 +263,6 @@ export default class WorkspaceFileSystem {
       message.params.files.forEach((file) => {
         this._files ??= {};
         this._files[file.uri] = { ...file };
-        this.preloadFile(file);
       });
       sendProtocolMessage(message);
     } else if (DidCreateFilesMessage.type.isNotification(message)) {
@@ -274,7 +271,6 @@ export default class WorkspaceFileSystem {
     } else if (DidDeleteFilesMessage.type.isNotification(message)) {
       message.params.files.forEach((file) => {
         delete this._files?.[file.uri];
-        delete this._preloaded[file.uri];
       });
       Workspace.ls.connection.sendNotification(message.method, message.params);
       sendProtocolMessage(message);
@@ -284,7 +280,6 @@ export default class WorkspaceFileSystem {
         const oldFile = this._files[file.oldUri];
         if (oldFile) {
           delete this._files[file.oldUri];
-          delete this._preloaded[file.oldUri];
         }
       });
       Workspace.ls.connection.sendNotification(message.method, message.params);
@@ -735,39 +730,6 @@ export default class WorkspaceFileSystem {
       [encodedText.buffer],
     );
     return result;
-  }
-
-  async preloadFile(file: FileData) {
-    try {
-      await new Promise((resolve, reject) => {
-        /* Preload image so it can be previewed instantly */
-        if (file.type === "image") {
-          const img = new Image();
-          img.src = file.src;
-          img.onload = () => {
-            resolve(img);
-          };
-          img.onerror = () => {
-            reject(img);
-          };
-          this._preloaded[file.uri] = img;
-        }
-        /* We shouldn't need to preload audio */
-        // else if (file.type === "audio") {
-        //   const aud = new Audio();
-        //   aud.src = file.src;
-        //   aud.onload = () => {
-        //     resolve(aud);
-        //   };
-        //   aud.onerror = () => {
-        //     reject(aud);
-        //   };
-        //   this._preloaded[file.uri] = aud;
-        // }
-      });
-    } catch (e) {
-      console.warn("Could not load: ", file.name, file.src);
-    }
   }
 
   async applyWorkspaceEdit(

--- a/impower-dev/src/modules/spark-editor/workspace/WorkspaceLanguageServer.ts
+++ b/impower-dev/src/modules/spark-editor/workspace/WorkspaceLanguageServer.ts
@@ -296,7 +296,6 @@ export default class WorkspaceLanguageServer {
       this._initializeParams,
     );
     this._initializeResult = result;
-    this.updateProgram(result["program"]);
     this._connection.sendNotification(InitializedMessage.method, {});
     this._onInitialized.forEach((callback) => {
       callback?.(result);

--- a/packages/codemirror-vscode-lsp-client/src/folding.ts
+++ b/packages/codemirror-vscode-lsp-client/src/folding.ts
@@ -8,12 +8,14 @@ import {
   EditorState,
   StateEffect,
   StateField,
+  Text,
   TransactionSpec,
 } from "@codemirror/state";
 import { EditorView, ViewUpdate, keymap } from "@codemirror/view";
 import type * as lsp from "vscode-languageserver-protocol";
 import { LSPClient, LSPClientExtension } from "./client";
 import { LSPPlugin } from "./plugin";
+import { coalesceRequest } from "./requestCoalescer";
 
 const CHEVRON_SVG_URL = `url('data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="black"><path d="M7.97612 10.0719L12.3334 5.7146L12.9521 6.33332L8.28548 11L7.66676 11L3.0001 6.33332L3.61882 5.7146L7.97612 10.0719Z"/></svg>')`;
 
@@ -69,7 +71,7 @@ export function foldingPlaceholderDOM(
   onclick: (this: GlobalEventHandlers, ev: PointerEvent) => any,
   prepared: boolean,
 ) {
-  const ranges = view.state.field(foldingRangeField);
+  const { ranges } = view.state.field(foldingRangeField);
   // prepared is usually the placeholder text if default logic is used
   // but we fetch our specific match from state
   const match =
@@ -126,37 +128,57 @@ export function setDocumentFoldingRanges(
   return { effects };
 }
 
-const foldingRangeField = StateField.define<DocumentFoldingRange[]>({
+interface FoldingRangeSet {
+  ranges: DocumentFoldingRange[];
+  /** First range starting on each 1-based line number, so the per-line
+   * foldService query is a lookup instead of a scan over every range. */
+  byStartLine: Map<number, DocumentFoldingRange>;
+}
+
+const indexFoldingRanges = (
+  ranges: DocumentFoldingRange[],
+  doc: Text,
+): FoldingRangeSet => {
+  const byStartLine = new Map<number, DocumentFoldingRange>();
+  for (const range of ranges) {
+    if (range.from < 0 || range.from > doc.length) {
+      continue;
+    }
+    const lineNumber = doc.lineAt(range.from).number;
+    if (!byStartLine.has(lineNumber)) {
+      byStartLine.set(lineNumber, range);
+    }
+  }
+  return { ranges, byStartLine };
+};
+
+const foldingRangeField = StateField.define<FoldingRangeSet>({
   create() {
-    return [];
+    return { ranges: [], byStartLine: new Map() };
   },
-  update(ranges, tr) {
+  update(value, tr) {
     for (let e of tr.effects) {
-      if (e.is(setFoldingRanges)) return e.value;
+      if (e.is(setFoldingRanges)) return indexFoldingRanges(e.value, tr.newDoc);
     }
 
     if (tr.docChanged) {
-      return ranges.map((range) => ({
+      const mapped = value.ranges.map((range) => ({
         ...range,
         from: tr.changes.mapPos(range.from),
         to: tr.changes.mapPos(range.to),
       }));
+      return indexFoldingRanges(mapped, tr.newDoc);
     }
 
-    return ranges;
+    return value;
   },
 });
 
 const foldingRangesService = foldService.of((state, from, to) => {
-  const ranges = state.field(foldingRangeField);
-  const line = state.doc.lineAt(from);
-
-  for (const range of ranges) {
-    // Check if this range starts on the line currently being queried by the gutter
-    const rangeStartLine = state.doc.lineAt(range.from);
-    if (rangeStartLine.number === line.number) {
-      return { from: range.from, to: range.to };
-    }
+  const { byStartLine } = state.field(foldingRangeField);
+  const range = byStartLine.get(state.doc.lineAt(from).number);
+  if (range) {
+    return { from: range.from, to: range.to };
   }
   return null;
 });
@@ -205,21 +227,23 @@ export async function updateDocumentFoldingRanges(
   client: LSPClient,
   uri: string,
 ) {
-  let file = client.workspace.getFile(uri);
-  if (!file) return;
-  const view = file.getView();
-  if (!view) return;
-  const plugin = LSPPlugin.get(view);
-  if (!plugin) return;
-  const result = await plugin.client.request<
-    lsp.FoldingRangeParams,
-    lsp.FoldingRange[] | null,
-    typeof lsp.FoldingRangeRequest.method
-  >("textDocument/foldingRange", {
-    textDocument: { uri },
+  return coalesceRequest(client, `foldingRange:${uri}`, async () => {
+    let file = client.workspace.getFile(uri);
+    if (!file) return;
+    const view = file.getView();
+    if (!view) return;
+    const plugin = LSPPlugin.get(view);
+    if (!plugin) return;
+    const result = await plugin.client.request<
+      lsp.FoldingRangeParams,
+      lsp.FoldingRange[] | null,
+      typeof lsp.FoldingRangeRequest.method
+    >("textDocument/foldingRange", {
+      textDocument: { uri },
+    });
+    const foldables = convertFromServerFoldingRanges(plugin, result);
+    view.dispatch(setDocumentFoldingRanges(view.state, foldables));
   });
-  const foldables = convertFromServerFoldingRanges(plugin, result);
-  view.dispatch(setDocumentFoldingRanges(view.state, foldables));
 }
 
 export function serverFolding(): LSPClientExtension {

--- a/packages/codemirror-vscode-lsp-client/src/requestCoalescer.ts
+++ b/packages/codemirror-vscode-lsp-client/src/requestCoalescer.ts
@@ -1,0 +1,37 @@
+/**
+ * Collapses bursts of identical pull round-trips (didChange +
+ * publishDiagnostics + workspace refresh listeners all triggering the same
+ * feature request). While a pull for a (scope, key) is in flight, further
+ * pulls just mark it dirty; when the in-flight one settles, at most one more
+ * runs to pick up the latest server state. Net effect: a burst of N triggers
+ * costs at most 2 round-trips instead of N, and the last one always reflects
+ * the newest state.
+ */
+const pendingByScope = new WeakMap<object, Map<string, { rerun: boolean }>>();
+
+export async function coalesceRequest(
+  scope: object,
+  key: string,
+  run: () => Promise<void>,
+): Promise<void> {
+  let pending = pendingByScope.get(scope);
+  if (!pending) {
+    pending = new Map();
+    pendingByScope.set(scope, pending);
+  }
+  const inFlight = pending.get(key);
+  if (inFlight) {
+    inFlight.rerun = true;
+    return;
+  }
+  const state = { rerun: false };
+  pending.set(key, state);
+  try {
+    do {
+      state.rerun = false;
+      await run();
+    } while (state.rerun);
+  } finally {
+    pending.delete(key);
+  }
+}

--- a/packages/codemirror-vscode-lsp-client/src/semantics.ts
+++ b/packages/codemirror-vscode-lsp-client/src/semantics.ts
@@ -10,6 +10,7 @@ import { Decoration, DecorationSet, EditorView } from "@codemirror/view";
 import type * as lsp from "vscode-languageserver-protocol";
 import { LSPClient, LSPClientExtension } from "./client";
 import { LSPPlugin } from "./plugin";
+import { coalesceRequest } from "./requestCoalescer";
 
 export interface SemanticTokens {
   /** (Optional) For delta updates; this extension ignores deltas and expects full sets */
@@ -175,25 +176,27 @@ export async function updateDocumentSemanticHighlighting(
   client: LSPClient,
   uri: string,
 ) {
-  let file = client.workspace.getFile(uri);
-  if (!file) return;
-  const view = file.getView();
-  if (!view) return;
-  const plugin = LSPPlugin.get(view);
-  if (!plugin) return;
-  const result = await plugin.client.request<
-    lsp.SemanticTokensParams,
-    lsp.SemanticTokens | null,
-    typeof lsp.SemanticTokensRequest.method
-  >("textDocument/semanticTokens/full", {
-    textDocument: { uri },
+  return coalesceRequest(client, `semanticTokens:${uri}`, async () => {
+    let file = client.workspace.getFile(uri);
+    if (!file) return;
+    const view = file.getView();
+    if (!view) return;
+    const plugin = LSPPlugin.get(view);
+    if (!plugin) return;
+    const result = await plugin.client.request<
+      lsp.SemanticTokensParams,
+      lsp.SemanticTokens | null,
+      typeof lsp.SemanticTokensRequest.method
+    >("textDocument/semanticTokens/full", {
+      textDocument: { uri },
+    });
+    view.dispatch(
+      setDocumentSemanticHighlighting(
+        view.state,
+        convertFromServerSemanticTokens(plugin, result),
+      ),
+    );
   });
-  view.dispatch(
-    setDocumentSemanticHighlighting(
-      view.state,
-      convertFromServerSemanticTokens(plugin, result),
-    ),
-  );
 }
 
 export function serverSemanticHighlighting(

--- a/packages/spark-web-player/src/GamePlayerController.ts
+++ b/packages/spark-web-player/src/GamePlayerController.ts
@@ -1120,7 +1120,11 @@ export class GamePlayerController {
     await this.startGameAndApp(true);
   }
 
-  protected debouncedRestartGame = debounce(() => this.restartGame(), 100);
+  // Long enough to actually coalesce: compiles arrive at most once per
+  // typing pause (they're debounced upstream), so a 100ms window here never
+  // merged anything and a RUNNING game was torn down and restarted for every
+  // pause. One second batches consecutive pauses into one restart.
+  protected debouncedRestartGame = debounce(() => this.restartGame(), 1000);
 
   async buildGame(program: SparkProgram, restarted?: boolean) {
     const options = this._options;
@@ -1423,7 +1427,13 @@ export class GamePlayerController {
       this.listen(this._game);
     }
 
-    this._app = await this.buildApp(this._game);
+    // Rebuilding the Application destroys and recreates the game's whole
+    // DOM/canvas binding (~100ms+ on the iframe main thread). Only necessary
+    // when the Game instance itself changed -- NOT on cursor scrubs, which
+    // land here with the same game and just need a re-preview.
+    if (shouldBuildNewGame || !this._app) {
+      this._app = await this.buildApp(this._game);
+    }
 
     if (validPreviewFrom) {
       this._game.preview(validPreviewFrom.file, validPreviewFrom.line);

--- a/packages/spark-web-player/src/GamePlayerController.ts
+++ b/packages/spark-web-player/src/GamePlayerController.ts
@@ -56,7 +56,6 @@ import { SparkProgram } from "@impower/sparkdown/src/compiler/types/SparkProgram
 import { SparkdownWorkspace } from "@impower/sparkdown/src/workspace/classes/SparkdownWorkspace";
 import { Application } from "./app/Application";
 import { conflate } from "./utils/conflate";
-import { debounce } from "./utils/debounce";
 import { profile } from "./utils/profile";
 
 const COMMON_ASPECT_RATIOS = [
@@ -1020,12 +1019,11 @@ export class GamePlayerController {
       this._program = program;
       this._checkpoint = checkpoint;
       if (this._game?.state === "running") {
-        // Stop and restart game if we loaded a new game while the old game was running
-        await this.debouncedRestartGame();
-        sendProtocolMessage(
-          GameReloadedMessage.type.notification({}),
-          this.host,
-        );
+        // Stop and restart game if we loaded a new game while the old game
+        // was running. (GameReloaded is sent when the restart actually
+        // executes -- see scheduleRestartGame -- not when it is merely
+        // scheduled.)
+        this.scheduleRestartGame();
       } else {
         this._options ??= {};
         this._options.startFrom ??= program.startFrom;
@@ -1073,6 +1071,9 @@ export class GamePlayerController {
   }
 
   async destroyGameAndApp() {
+    // A teardown supersedes any pending compile-driven restart; without this
+    // the timer fires after STOP and silently resurrects the game.
+    this.cancelScheduledRestart();
     if (this._game) {
       this._game.destroy();
       this._game = undefined;
@@ -1120,11 +1121,37 @@ export class GamePlayerController {
     await this.startGameAndApp(true);
   }
 
-  // Long enough to actually coalesce: compiles arrive at most once per
-  // typing pause (they're debounced upstream), so a 100ms window here never
-  // merged anything and a RUNNING game was torn down and restarted for every
-  // pause. One second batches consecutive pauses into one restart.
-  protected debouncedRestartGame = debounce(() => this.restartGame(), 1000);
+  // Compile-driven restart of a RUNNING game, coalesced: compiles arrive at
+  // most once per typing pause (they're debounced upstream), so the old
+  // 100ms window never merged anything and the running game was torn down
+  // and restarted for every pause. One second batches consecutive pauses
+  // into one restart. Owned as an explicit timer (not the bare debounce
+  // util) so teardown paths can CANCEL it -- a pending restart firing after
+  // the user hit STOP would resurrect the game.
+  protected _restartGameTimeout?: ReturnType<typeof setTimeout>;
+
+  protected cancelScheduledRestart() {
+    if (this._restartGameTimeout != null) {
+      clearTimeout(this._restartGameTimeout);
+      this._restartGameTimeout = undefined;
+    }
+  }
+
+  protected scheduleRestartGame() {
+    this.cancelScheduledRestart();
+    this._restartGameTimeout = setTimeout(async () => {
+      this._restartGameTimeout = undefined;
+      // Only restart a game that is still meant to be running; the state can
+      // have changed (STOP, finish, error) while the timer was pending.
+      if (this._game?.state === "running") {
+        await this.restartGame();
+        sendProtocolMessage(
+          GameReloadedMessage.type.notification({}),
+          this.host,
+        );
+      }
+    }, 1000);
+  }
 
   async buildGame(program: SparkProgram, restarted?: boolean) {
     const options = this._options;

--- a/packages/spark-web-player/src/main/workers/installWorkspaceWorker.ts
+++ b/packages/spark-web-player/src/main/workers/installWorkspaceWorker.ts
@@ -135,10 +135,13 @@ export function installWorkspaceWorker(connection: MessageConnection) {
     // Handle Workspace Events
     if (InitializeMessage.type.is(message)) {
       connection.sendResponse(message, async () => {
-        const { program } = await state.workspace.initialize(message.params);
+        // The initial compile inside initialize() already delivers the
+        // program to the game via the CompiledProgram notification; no caller
+        // reads it from this response, so don't clone the multi-MB program
+        // into it too.
+        await state.workspace.initialize(message.params);
         return {
           capabilities: {},
-          program,
         };
       });
       return;

--- a/packages/sparkdown-document-views/src/cm-indented-line-wrapping/indentedLineWrapping.ts
+++ b/packages/sparkdown-document-views/src/cm-indented-line-wrapping/indentedLineWrapping.ts
@@ -39,7 +39,7 @@ class IndentedLineWrappingPluginValue implements PluginValue {
   }
 
   update(update: ViewUpdate) {
-    if (update.docChanged) {
+    if (update.docChanged || update.viewportChanged) {
       this.decorations = this.getDecorations(update.view);
     }
   }
@@ -50,34 +50,44 @@ class IndentedLineWrappingPluginValue implements PluginValue {
 
     const tabSize = view.state.tabSize;
 
-    for (let i of [...Array(view.state.doc.lines).keys()]) {
-      const line = view.state.doc.line(i + 1);
-      if (line.length === 0) {
-        continue;
-      }
-
-      let indentSize = 0;
-      for (let ch of line.text) {
-        if (ch === "\t") {
-          indentSize = indentSize + tabSize;
-        } else if (ch === " ") {
-          indentSize = indentSize + 1;
-        } else {
-          break;
+    // Decorations only take effect inside the rendered (visible) ranges, so
+    // only build them there instead of for every line in the document.
+    let lastLineFrom = -1;
+    for (const range of view.visibleRanges) {
+      for (let pos = range.from; pos <= range.to; ) {
+        const line = view.state.doc.lineAt(pos);
+        pos = line.to + 1;
+        if (line.from === lastLineFrom) {
+          continue;
         }
+        lastLineFrom = line.from;
+        if (line.length === 0) {
+          continue;
+        }
+
+        let indentSize = 0;
+        for (let ch of line.text) {
+          if (ch === "\t") {
+            indentSize = indentSize + tabSize;
+          } else if (ch === " ") {
+            indentSize = indentSize + 1;
+          } else {
+            break;
+          }
+        }
+
+        const indentWidth = `${indentSize}ch`;
+        const textIndent = `-${indentWidth}`;
+        const paddingLeft = `calc(${config.padding} + ${indentWidth})`;
+
+        const decoration = Decoration.line({
+          attributes: {
+            style: `text-indent: ${textIndent}; padding-left: ${paddingLeft}`,
+          },
+        });
+
+        decorations.push(decoration.range(line.from, line.from));
       }
-
-      const indentWidth = `${indentSize}ch`;
-      const textIndent = `-${indentWidth}`;
-      const paddingLeft = `calc(${config.padding} + ${indentWidth})`;
-
-      const decoration = Decoration.line({
-        attributes: {
-          style: `text-indent: ${textIndent}; padding-left: ${paddingLeft}`,
-        },
-      });
-
-      decorations.push(decoration.range(line.from, line.from));
     }
 
     return Decoration.set(decorations, true);

--- a/packages/sparkdown-document-views/src/modules/script-editor/ScriptEditorController.ts
+++ b/packages/sparkdown-document-views/src/modules/script-editor/ScriptEditorController.ts
@@ -120,10 +120,12 @@ export interface ScriptEditorOptions {
 }
 
 // How long a load may keep the editor hidden before it is revealed anyway.
-// Comfortably longer than a normal large-project parse (~2.7s measured on an
-// 8k-line script) so the usual idle-driven fade-in still wins the race and
-// the user doesn't see a half-parsed document flash; short enough that a
-// wedged load self-heals well inside the "is this broken?" threshold.
+// The normal reveal comes from `onViewportParsed` (the syntax tree covers the
+// visible region, usually within a few hundred ms) or, on small documents,
+// from the parse-idle signal. This backstop only exists for loads where
+// neither signal arrives (a wedged parse, or a deep saved scroll position on
+// a document that parses slowly) -- short enough that a broken load
+// self-heals well inside the "is this broken?" threshold.
 const LOAD_REVEAL_TIMEOUT_MS = 5000;
 
 export class ScriptEditorController {
@@ -666,6 +668,7 @@ export class ScriptEditorController {
               ? (visibleRange?.start.line ?? 0) + 1
               : undefined,
           onIdle: this.handleIdle,
+          onViewportParsed: this.handleViewportParsed,
           onFocus: () => {
             this._editing = true;
             if (this._textDocument) {
@@ -1054,6 +1057,33 @@ export class ScriptEditorController {
     this.refs.editor.style.visibility = "visible";
     this.refs.editor.style.opacity = "1";
     this._loadingRequest = undefined;
+  };
+
+  /**
+   * The syntax tree covers the visible viewport (and the restored scroll
+   * target) while the rest of the document is still parsing. That is enough
+   * to finish loading: restore scroll/focus and reveal now instead of hiding
+   * the editor behind the multi-second full-document parse. Runs the same
+   * completion path as the idle signal, so whichever fires first wins and the
+   * other becomes a no-op.
+   */
+  protected handleViewportParsed = () => {
+    if (this._loaded) {
+      return;
+    }
+    // Wait for fonts before the first reveal so the just-shown viewport
+    // doesn't immediately reflow under a late-loading editor font.
+    const fonts = document.fonts;
+    if (fonts && fonts.status !== "loaded") {
+      const view = this._view;
+      fonts.ready.then(() => {
+        if (!this._loaded && this._view === view) {
+          this.handleIdle();
+        }
+      });
+      return;
+    }
+    this.handleIdle();
   };
 
   protected handleIdle = () => {

--- a/packages/sparkdown-document-views/src/modules/script-editor/utils/createEditorView.ts
+++ b/packages/sparkdown-document-views/src/modules/script-editor/utils/createEditorView.ts
@@ -1,5 +1,8 @@
 import { historyField } from "@codemirror/commands";
-import { syntaxParserRunning } from "@codemirror/language";
+import {
+  syntaxParserRunning,
+  syntaxTreeAvailable,
+} from "@codemirror/language";
 import {
   Compartment,
   EditorSelection,
@@ -111,6 +114,13 @@ interface EditorConfig {
   onFocus?: () => void;
   onBlur?: () => void;
   onIdle?: () => void;
+  /**
+   * Fired once, while the initial background parse is still running, as soon
+   * as the syntax tree covers the visible viewport AND the restored scroll
+   * target. Lets the host reveal the editor without waiting for the whole
+   * document to parse (which takes many seconds on large scripts).
+   */
+  onViewportParsed?: () => void;
   onSelectionChanged?: (
     update: ViewUpdate,
     anchor: number,
@@ -155,13 +165,13 @@ const createEditorView = (
   const onBlur = config?.onBlur;
   const onFocus = config?.onFocus;
   const onIdle = config?.onIdle ?? (() => {});
+  const onViewportParsed = config?.onViewportParsed;
   const onSelectionChanged = config?.onSelectionChanged;
   const onBreakpointsChanged = config?.onBreakpointsChanged;
   const onPinpointsChanged = config?.onPinpointsChanged;
   const onHighlightsChanged = config?.onHighlightsChanged;
   const onHeightChanged = config?.onHeightChanged;
   const debouncedIdle = debounce(onIdle, stabilizationDuration);
-  const getEditorState = config?.getEditorState;
   const setEditorState = config?.setEditorState;
   const changeFilter = config?.changeFilter;
   const transactionFilter = config?.transactionFilter;
@@ -204,6 +214,7 @@ const createEditorView = (
   let prevBreakpointLineNumbers = breakpointLineNumbers;
   let prevPinpointLineNumbers = pinpointLineNumbers;
   let prevHighlightLineNumbers = highlightLineNumbers;
+  let notifiedViewportParsed = false;
 
   // Using state.doc.line() errors on Mac
   const lines = doc.replace(NEWLINE_REGEX, "\n").split("\n");
@@ -351,6 +362,21 @@ const createEditorView = (
           if (!parsing) {
             onReady?.();
             debouncedIdle();
+          } else if (!notifiedViewportParsed && onViewportParsed) {
+            // While the initial parse of a large document is still grinding
+            // through the rest of the file, the tree usually covers the
+            // visible region within a few frames -- that is enough to show
+            // the editor. Evaluate against the restored scroll target too,
+            // so a deep saved position doesn't reveal (and then jump) before
+            // its own region has parsed.
+            const target = Math.max(
+              u.view.viewport.to,
+              scrollToLine ? scrollToLine.to : 0,
+            );
+            if (syntaxTreeAvailable(u.view.state, target)) {
+              notifiedViewportParsed = true;
+              onViewportParsed();
+            }
           }
           if (u.heightChanged) {
             onHeightChanged?.();
@@ -394,39 +420,8 @@ const createEditorView = (
             }
           }
           onViewUpdate?.(u);
-          const json: {
-            history: SerializableHistoryState;
-            folded: SerializableFoldedState;
-          } = u.state.toJSON({
-            history: historyField,
-            folded: foldedField,
-          });
-          const selection =
-            u.view.state.selection.toJSON() as SerializableEditorSelection;
-          const history = json?.history;
-          const folded = json?.folded;
-          const transaction = u.transactions?.[0];
-          const userEvent = transaction?.isUserEvent("undo")
-            ? "undo"
-            : transaction?.isUserEvent("redo")
-              ? "redo"
-              : undefined;
-          const focused = u.view.hasFocus;
           const snippet = Boolean(parent.querySelector(".cm-snippetField"));
           const lint = Boolean(parent.querySelector(".cm-panel-lint"));
-          const selected =
-            selection?.ranges?.[selection.main]?.head !==
-            selection?.ranges?.[selection.main]?.anchor;
-          const editorState = {
-            doc,
-            selection,
-            history,
-            userEvent,
-            focused,
-            selected,
-            snippet,
-            folded,
-          };
           if (parent) {
             if (snippet) {
               parent.classList.add("cm-snippet");
@@ -439,11 +434,42 @@ const createEditorView = (
               parent.classList.remove("cm-lint");
             }
           }
-          if (
-            JSON.stringify(getEditorState?.() || {}) !==
-            JSON.stringify(editorState)
-          ) {
-            setEditorState?.(editorState);
+          if (setEditorState) {
+            // Serializing editor state (history + folds + the full doc via
+            // toJSON) costs several ms per dispatch on large documents, so
+            // only pay for it when a consumer actually wires setEditorState.
+            const json: {
+              history: SerializableHistoryState;
+              folded: SerializableFoldedState;
+            } = u.state.toJSON({
+              history: historyField,
+              folded: foldedField,
+            });
+            const selection =
+              u.view.state.selection.toJSON() as SerializableEditorSelection;
+            const history = json?.history;
+            const folded = json?.folded;
+            const transaction = u.transactions?.[0];
+            const userEvent = transaction?.isUserEvent("undo")
+              ? "undo"
+              : transaction?.isUserEvent("redo")
+                ? "redo"
+                : undefined;
+            const focused = u.view.hasFocus;
+            const selected =
+              selection?.ranges?.[selection.main]?.head !==
+              selection?.ranges?.[selection.main]?.anchor;
+            const editorState = {
+              doc,
+              selection,
+              history,
+              userEvent,
+              focused,
+              selected,
+              snippet,
+              folded,
+            };
+            setEditorState(editorState);
           }
           if (u.focusChanged) {
             if (u.view.hasFocus) {
@@ -452,7 +478,6 @@ const createEditorView = (
               onBlur?.();
             }
           }
-          setEditorState?.(editorState);
         }),
         scrollMarginsConfig.of(
           EditorView.scrollMargins.of(() => ({

--- a/packages/sparkdown-language-server/src/classes/SparkdownLanguageServerWorkspace.ts
+++ b/packages/sparkdown-language-server/src/classes/SparkdownLanguageServerWorkspace.ts
@@ -211,6 +211,12 @@ export class SparkdownLanguageServerWorkspace extends SparkdownWorkspace {
     this._documents.update(params);
   }
 
+  // Fingerprint of the last diagnostics published per uri, so a compile only
+  // notifies files whose diagnostics actually changed. Every publish fans out
+  // into client-side feature re-pulls, so N identical publishes per compile
+  // multiply into real work.
+  protected _lastPublishedDiagnostics = new Map<string, string>();
+
   override onCompiledTextDocument(params: {
     textDocument?: { uri: string };
     program: any;
@@ -219,14 +225,23 @@ export class SparkdownLanguageServerWorkspace extends SparkdownWorkspace {
     for (const uri of uris) {
       const version = this._documentVersions.get(uri);
       const diagnostics = this.getDiagnostics(params.program, uri);
+      const fingerprint = JSON.stringify(diagnostics);
+      if (this._lastPublishedDiagnostics.get(uri) === fingerprint) {
+        continue;
+      }
+      this._lastPublishedDiagnostics.set(uri, fingerprint);
       this.sendNotification(PublishDiagnosticsNotification.method, {
         uri,
         diagnostics,
         version,
       });
-      this.sendRequest(FoldingRangeRefreshRequest.method, {});
-      this.sendRequest(SemanticTokensRefreshRequest.method, {});
     }
+    // These refreshes are workspace-wide and carry no params, so once per
+    // compile is lossless. (They used to be sent inside the loop above --
+    // 2 x tracked-uris redundant refresh storms per keystroke, each of which
+    // made clients re-pull folding/semantic tokens for every visible file.)
+    this.sendRequest(FoldingRangeRefreshRequest.method, {});
+    this.sendRequest(SemanticTokensRefreshRequest.method, {});
   }
 
   override onCreatedFile(file: {
@@ -295,6 +310,7 @@ export class SparkdownLanguageServerWorkspace extends SparkdownWorkspace {
   }) {
     this._documents.remove({ textDocument: { uri: file.uri } });
     this._lastFormattedText.delete(file.uri);
+    this._lastPublishedDiagnostics.delete(file.uri);
   }
 
   public listen(): Disposable {

--- a/packages/sparkdown-language-server/src/classes/SparkdownLanguageServerWorkspace.ts
+++ b/packages/sparkdown-language-server/src/classes/SparkdownLanguageServerWorkspace.ts
@@ -220,7 +220,11 @@ export class SparkdownLanguageServerWorkspace extends SparkdownWorkspace {
       }
       const uri = uris[i++]!;
       try {
-        this._documents.tree(uri);
+        // The document can have been removed since the list was captured;
+        // touching it would just recreate an empty registry state entry.
+        if (this._documents.has(uri)) {
+          this._documents.tree(uri);
+        }
       } catch (e) {
         console.error("background parse failed", uri, e);
       }
@@ -250,11 +254,18 @@ export class SparkdownLanguageServerWorkspace extends SparkdownWorkspace {
     this._documents.update(params);
   }
 
-  // Fingerprint of the last diagnostics published per uri, so a compile only
-  // notifies files whose diagnostics actually changed. Every publish fans out
-  // into client-side feature re-pulls, so N identical publishes per compile
-  // multiply into real work.
-  protected _lastPublishedDiagnostics = new Map<string, string>();
+  // Fingerprint + published-at version of the last diagnostics publish per
+  // uri, so a compile only notifies files whose diagnostics actually changed.
+  // Every publish fans out into client-side feature re-pulls, so N identical
+  // publishes per compile multiply into real work. The VERSION must be part
+  // of the key: clients that declare versionSupport DROP a publish whose
+  // version trails their document (routine mid-typing, since compiles are
+  // debounced with a max-wait), so an identical-content publish at a NEWER
+  // version must still go out or the client keeps stale squiggles forever.
+  protected _lastPublishedDiagnostics = new Map<
+    string,
+    { fingerprint: string; version: number | undefined }
+  >();
 
   override onCompiledTextDocument(params: {
     textDocument?: { uri: string };
@@ -265,10 +276,11 @@ export class SparkdownLanguageServerWorkspace extends SparkdownWorkspace {
       const version = this._documentVersions.get(uri);
       const diagnostics = this.getDiagnostics(params.program, uri);
       const fingerprint = JSON.stringify(diagnostics);
-      if (this._lastPublishedDiagnostics.get(uri) === fingerprint) {
+      const last = this._lastPublishedDiagnostics.get(uri);
+      if (last && last.fingerprint === fingerprint && last.version === version) {
         continue;
       }
-      this._lastPublishedDiagnostics.set(uri, fingerprint);
+      this._lastPublishedDiagnostics.set(uri, { fingerprint, version });
       this.sendNotification(PublishDiagnosticsNotification.method, {
         uri,
         diagnostics,
@@ -397,7 +409,18 @@ export class SparkdownLanguageServerWorkspace extends SparkdownWorkspace {
         async (
           params: CompileProgramParams,
         ): Promise<SparkProgram | undefined> => {
-          return this.compile(params.textDocument.uri, true);
+          // Tolerate the bare `{ uri }` shape older clients sent.
+          const uri =
+            params.textDocument?.uri ?? (params as { uri?: string }).uri;
+          if (!uri) {
+            return undefined;
+          }
+          // force=false: when nothing changed since the last compile this
+          // serves the cached program WITHOUT re-compiling or re-notifying.
+          // A forced compile here re-broadcast compiler/didCompile, and
+          // pull-on-didCompile consumers (the vscode compilation view) would
+          // chase their own tail in an infinite pull->compile->notify loop.
+          return this.compile(uri, false);
         },
       ),
     );

--- a/packages/sparkdown-language-server/src/classes/SparkdownLanguageServerWorkspace.ts
+++ b/packages/sparkdown-language-server/src/classes/SparkdownLanguageServerWorkspace.ts
@@ -190,6 +190,45 @@ export class SparkdownLanguageServerWorkspace extends SparkdownWorkspace {
     });
   }
 
+  override async initialize(
+    params: Parameters<SparkdownWorkspace["initialize"]>[0],
+  ) {
+    const result = await super.initialize(params);
+    this.scheduleBackgroundParses();
+    return result;
+  }
+
+  /**
+   * Project scripts are registered with deferred parses (see onCreatedFile)
+   * so initialize can return immediately. Warm them here in the background --
+   * smallest first, one per tick so early feature requests aren't stuck
+   * behind the whole project -- because some features (e.g. completions) read
+   * every script's annotations and would otherwise pay all outstanding
+   * parses at once on first use. tree() is a no-op for anything already
+   * parsed on demand in the meantime.
+   */
+  protected scheduleBackgroundParses() {
+    const uris = Array.from(this._documents.keys()).sort(
+      (a, b) =>
+        (this._documents.get(a)?.length ?? 0) -
+        (this._documents.get(b)?.length ?? 0),
+    );
+    let i = 0;
+    const step = () => {
+      if (i >= uris.length) {
+        return;
+      }
+      const uri = uris[i++]!;
+      try {
+        this._documents.tree(uri);
+      } catch (e) {
+        console.error("background parse failed", uri, e);
+      }
+      setTimeout(step, 50);
+    };
+    setTimeout(step, 500);
+  }
+
   override async onOpenTextDocument(params: {
     textDocument: {
       uri: string;
@@ -260,14 +299,22 @@ export class SparkdownLanguageServerWorkspace extends SparkdownWorkspace {
       file.version !== undefined &&
       file.languageId !== undefined
     ) {
-      this._documents.set({
-        textDocument: {
-          uri: file.uri,
-          text: file.text! || "",
-          version: file.version,
-          languageId: file.languageId,
+      // Defer the parse: this fires for EVERY project script during
+      // initialize, but this registry only serves language-feature requests,
+      // which arrive for documents the user actually has open. Eagerly
+      // parsing the whole project here (with all annotators) cost many
+      // seconds of time-to-first-interaction on large projects (#224/#285).
+      this._documents.set(
+        {
+          textDocument: {
+            uri: file.uri,
+            text: file.text! || "",
+            version: file.version,
+            languageId: file.languageId,
+          },
         },
-      });
+        { defer: true },
+      );
     }
   }
 
@@ -287,14 +334,19 @@ export class SparkdownLanguageServerWorkspace extends SparkdownWorkspace {
       file.version !== undefined &&
       file.languageId !== undefined
     ) {
-      this._documents.set({
-        textDocument: {
-          uri: file.uri,
-          text: file.text! || "",
-          version: file.version,
-          languageId: file.languageId,
+      // Only unopened scripts arrive here (see SparkdownWorkspace.changeFile);
+      // defer their re-parse until something reads them.
+      this._documents.set(
+        {
+          textDocument: {
+            uri: file.uri,
+            text: file.text! || "",
+            version: file.version,
+            languageId: file.languageId,
+          },
         },
-      });
+        { defer: true },
+      );
     }
   }
 

--- a/packages/sparkdown-language-server/src/sparkdown-language-server.ts
+++ b/packages/sparkdown-language-server/src/sparkdown-language-server.ts
@@ -650,10 +650,13 @@ try {
   // semanticTokensProvider
   connection.languages.semanticTokens.on(async (params) => {
     const uri = params.textDocument.uri;
+    const program =
+      workspace.program(uri) || (await workspace.compile(uri, false));
+    // Read the document/annotations AFTER the potential compile await, so a
+    // didChange processed during it can't leave us caching a result built
+    // from older annotations under the newer document version.
     const document = workspace.document(uri);
     const annotations = workspace.annotations(uri);
-    const program =
-      workspace.program(uri) || (await workspace.compile(uri, true));
     const cached = semanticTokensCache.get(uri);
     if (
       document &&
@@ -682,10 +685,10 @@ try {
   });
   connection.languages.semanticTokens.onRange(async (params) => {
     const uri = params.textDocument.uri;
+    const program =
+      workspace.program(uri) || (await workspace.compile(uri, false));
     const document = workspace.document(uri);
     const annotations = workspace.annotations(uri);
-    const program =
-      workspace.program(uri) || (await workspace.compile(uri, true));
     performance.mark(`lsp: semanticTokens.onRange ${uri} start`);
     const result = getSemanticTokens(
       document,

--- a/packages/sparkdown-language-server/src/sparkdown-language-server.ts
+++ b/packages/sparkdown-language-server/src/sparkdown-language-server.ts
@@ -150,12 +150,34 @@ try {
     }
   });
 
+  // Clients re-pull folding ranges and semantic tokens after every change AND
+  // every refresh, so identical requests arrive in bursts. Both computations
+  // are pure functions of (document version, program version) -- cache the
+  // last result per uri and only recompute when either input moves.
+  const foldingRangeCache = new Map<
+    string,
+    { documentVersion: number; programVersion: number | undefined; result: any }
+  >();
+  const semanticTokensCache = new Map<
+    string,
+    { documentVersion: number; programVersion: number | undefined; result: any }
+  >();
+
   // foldingRangeProvider
   connection.onFoldingRanges((params) => {
     const uri = params.textDocument.uri;
     const document = workspace.document(uri);
     const annotations = workspace.annotations(uri);
     const program = workspace.program(uri);
+    const cached = foldingRangeCache.get(uri);
+    if (
+      document &&
+      cached &&
+      cached.documentVersion === document.version &&
+      cached.programVersion === program?.version
+    ) {
+      return cached.result;
+    }
     performance.mark(`lsp: onFoldingRanges ${uri} start`);
     const result = getFoldingRanges(document, annotations, program);
     performance.mark(`lsp: onFoldingRanges ${uri} end`);
@@ -164,6 +186,13 @@ try {
       `lsp: onFoldingRanges ${uri} start`,
       `lsp: onFoldingRanges ${uri} end`,
     );
+    if (document) {
+      foldingRangeCache.set(uri, {
+        documentVersion: document.version,
+        programVersion: program?.version,
+        result,
+      });
+    }
     return result;
   });
 
@@ -625,6 +654,15 @@ try {
     const annotations = workspace.annotations(uri);
     const program =
       workspace.program(uri) || (await workspace.compile(uri, true));
+    const cached = semanticTokensCache.get(uri);
+    if (
+      document &&
+      cached &&
+      cached.documentVersion === document.version &&
+      cached.programVersion === program?.version
+    ) {
+      return cached.result;
+    }
     performance.mark(`lsp: semanticTokens.on ${uri} start`);
     const result = getSemanticTokens(document, annotations, program);
     performance.mark(`lsp: semanticTokens.on ${uri} end`);
@@ -633,6 +671,13 @@ try {
       `lsp: semanticTokens.on ${uri} start`,
       `lsp: semanticTokens.on ${uri} end`,
     );
+    if (document) {
+      semanticTokensCache.set(uri, {
+        documentVersion: document.version,
+        programVersion: program?.version,
+        result,
+      });
+    }
     return result;
   });
   connection.languages.semanticTokens.onRange(async (params) => {

--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -56,6 +56,7 @@ import { formatList } from "../utils/formatList";
 import { getExpectedSelectorTypes } from "../utils/getExpectedSelectorTypes";
 import { getPossibleStringIdentifiers } from "../utils/getPossibleStringIdentifiers";
 import { indexStructs } from "../utils/indexStructs";
+import { populateFilteredImages } from "../utils/populateFilteredImages";
 import { profile } from "../utils/profile";
 import { readProperty } from "../utils/readProperty";
 import { resolveFileUsingImpliedExtension } from "../utils/resolveFileUsingImpliedExtension";
@@ -704,6 +705,14 @@ export class SparkdownCompiler {
       program.simulationOptions = this._config.simulationOptions;
     }
     program.startFrom = startFrom ?? this._config.startFrom;
+    // Precompute every authored filtered_image's `filtered_src` while the raw
+    // SVG source is still attached, then strip that source from the context:
+    // it dominated the full program payload (7.5MB of 8.9MB on a real
+    // project), and with filtered_srcs baked no consumer reads it -- previews
+    // resolve through `src`, and the engine's runtime filterImage() no-ops on
+    // anything already filtered.
+    populateFilteredImages(program.context ?? {});
+    this.stripImageData(program);
     const result = {
       textDocument: {
         uri,
@@ -2324,6 +2333,22 @@ export class SparkdownCompiler {
     this.populateImplicitDefs(state, program);
     this.populateDefinedDefaultProperties(state, program);
     profile("end", this._profilerId, "buildContext", uri);
+  }
+
+  /**
+   * Remove the inlined SVG source (`data`) from image context structs before
+   * the program leaves the compiler. Runs AFTER populateFilteredImages, so
+   * filtered images already carry their computed `filtered_src`.
+   */
+  protected stripImageData(program: SparkProgram) {
+    const images = program.context?.["image"];
+    if (images) {
+      for (const image of Object.values(images)) {
+        if (image && typeof image === "object" && (image as any).data != null) {
+          delete (image as any).data;
+        }
+      }
+    }
   }
 
   populateBuiltins(state: SparkdownCompilerState, program: SparkProgram) {

--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -56,7 +56,6 @@ import { formatList } from "../utils/formatList";
 import { getExpectedSelectorTypes } from "../utils/getExpectedSelectorTypes";
 import { getPossibleStringIdentifiers } from "../utils/getPossibleStringIdentifiers";
 import { indexStructs } from "../utils/indexStructs";
-import { populateFilteredImages } from "../utils/populateFilteredImages";
 import { profile } from "../utils/profile";
 import { readProperty } from "../utils/readProperty";
 import { resolveFileUsingImpliedExtension } from "../utils/resolveFileUsingImpliedExtension";
@@ -705,14 +704,6 @@ export class SparkdownCompiler {
       program.simulationOptions = this._config.simulationOptions;
     }
     program.startFrom = startFrom ?? this._config.startFrom;
-    // Precompute every authored filtered_image's `filtered_src` while the raw
-    // SVG source is still attached, then strip that source from the context:
-    // it dominated the full program payload (7.5MB of 8.9MB on a real
-    // project), and with filtered_srcs baked no consumer reads it -- previews
-    // resolve through `src`, and the engine's runtime filterImage() no-ops on
-    // anything already filtered.
-    populateFilteredImages(program.context ?? {});
-    this.stripImageData(program);
     const result = {
       textDocument: {
         uri,
@@ -2333,22 +2324,6 @@ export class SparkdownCompiler {
     this.populateImplicitDefs(state, program);
     this.populateDefinedDefaultProperties(state, program);
     profile("end", this._profilerId, "buildContext", uri);
-  }
-
-  /**
-   * Remove the inlined SVG source (`data`) from image context structs before
-   * the program leaves the compiler. Runs AFTER populateFilteredImages, so
-   * filtered images already carry their computed `filtered_src`.
-   */
-  protected stripImageData(program: SparkProgram) {
-    const images = program.context?.["image"];
-    if (images) {
-      for (const image of Object.values(images)) {
-        if (image && typeof image === "object" && (image as any).data != null) {
-          delete (image as any).data;
-        }
-      }
-    }
   }
 
   populateBuiltins(state: SparkdownCompilerState, program: SparkProgram) {

--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -342,14 +342,20 @@ export class SparkdownCompiler {
           file.version !== undefined &&
           file.languageId !== undefined
         ) {
-          this.documents.add({
-            textDocument: {
-              uri: file.uri,
-              languageId: file.languageId!,
-              version: file.version,
-              text: file.text || "",
+          // Defer parses: the compile that follows pulls the trees it needs
+          // through tree()/annotations(), so scripts the program never
+          // includes are never parsed, and configure itself stays fast.
+          this.documents.add(
+            {
+              textDocument: {
+                uri: file.uri,
+                languageId: file.languageId!,
+                version: file.version,
+                text: file.text || "",
+              },
             },
-          });
+            { defer: true },
+          );
         }
         this.addFile({ file });
       }
@@ -365,14 +371,19 @@ export class SparkdownCompiler {
       file.version !== undefined &&
       file.languageId !== undefined
     ) {
-      this.documents.add({
-        textDocument: {
-          uri: file.uri,
-          text: file.text || "",
-          version: file.version,
-          languageId: file.languageId,
+      // Deferred: the next compile pulls the tree if this script is part of
+      // the program (see configure()).
+      this.documents.add(
+        {
+          textDocument: {
+            uri: file.uri,
+            text: file.text || "",
+            version: file.version,
+            languageId: file.languageId,
+          },
         },
-      });
+        { defer: true },
+      );
     }
     return result;
   }
@@ -384,14 +395,17 @@ export class SparkdownCompiler {
       file.version !== undefined &&
       file.languageId !== undefined
     ) {
-      this.documents.set({
-        textDocument: {
-          uri: file.uri,
-          text: file.text! || "",
-          version: file.version,
-          languageId: file.languageId,
+      this.documents.set(
+        {
+          textDocument: {
+            uri: file.uri,
+            text: file.text! || "",
+            version: file.version,
+            languageId: file.languageId,
+          },
         },
-      });
+        { defer: true },
+      );
     }
     return this.files.update(params);
   }

--- a/packages/sparkdown/src/compiler/classes/SparkdownDocument.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownDocument.ts
@@ -26,10 +26,24 @@ export class SparkdownDocument implements TextDocument {
   }
 
   get length() {
-    return this.text.offsetAt(this.text.positionAt(Number.MAX_VALUE));
+    return this.cachedText.length;
   }
 
-  lineChunks = true;
+  // chunk() serves multi-line, line-aligned slices, not single lines.
+  lineChunks = false;
+
+  /**
+   * The parser reads the document through `chunk()`/`read()`/`length` many
+   * thousands of times per parse; computing each read through positionAt's
+   * binary search almost doubled full-parse time on large documents. Cache the
+   * flat text and serve reads from it (invalidated on `update()`).
+   */
+  protected _cachedText?: string;
+
+  protected get cachedText(): string {
+    this._cachedText ??= this.text.getText();
+    return this._cachedText;
+  }
 
   constructor(
     uri: DocumentUri,
@@ -62,7 +76,7 @@ export class SparkdownDocument implements TextDocument {
   }
 
   read(from: number, to: number): string {
-    return this.text.getText(this.range(from, to));
+    return this.cachedText.slice(from, to);
   }
 
   lineAt(from: number): number {
@@ -74,12 +88,33 @@ export class SparkdownDocument implements TextDocument {
       line: line,
       character: 0,
     });
-    const lineText = this.chunk(lineFrom);
+    const lineText = this.lineChunk(lineFrom);
     if (lineText === "\r\n" || lineText === "\r" || lineText === "\n") {
       return "";
     }
     return lineText;
   };
+
+  /**
+   * One line starting at `from`, without its trailing newline -- unless `from`
+   * sits on a bare newline, which is returned as-is. (The pre-slice `chunk()`
+   * semantics, kept for line-oriented callers.)
+   */
+  lineChunk(from: number): string {
+    const start = this.text.positionAt(from);
+    const end = { line: start.line + 1, character: 0 };
+    const line = this.text.getText({ start, end });
+    if (line === "\r\n" || line === "\r" || line === "\n") {
+      return line;
+    }
+    if (line.endsWith("\r\n")) {
+      return line.slice(0, -2);
+    }
+    if (line.endsWith("\r") || line.endsWith("\n")) {
+      return line.slice(0, -1);
+    }
+    return line;
+  }
 
   getLineRange = (line: number): Range => {
     const lineTo = Math.max(
@@ -100,21 +135,30 @@ export class SparkdownDocument implements TextDocument {
 
   update(changes: TextDocumentContentChangeEvent[], version: number): void {
     this.text = TextDocument.update(this.text, changes, version);
+    this._cachedText = undefined;
   }
 
+  /**
+   * Target size for `chunk()` slices. Large enough that a full parse only
+   * needs a handful of chunk calls (serving one LINE per call cost +86% on a
+   * 207KB document); bounded so an incremental resume doesn't pull the whole
+   * remaining document into the tokenizer's string window.
+   */
+  static readonly CHUNK_TARGET_SIZE = 16384;
+
   chunk(from: number): string {
-    const start = this.text.positionAt(from);
-    const end = { line: start.line + 1, character: 0 };
-    const line = this.text.getText({ start, end });
-    if (line === "\r\n" || line === "\r" || line === "\n") {
-      return line;
+    const text = this.cachedText;
+    if (from >= text.length) {
+      return "";
     }
-    if (line.endsWith("\r\n")) {
-      return line.slice(0, -2);
+    let end = from + SparkdownDocument.CHUNK_TARGET_SIZE;
+    if (end >= text.length) {
+      return text.slice(from);
     }
-    if (line.endsWith("\r") || line.endsWith("\n")) {
-      return line.slice(0, -1);
-    }
-    return line;
+    // Extend to the end of the line containing `end` so slices always break
+    // right after a newline (the tokenizer's window loop expects that).
+    const newline = text.indexOf("\n", end);
+    end = newline === -1 ? text.length : newline + 1;
+    return text.slice(from, end);
   }
 }

--- a/packages/sparkdown/src/compiler/classes/SparkdownDocumentRegistry.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownDocumentRegistry.ts
@@ -184,12 +184,31 @@ export class SparkdownDocumentRegistry {
     }
   }
 
+  /**
+   * Parse (or re-parse) a document whose parse was deferred by
+   * `set(..., { defer: true })` -- or whose tree is stale -- so accessors
+   * always observe an up-to-date tree without every bulk-loaded document
+   * paying a full parse up front.
+   */
+  protected ensureParsed(uri: string) {
+    const syncedDocument = this._syncedDocuments.get(uri);
+    if (!syncedDocument) {
+      return;
+    }
+    const state = this.getDocumentState(uri);
+    if (!state.tree || state.treeVersion !== syncedDocument.version) {
+      this.updateSyntaxTree(syncedDocument, syncedDocument);
+    }
+  }
+
   tree(uri: string) {
+    this.ensureParsed(uri);
     const state = this.getDocumentState(uri);
     return state.tree;
   }
 
   annotations(uri: string) {
+    this.ensureParsed(uri);
     const state = this.getDocumentState(uri);
     return state.annotators.get();
   }
@@ -218,25 +237,31 @@ export class SparkdownDocumentRegistry {
     }
   }
 
-  add(params: {
-    textDocument: {
-      uri: string;
-      text: string;
-      version: number | null;
-      languageId: string | null;
-    };
-  }) {
-    return this.set(params);
+  add(
+    params: {
+      textDocument: {
+        uri: string;
+        text: string;
+        version: number | null;
+        languageId: string | null;
+      };
+    },
+    options?: { defer?: boolean },
+  ) {
+    return this.set(params, options);
   }
 
-  set(params: {
-    textDocument: {
-      uri: string;
-      text: string;
-      version: number | null;
-      languageId: string | null;
-    };
-  }) {
+  set(
+    params: {
+      textDocument: {
+        uri: string;
+        text: string;
+        version: number | null;
+        languageId: string | null;
+      };
+    },
+    options?: { defer?: boolean },
+  ) {
     const td = params.textDocument;
     const beforeDocument =
       this._syncedDocuments.get(td.uri) ||
@@ -248,6 +273,16 @@ export class SparkdownDocumentRegistry {
       td.text.replace(NEWLINE_REGEX, "\n"),
     );
     this._syncedDocuments.set(td.uri, syncedDocument);
+    if (options?.defer) {
+      // Defer the (expensive) parse until something actually reads this
+      // document's tree/annotations. Drop stale parse state so ensureParsed
+      // re-parses the new content.
+      const state = this.getDocumentState(td.uri);
+      state.tree = undefined;
+      state.treeFragments = undefined;
+      state.treeVersion = undefined;
+      return true;
+    }
     this.updateSyntaxTree(beforeDocument, syncedDocument);
     return true;
   }

--- a/packages/sparkdown/src/workspace/classes/SparkdownWorkspace.ts
+++ b/packages/sparkdown/src/workspace/classes/SparkdownWorkspace.ts
@@ -257,6 +257,7 @@ export abstract class SparkdownWorkspace {
       uri?: string;
       omitImageData?: boolean;
       slimProgramNotifications?: boolean;
+      compileDebounceDelay?: number;
       files?: Omit<File, "type" | "name" | "ext">[];
     } & Omit<SparkdownCompilerConfig, "files">;
   }): Promise<{
@@ -273,11 +274,12 @@ export abstract class SparkdownWorkspace {
       this._resolveCompilerConfigured = resolve;
     });
     if (params.initializationOptions) {
-      // (slimProgramNotifications must be destructured out so it doesn't
-      // fall through into compilerConfig.)
+      // (slimProgramNotifications/compileDebounceDelay must be destructured
+      // out so they don't fall through into compilerConfig.)
       const {
         omitImageData,
         slimProgramNotifications,
+        compileDebounceDelay,
         settings,
         uri,
         ...compilerConfig
@@ -287,6 +289,9 @@ export abstract class SparkdownWorkspace {
       }
       if (slimProgramNotifications != null) {
         this.slimProgramNotifications = slimProgramNotifications;
+      }
+      if (compileDebounceDelay != null) {
+        this._changeCompileDebounceDelay = compileDebounceDelay;
       }
       if (settings) {
         this.loadConfiguration(settings);
@@ -627,6 +632,42 @@ export abstract class SparkdownWorkspace {
     return this.compile(uri, force);
   }, DEBOUNCE_DELAY);
 
+  // Trailing debounce for keystroke-driven compiles. A full compile costs
+  // hundreds of ms on a large project, and running one per keystroke just
+  // saturates the compiler worker with results that are stale on arrival.
+  // The max-wait keeps diagnostics/preview converging during sustained
+  // typing instead of freezing until the first pause.
+  protected _changeCompileDebounceDelay = 200;
+  protected _changeCompileTimer?: ReturnType<typeof setTimeout>;
+  protected _changeCompileDeadline?: number;
+  protected _pendingChangeCompileUri?: string;
+
+  protected scheduleChangeCompile(uri: string) {
+    const delay = this._changeCompileDebounceDelay;
+    if (delay <= 0) {
+      this.compile(uri, false);
+      return;
+    }
+    this._pendingChangeCompileUri = uri;
+    if (this._changeCompileTimer != null) {
+      clearTimeout(this._changeCompileTimer);
+    }
+    const now = Date.now();
+    if (this._changeCompileDeadline == null) {
+      this._changeCompileDeadline = now + delay * 4;
+    }
+    const wait = Math.min(delay, Math.max(0, this._changeCompileDeadline - now));
+    this._changeCompileTimer = setTimeout(() => {
+      this._changeCompileTimer = undefined;
+      this._changeCompileDeadline = undefined;
+      const pendingUri = this._pendingChangeCompileUri;
+      this._pendingChangeCompileUri = undefined;
+      if (pendingUri != null) {
+        this.compile(pendingUri, false);
+      }
+    }, wait);
+  }
+
   async compile(
     uri: string,
     force: boolean,
@@ -644,7 +685,23 @@ export abstract class SparkdownWorkspace {
     }
     const state = this.getProgramState(uri);
     if (!force && !anyDocChanged && state.program) {
+      // Flush any waiters queued behind a compile that ended up unnecessary
+      // (e.g. a forced compile already covered their version).
+      const nextCompiledCallbacks = this._onNextCompiled.get(uri);
+      if (nextCompiledCallbacks) {
+        this._onNextCompiled.delete(uri);
+        nextCompiledCallbacks.forEach((c) => c?.(state.program));
+      }
       return state.program;
+    }
+    if (!force && this._pendingChangeCompileUri === uri) {
+      // A debounced keystroke compile for this document is already scheduled;
+      // piggyback on it instead of racing it with a second full compile.
+      return new Promise((resolve) => {
+        const nextCompiledCallbacks = this._onNextCompiled.get(uri) || [];
+        nextCompiledCallbacks.push(resolve);
+        this._onNextCompiled.set(uri, nextCompiledCallbacks);
+      });
     }
     if (
       !force &&
@@ -845,7 +902,7 @@ export abstract class SparkdownWorkspace {
     const contentChanges = params.contentChanges;
     this._documentVersions.set(textDocument.uri, textDocument.version);
     this.updateCompilerDocument(textDocument, contentChanges).then(() => {
-      this.compile(textDocument.uri, false);
+      this.scheduleChangeCompile(textDocument.uri);
     });
     this.onChangeTextDocument(params);
   }

--- a/packages/sparkdown/src/workspace/classes/SparkdownWorkspace.ts
+++ b/packages/sparkdown/src/workspace/classes/SparkdownWorkspace.ts
@@ -666,15 +666,22 @@ export abstract class SparkdownWorkspace {
   protected _changeCompileDebounceDelay = 200;
   protected _changeCompileTimer?: ReturnType<typeof setTimeout>;
   protected _changeCompileDeadline?: number;
-  protected _pendingChangeCompileUri?: string;
+  // EVERY document with a pending debounced compile. A multi-file change
+  // burst (find-and-replace, Save All, a workspace edit) can touch documents
+  // in DIFFERENT compile trees (a standalone script, a second main.sd tree);
+  // keeping only the latest uri silently dropped the earlier ones' compiles,
+  // stranding their piggybacked waiters and leaving their diagnostics stale.
+  protected _pendingChangeCompileUris = new Set<string>();
 
   protected scheduleChangeCompile(uri: string) {
     const delay = this._changeCompileDebounceDelay;
     if (delay <= 0) {
-      this.compile(uri, false);
+      this.compile(uri, false).catch((e) => {
+        console.error(e);
+      });
       return;
     }
-    this._pendingChangeCompileUri = uri;
+    this._pendingChangeCompileUris.add(uri);
     if (this._changeCompileTimer != null) {
       clearTimeout(this._changeCompileTimer);
     }
@@ -683,13 +690,21 @@ export abstract class SparkdownWorkspace {
       this._changeCompileDeadline = now + delay * 4;
     }
     const wait = Math.min(delay, Math.max(0, this._changeCompileDeadline - now));
-    this._changeCompileTimer = setTimeout(() => {
+    this._changeCompileTimer = setTimeout(async () => {
       this._changeCompileTimer = undefined;
       this._changeCompileDeadline = undefined;
-      const pendingUri = this._pendingChangeCompileUri;
-      this._pendingChangeCompileUri = undefined;
-      if (pendingUri != null) {
-        this.compile(pendingUri, false);
+      const pendingUris = Array.from(this._pendingChangeCompileUris);
+      this._pendingChangeCompileUris.clear();
+      // Compile each pending document in order. Documents covered by an
+      // earlier compile in this batch hit the no-change early-return (which
+      // also flushes their waiters), so same-tree batches still cost one
+      // compile; only genuinely separate trees pay for their own.
+      for (const pendingUri of pendingUris) {
+        try {
+          await this.compile(pendingUri, false);
+        } catch (e) {
+          console.error(e);
+        }
       }
     }, wait);
   }
@@ -720,7 +735,7 @@ export abstract class SparkdownWorkspace {
       }
       return state.program;
     }
-    if (!force && this._pendingChangeCompileUri === uri) {
+    if (!force && this._pendingChangeCompileUris.has(uri)) {
       // A debounced keystroke compile for this document is already scheduled;
       // piggyback on it instead of racing it with a second full compile.
       return new Promise((resolve) => {
@@ -743,32 +758,51 @@ export abstract class SparkdownWorkspace {
     state.compilingDocumentVersion = this._documentVersions.get(uri);
     let result: CompileProgramResult | undefined = undefined;
     const mainScriptUri = this.getMainScriptUri(uri);
-    if (mainScriptUri) {
-      result = await this.compileDocument(mainScriptUri);
-      this.getProgramState(mainScriptUri).program = result.program;
-      if (result.program.scripts) {
-        for (const [uri, version] of Object.entries(result.program.scripts)) {
-          const state = this.getProgramState(uri);
-          state.program = result.program;
-          state.compilingDocumentVersion = undefined;
-          state.compiledDocumentVersion = version;
-          state.version++;
-          this._onNextCompiled.get(uri)?.forEach((c) => c?.(result?.program));
-          this._onNextCompiled.delete(uri);
+    try {
+      if (mainScriptUri) {
+        result = await this.compileDocument(mainScriptUri);
+        this.getProgramState(mainScriptUri).program = result.program;
+        if (result.program.scripts) {
+          for (const [uri, version] of Object.entries(result.program.scripts)) {
+            const state = this.getProgramState(uri);
+            state.program = result.program;
+            state.compilingDocumentVersion = undefined;
+            state.compiledDocumentVersion = version;
+            state.version++;
+            this._onNextCompiled.get(uri)?.forEach((c) => c?.(result?.program));
+            this._onNextCompiled.delete(uri);
+          }
         }
       }
-    }
-    if (uri !== mainScriptUri && result?.program?.scripts[uri] == null) {
-      // Target script is not included by main,
-      // So it must be parsed on its own to report diagnostics
-      result = await this.compileDocument(uri);
-      const state = this.getProgramState(uri);
-      state.program = result.program;
+      if (uri !== mainScriptUri && result?.program?.scripts[uri] == null) {
+        // Target script is not included by main,
+        // So it must be parsed on its own to report diagnostics
+        result = await this.compileDocument(uri);
+        const state = this.getProgramState(uri);
+        state.program = result.program;
+        state.compilingDocumentVersion = undefined;
+        state.compiledDocumentVersion = result.program?.scripts[uri];
+        state.version++;
+        this._onNextCompiled.get(uri)?.forEach((c) => c?.(result?.program));
+        this._onNextCompiled.delete(uri);
+      }
+    } catch (e) {
+      // Settle instead of strand: piggybacked callers (pull diagnostics etc.)
+      // are awaiting these resolvers, and a compile failure must not turn
+      // their requests into permanent hangs.
+      const flush = (flushUri: string) => {
+        const callbacks = this._onNextCompiled.get(flushUri);
+        if (callbacks) {
+          this._onNextCompiled.delete(flushUri);
+          callbacks.forEach((c) => c?.(undefined));
+        }
+      };
+      flush(uri);
+      if (mainScriptUri) {
+        flush(mainScriptUri);
+      }
       state.compilingDocumentVersion = undefined;
-      state.compiledDocumentVersion = result.program?.scripts[uri];
-      state.version++;
-      this._onNextCompiled.get(uri)?.forEach((c) => c?.(result?.program));
-      this._onNextCompiled.delete(uri);
+      throw e;
     }
     if (result?.program) {
       const state = this.getProgramState(uri);

--- a/packages/sparkdown/src/workspace/classes/SparkdownWorkspace.ts
+++ b/packages/sparkdown/src/workspace/classes/SparkdownWorkspace.ts
@@ -261,7 +261,6 @@ export abstract class SparkdownWorkspace {
       files?: Omit<File, "type" | "name" | "ext">[];
     } & Omit<SparkdownCompilerConfig, "files">;
   }): Promise<{
-    program?: SparkProgram;
     textDocuments?: {
       uri: string;
       text: string;
@@ -344,12 +343,25 @@ export abstract class SparkdownWorkspace {
         compilerConfig.workspace ??
         params.workspaceFolders?.[0]?.uri ??
         params.rootUri;
-      await this.loadCompiler({
-        ...compilerConfig,
-        workspace,
-        files,
+      // Configure the compiler and run the first compile OFF the initialize
+      // response path. Nothing the client renders first needs them: compiler
+      // requests wait on `whenCompilerConfigured`, results arrive through
+      // publishDiagnostics/didCompile, and the post-initialize refreshes
+      // re-request anything asked for too early (#224). Awaiting this wall
+      // here kept the editor invisible for the entire multi-second
+      // parse+configure+compile chain on large projects (#285).
+      (async () => {
+        await this.loadCompiler({
+          ...compilerConfig,
+          workspace,
+          files,
+        });
+        if (uri) {
+          await this.compile(uri, true);
+        }
+      })().catch((err) => {
+        console.error("compiler configuration failed", err);
       });
-      const program = uri ? await this.compile(uri, true) : undefined;
       const textDocuments: {
         uri: string;
         text: string;
@@ -370,7 +382,7 @@ export abstract class SparkdownWorkspace {
           });
         }
       }
-      return { program, textDocuments };
+      return { textDocuments };
     }
     return {};
   }
@@ -615,10 +627,24 @@ export abstract class SparkdownWorkspace {
     return this._openDocuments.has(uri);
   }
 
+  /**
+   * Wait (if necessary) for the compiler worker to be configured before
+   * talking to it. Since initialize() no longer blocks on configuration,
+   * document/file traffic can otherwise race ahead of ConfigureCompiler and
+   * be silently clobbered by its files snapshot.
+   */
+  protected async compilerReady() {
+    const configuring = this.whenCompilerConfigured;
+    if (configuring) {
+      await configuring;
+    }
+  }
+
   protected async updateCompilerDocument(
     textDocument: { uri: string },
     contentChanges: SparkdownDocumentContentChangeEvent[],
   ) {
+    await this.compilerReady();
     return this._compilerChannelConnection.sendRequest(
       UpdateCompilerDocumentMessage.type,
       {
@@ -924,6 +950,7 @@ export abstract class SparkdownWorkspace {
       line: selectedRange.start.line,
     };
     this.onSelectTextDocument(params);
+    await this.compilerReady();
     const result = await this._compilerChannelConnection.sendRequest(
       SelectCompilerDocumentMessage.type,
       params,
@@ -939,6 +966,7 @@ export abstract class SparkdownWorkspace {
     const file = await this.loadFile({ uri });
     this._watchedFiles.set(uri, file);
     this.onCreatedFile(file);
+    await this.compilerReady();
     await this._compilerChannelConnection.sendRequest(
       AddCompilerFileMessage.type,
       { file },
@@ -960,6 +988,7 @@ export abstract class SparkdownWorkspace {
       this._watchedFiles.set(uri, file);
       this._documentVersions.set(uri, file.version);
       this.onChangedFile(file);
+      await this.compilerReady();
       await this._compilerChannelConnection.sendRequest(
         UpdateCompilerFileMessage.type,
         { file },
@@ -986,6 +1015,7 @@ export abstract class SparkdownWorkspace {
     if (deletedFile) {
       this.onDeletedFile(deletedFile!);
     }
+    await this.compilerReady();
     await this._compilerChannelConnection.sendRequest(
       RemoveCompilerFileMessage.type,
       {

--- a/sparkdown-player-app/src/main.ts
+++ b/sparkdown-player-app/src/main.ts
@@ -88,11 +88,24 @@ connection.addEventListener("message", async (e) => {
   if (isMessage(message)) {
     // Forward protocol messages from editor to player
     sendProtocolMessage(message);
-    // Forward protocol responses and notifications from editor to service worker
-    navigator.serviceWorker.controller?.postMessage(
-      message,
-      (message as any).result?.transfer || (message as any).params?.transfer,
-    );
+    // Forward protocol RESPONSES to our own service worker. The SW only ever
+    // awaits responses (to the FetchGameAsset requests it sends while serving
+    // /file:/ assets), so notifications -- including the editor's
+    // per-keystroke textDocument traffic -- would just be cloned into it and
+    // dropped. Same-origin/proxied preview never registers this SW at all;
+    // the editor's own root-scoped SW serves /file:/ there.
+    if (
+      !SAME_ORIGIN &&
+      !SAME_ORIGIN_PROXY &&
+      (message as any).id !== undefined &&
+      ((message as any).result !== undefined ||
+        (message as any).error !== undefined)
+    ) {
+      navigator.serviceWorker.controller?.postMessage(
+        message,
+        (message as any).result?.transfer || (message as any).params?.transfer,
+      );
+    }
   }
 });
 

--- a/vscode-sparkdown/src/managers/SparkProgramManager.ts
+++ b/vscode-sparkdown/src/managers/SparkProgramManager.ts
@@ -9,7 +9,23 @@ import {
   LanguageClient,
 } from "vscode-languageclient/browser";
 
-type ProgramCompiledListener = (uri: vscode.Uri, program: SparkProgram) => void;
+/**
+ * Notified when a script's program has been recompiled. With slim
+ * notifications the program itself is not pushed, so `program` may be
+ * undefined -- consumers that need it should pull via `getOrCompile()`.
+ */
+type ProgramCompiledListener = (
+  uri: vscode.Uri,
+  program: SparkProgram | undefined,
+) => void;
+
+/** The projection relayed by slim `compiler/didCompile` notifications. */
+export interface SlimProgram {
+  uri: string;
+  scripts: SparkProgram["scripts"];
+  files?: SparkProgram["files"];
+  version?: number;
+}
 
 export class SparkProgramManager {
   private static _instance: SparkProgramManager;
@@ -56,6 +72,28 @@ export class SparkProgramManager {
         listener(vscode.Uri.parse(scriptUri), program),
       );
     }
+    this.updateResourceContexts();
+  }
+
+  /**
+   * Handle a slim `compiler/didCompile` notification: the full program was
+   * NOT pushed (that clone cost ~9MB per keystroke on a large project), so
+   * drop any cached full program for the affected scripts and let consumers
+   * pull a fresh one on demand via `getOrCompile()`.
+   */
+  updateSlim(uri: vscode.Uri, program: SlimProgram) {
+    this._lastCompiledUri = uri.toString();
+    for (const scriptUri of Object.keys(program.scripts)) {
+      this._compiledPrograms.delete(scriptUri);
+      this._compiledUris.add(vscode.Uri.parse(scriptUri));
+      this._listeners.forEach((listener) =>
+        listener(vscode.Uri.parse(scriptUri), undefined),
+      );
+    }
+    this.updateResourceContexts();
+  }
+
+  protected updateResourceContexts() {
     const resources = Array.from(
       this._compiledUris.keys().map((uri) => uri.toString()),
     );
@@ -110,10 +148,18 @@ export class SparkProgramManager {
   async compile(uri: vscode.Uri) {
     const client = await this.languageClientReady;
     const params: CompileProgramParams = { uri: uri.toString() };
-    return client.sendRequest<SparkProgram>(
+    const program = await client.sendRequest<SparkProgram>(
       CompileProgramMessage.method,
       params,
       CancellationToken.None,
     );
+    if (program?.scripts) {
+      // Cache the pulled program so bursts of readers don't re-request it;
+      // the next slim didCompile invalidates these entries.
+      for (const scriptUri of Object.keys(program.scripts)) {
+        this._compiledPrograms.set(scriptUri, program);
+      }
+    }
+    return program;
   }
 }

--- a/vscode-sparkdown/src/managers/SparkProgramManager.ts
+++ b/vscode-sparkdown/src/managers/SparkProgramManager.ts
@@ -147,7 +147,9 @@ export class SparkProgramManager {
 
   async compile(uri: vscode.Uri) {
     const client = await this.languageClientReady;
-    const params: CompileProgramParams = { uri: uri.toString() };
+    const params: CompileProgramParams = {
+      textDocument: { uri: uri.toString() },
+    };
     const program = await client.sendRequest<SparkProgram>(
       CompileProgramMessage.method,
       params,

--- a/vscode-sparkdown/src/managers/SparkdownStatisticsPanelSerializer.ts
+++ b/vscode-sparkdown/src/managers/SparkdownStatisticsPanelSerializer.ts
@@ -59,7 +59,7 @@ export async function refreshPanel(
     version: document.version,
     loading: true,
   });
-  const program = SparkProgramManager.instance.get(document.uri);
+  const program = await SparkProgramManager.instance.getOrCompile(document.uri);
   if (program) {
     const stats = await retrieveScreenPlayStatistics(
       context,

--- a/vscode-sparkdown/src/utils/activateCompilationView.ts
+++ b/vscode-sparkdown/src/utils/activateCompilationView.ts
@@ -38,7 +38,7 @@ export function activateCompilationView(context: vscode.ExtensionContext) {
   const treeView = vscode.window.createTreeView("sparkdown-compilation", {
     treeDataProvider: SparkdownCompilationTreeDataProvider.instance,
   });
-  treeView.onDidChangeSelection((e) => {
+  treeView.onDidChangeSelection(async (e) => {
     const initiatedByReveal = programmaticSelectionDepth > 0;
     if (initiatedByReveal) {
       // Ignore programmatically selected tree items
@@ -46,7 +46,7 @@ export function activateCompilationView(context: vscode.ExtensionContext) {
     }
     // If user selected tree item, then select the corresponding document location
     if (SparkdownCompilationTreeDataProvider.instance.uri) {
-      const program = SparkProgramManager.instance.get(
+      const program = await SparkProgramManager.instance.getOrCompile(
         SparkdownCompilationTreeDataProvider.instance.uri,
       );
       if (program) {
@@ -79,37 +79,52 @@ export function activateCompilationView(context: vscode.ExtensionContext) {
   });
   context.subscriptions.push(treeView);
 
+  // With slim program notifications the compiled tree is no longer pushed to
+  // us on every compile -- pull it on demand, and only while the tree view is
+  // actually visible. While hidden, just remember that the data went stale.
+  let treeDataStale = false;
+  let treeDataUri: vscode.Uri | undefined;
+  const refreshTreeData = async (uri: vscode.Uri) => {
+    treeDataUri = uri;
+    if (!treeView.visible) {
+      treeDataStale = true;
+      return;
+    }
+    treeDataStale = false;
+    const program = await SparkProgramManager.instance.getOrCompile(uri);
+    // The visible/current uri may have changed while we awaited the program.
+    if (treeDataUri?.toString() === uri.toString()) {
+      SparkdownCompilationTreeDataProvider.instance.setTreeData(
+        uri,
+        program?.compiled,
+      );
+    }
+  };
+
   // Initialize provider
   const editor = vscode.window.activeTextEditor;
   if (editor?.document.languageId === "sparkdown") {
-    const program = SparkProgramManager.instance.get(editor.document.uri);
-    SparkdownCompilationTreeDataProvider.instance.setTreeData(
-      editor.document.uri,
-      program?.compiled,
-    );
+    refreshTreeData(editor.document.uri);
   }
 
   context.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor((editor) => {
       if (editor?.document.languageId === "sparkdown") {
-        const program = SparkProgramManager.instance.get(editor.document.uri);
-        SparkdownCompilationTreeDataProvider.instance.setTreeData(
-          editor.document.uri,
-          program?.compiled,
-        );
+        refreshTreeData(editor.document.uri);
       }
     }),
   );
 
-  const handleCompiledProgram = (uri: vscode.Uri, program: SparkProgram) => {
+  const handleCompiledProgram = (
+    uri: vscode.Uri,
+    _program: SparkProgram | undefined,
+  ) => {
     if (
       SparkdownCompilationTreeDataProvider.instance.uri?.toString() ===
-      uri.toString()
+        uri.toString() ||
+      treeDataUri?.toString() === uri.toString()
     ) {
-      SparkdownCompilationTreeDataProvider.instance.setTreeData(
-        uri,
-        program.compiled,
-      );
+      refreshTreeData(uri);
     }
   };
   SparkProgramManager.instance.addListener(handleCompiledProgram);
@@ -118,6 +133,14 @@ export function activateCompilationView(context: vscode.ExtensionContext) {
       SparkProgramManager.instance.removeListener(handleCompiledProgram);
     },
   });
+
+  context.subscriptions.push(
+    treeView.onDidChangeVisibility((e) => {
+      if (e.visible && treeDataStale && treeDataUri) {
+        refreshTreeData(treeDataUri);
+      }
+    }),
+  );
 
   context.subscriptions.push(
     vscode.window.onDidChangeTextEditorSelection((change) => {

--- a/vscode-sparkdown/src/utils/activateLanguageClient.ts
+++ b/vscode-sparkdown/src/utils/activateLanguageClient.ts
@@ -69,6 +69,11 @@ export const activateLanguageClient = async (
       },
       uri: editor?.document?.uri.toString(),
       omitImageData: true,
+      // Receive only {uri, scripts, files, version} + diagnosticsSummary per
+      // compile instead of the multi-MB full program (which was structured-
+      // cloned across two threads on every keystroke). Consumers that need
+      // the full program pull it on demand via SparkProgramManager.
+      slimProgramNotifications: true,
     },
     middleware: {
       provideDocumentSymbols: async (
@@ -118,13 +123,16 @@ const onCompile = async (
   _context: vscode.ExtensionContext,
   params: CompiledProgramParams,
 ) => {
+  // With slimProgramNotifications this is only the {uri, scripts, files,
+  // version} projection -- enough to know WHAT recompiled, not the program
+  // itself.
   const program = params.program;
   const textDocument = params.textDocument;
   const document = await getOpenTextDocument(
     vscode.Uri.parse(textDocument.uri),
   );
   if (document) {
-    SparkProgramManager.instance.update(document.uri, program);
+    SparkProgramManager.instance.updateSlim(document.uri, program);
     updateCommands(document.uri);
     // TODO:
     // SparkdownStatusBarManager.instance.updateStatusBarItem(

--- a/vscode-sparkdown/src/utils/exportJson.ts
+++ b/vscode-sparkdown/src/utils/exportJson.ts
@@ -19,7 +19,7 @@ export const exportJson = async (): Promise<void> => {
   if (!fsPath) {
     return;
   }
-  const program = SparkProgramManager.instance.get(uri);
+  const program = await SparkProgramManager.instance.getOrCompile(uri);
   if (!program) {
     vscode.window.showWarningMessage(
       "Still compiling program... Try again later.",


### PR DESCRIPTION
# Long-script editing performance: waves 1+2 of the measured roadmap

A 13-agent audit of the editing pipeline on the real R&B project (8,309-line `main.sd`, 7 includes, 617 assets / 189MB) attributed where every millisecond of typing latency and startup time goes, adversarially verified the top findings against `main`, and produced a ranked roadmap. This PR lands the first two waves. Every claim below was measured on that project, and the result was live-verified in the running editor (headless-Chromium-driven, full project seeded into OPFS).

## Results on R&B

| Metric | Before | After |
| --- | --- | --- |
| Keystroke dispatch, deep in ACT ONE (median) | ~136ms | **15.8ms** |
| Editor reveal (#285, from navigation) | ~11,000ms (5s watchdog always won) | **~3.7s** (hidden→visible ~1.4s) |
| First diagnostics | blocked the editor | ~6.6s, in the background |
| Full program relay to player | ~8.9MB per keystroke | ~8.9MB, but once per pause (and vscode now takes the 118KB slim relay instead) |
| Slim relay to the editor | 118.6KB/keystroke | unchanged, but sent once per pause |
| From-scratch parse of `main.sd` (per registry) | ~4.3s | **~2.2s** (chunk() tax eliminated: 14,287 → 13 calls) |
| Editing with preview open | ~0.9–1.2s player CPU per keystroke | one pipeline per typing pause |

Verified working end-to-end after the changes: syntax + semantic highlighting, 324 warnings reported, fold gutter (fold/unfold on the real doc), cursor-scrub preview, edit → compile → preview convergence with full visuals (backdrop, portrait, textbox skin, typed text appearing in the speech bubble).

## What changed

**Client (impower-dev editor)**
- `foldService` answered "is this line foldable?" by scanning all 3,273 folding ranges with a `doc.lineAt` per range per viewport line (70.9ms/keystroke — the largest client cost). Ranges are now indexed by start line (bare-node repro: 41.2ms → 0.025ms).
- The editor reveals as soon as the syntax tree covers the viewport + restored scroll target, instead of a parse-idle signal that a 207KB doc starves for ~11s (the 5s watchdog — kept as backstop — was what actually revealed every load). Scroll/focus restore and view binding now happen at reveal, eliminating the post-reveal scroll yank.
- Dead per-dispatch work removed: full-doc `state.toJSON`+stringify feeding a never-wired callback; whole-doc indent decorations rebuilt per keystroke (now viewport-scoped); a 51MB eager `Image()` preload whose cache map had no readers.

**Language server / workspace (shared by impower-dev AND vscode)**
- Keystroke-driven compiles are debounced (trailing 200ms, 4× max-wait, per-host configurable; force/PLAY compiles stay immediate). Pull-diagnostics piggyback on the pending compile instead of racing it.
- The post-compile notification storm is gone: workspace-wide folding/semantic-token refreshes were sent once **per tracked uri** per compile (16–22/keystroke); now once per compile. Diagnostics publish only when they actually changed. Folding/semantic tokens are cached per (doc version, program version) server-side, and the client coalesces pull bursts per (client, uri).
- `initialize` no longer blocks on the compiler configure + first full compile (#224 — the wall behind #285); compiler-channel traffic is gated on the configured signal so nothing races the files snapshot. Both worker registries now defer bulk parses (parse-on-first-access; LS warms them in the background smallest-first because completions read every script's annotations).
- `SparkdownDocument.chunk()` served ONE line per call through positionAt binary searches (+86–93% on every from-scratch parse). It now serves cached 16KB line-aligned slices — parity suites confirm byte-identical trees.

**Program payload (#227) — attempted, then reverted in-branch (kept for the record)**
- The plan was: precompute every filtered image's `filtered_src` at compile time, then strip the raw `buildSVGSource` output (7.5MB of the 8.9MB program) from `context.image`. It works visually (live-verified), but benching the payload showed eager baking adds a full per-variant SVG data-URI for *every* tilde-filter combination the script uses — context grew to ~18.6MB, worse than the disease, and every compile re-paid all the `filterSVG` calls. Reverted; the real fix is serving SVG source on demand (follow-up issue).

**vscode-sparkdown**
- Opts into slim program notifications (it was the last full-relay-per-keystroke consumer) and pulls the full program on demand: the compilation tree refreshes only while visible, statistics/JSON-export pull when invoked.

**Player**
- Cursor scrubs no longer destroy+rebuild the whole Application (only a real program change does); the running-game restart debounce actually coalesces now (100ms → 1s); dead per-keystroke traffic removed (didSave full-text forward, SW re-posts of notifications, unused Initialize program clone).

## Notes for review

- Deliberately NOT done: swapping a new program into the connected `Game` in place. `Game.updateProgram` rebuilds the Story but not module context, so an in-place swap after editing a define/UI would preview stale visuals. With compiles debounced, the rebuild now runs once per pause, which was the win that mattered.
- Two benign `Request timed out` page errors can appear at boot: early feature pulls racing the now-async configure; the existing post-initialize refresh (#224's self-heal) re-requests and everything recovers. Worth a follow-up to widen that request timeout or gate the first pulls.
- The vscode extension builds cleanly with the slim opt-in but has not been soak-tested in a live Extension Host session yet.
- Wave 3 (breaking the remaining ~450ms compile floor — inkjs ExportRuntime is 208ms fully non-incremental) is a follow-up.

Closes #285. Addresses the startup half of #224 and the payload half of #227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
