### PR TITLE
perf(compiler): short-circuit no-change compiles (449ms → 0)

### DIFF
--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -193,6 +193,25 @@ export class SparkdownCompiler {
   // cross-flow fingerprint matches AND no header/global chunk changed (const
   // inlining / global decl) — see the `flowMemo` in `compile`.
   protected _flowJsonCache?: Map<string, { fp: string; value: any }>;
+
+  // Bumped whenever the file registry changes (assets added/updated/removed,
+  // or a reconfigure). Part of the no-change compile short-circuit key:
+  // document versions alone can't see asset changes, but populateAssets and
+  // include resolution can be affected by them.
+  protected _filesEpoch = 0;
+  // The previous successful compile, reusable verbatim when nothing that
+  // feeds a compile has changed since. A forced no-change recompile measured
+  // ~450ms on a large project even with every incremental cache warm --
+  // ExportRuntime alone is ~200ms and fully non-incremental -- and PLAY /
+  // init paths re-request compiles without any edit having happened.
+  protected _lastCompileResult?: {
+    uri: string;
+    scripts: Record<string, number>;
+    filesEpoch: number;
+    countAllVisits: boolean;
+    program: SparkProgram;
+    story?: RuntimeStory;
+  };
   // While recomputing a non-reusable flow's subtree, populateLocations tees the
   // entries it commits here so they can be cached for next compile.
   protected _locCaptureTarget?: {
@@ -237,6 +256,9 @@ export class SparkdownCompiler {
   }
 
   configure(config: SparkdownCompilerConfig) {
+    // Anything a reconfigure can change (definitions, settings, files) feeds
+    // compiles, so retire the no-change short-circuit's snapshot.
+    this._filesEpoch++;
     if (
       config.definitions?.builtins !== undefined &&
       config.definitions?.builtins !== this._config.definitions?.builtins
@@ -365,6 +387,7 @@ export class SparkdownCompiler {
   }
 
   addFile(params: AddCompilerFileParams) {
+    this._filesEpoch++;
     const result = this.files.add(params);
     const file = params.file;
     if (
@@ -390,6 +413,7 @@ export class SparkdownCompiler {
   }
 
   updateFile(params: UpdateCompilerFileParams) {
+    this._filesEpoch++;
     const file = params.file;
     if (
       file.type === "script" &&
@@ -416,6 +440,7 @@ export class SparkdownCompiler {
   }
 
   removeFile(params: RemoveCompilerFileParams) {
+    this._filesEpoch++;
     this.files.remove(params);
     const file = params.file;
     const removed = this.documents.remove({ textDocument: { uri: file.uri } });
@@ -446,7 +471,42 @@ export class SparkdownCompiler {
     const uri = params.textDocument.uri;
     const startFrom = params.startFrom;
 
-    // console.clear();
+    // No-change short-circuit: if every script the last compile read is at
+    // the same version, the file registry hasn't changed, and the visit
+    // counting mode matches, this compile would reproduce the previous
+    // program bit-for-bit -- serve it instead of re-running the pipeline.
+    // (Per-request fields are re-stamped below; listeners still fire so
+    // downstream consumers observe the compile as usual.)
+    const cached = this._lastCompileResult;
+    if (
+      cached &&
+      cached.uri === uri &&
+      cached.filesEpoch === this._filesEpoch &&
+      cached.countAllVisits === !!params.countAllVisits &&
+      Object.entries(cached.scripts).every(
+        ([scriptUri, version]) =>
+          this.documents.get(scriptUri)?.version === version,
+      )
+    ) {
+      cached.program.startFrom = startFrom ?? this._config.startFrom;
+      const result: {
+        textDocument: { uri: string; version: number };
+        program: SparkProgram;
+        story?: RuntimeStory;
+      } = {
+        textDocument: {
+          uri,
+          version: this.documents.get(uri)?.version ?? -1,
+        },
+        program: cached.program,
+        story: cached.story,
+      };
+      this._events[CompiledProgramMessage.method].forEach((l) => {
+        l?.(result);
+      });
+      delete result.story;
+      return result;
+    }
 
     const program: SparkProgram = {
       uri,
@@ -571,6 +631,7 @@ export class SparkdownCompiler {
     this._compilationIds = new Set();
     this._changedChunkRanges = [];
 
+    let compileThrew = false;
     try {
       profile("start", this._profilerId, "ink/parse", uri);
       const parsedStory = this.parseIncrementally(
@@ -686,6 +747,7 @@ export class SparkdownCompiler {
         profile("end", this._profilerId, "populateLocations", uri);
       }
     } catch (e) {
+      compileThrew = true;
       console.error(e);
     }
 
@@ -713,6 +775,18 @@ export class SparkdownCompiler {
     // anything already filtered.
     populateFilteredImages(program.context ?? {});
     this.stripImageData(program);
+    // Remember this compile for the no-change short-circuit -- but only if it
+    // completed cleanly (a compile that threw may hold a partial program).
+    this._lastCompileResult = compileThrew
+      ? undefined
+      : {
+          uri,
+          scripts: { ...program.scripts },
+          filesEpoch: this._filesEpoch,
+          countAllVisits: !!params.countAllVisits,
+          program,
+          story: state.story,
+        };
     const result = {
       textDocument: {
         uri,

--- a/packages/sparkdown/src/workspace/classes/SparkdownWorkspace.ts
+++ b/packages/sparkdown/src/workspace/classes/SparkdownWorkspace.ts
@@ -757,10 +757,18 @@ export abstract class SparkdownWorkspace {
     }
     state.compilingDocumentVersion = this._documentVersions.get(uri);
     let result: CompileProgramResult | undefined = undefined;
+    // When the compiler's no-change short-circuit serves its cached program,
+    // it returns the SAME object as last time. Bumping our version counter on
+    // that would advertise a "new" program that is bit-identical -- and the
+    // player rebuilds its whole Game whenever program.version changes -- so
+    // detect identity and keep the version stable.
+    let programUnchanged = false;
     const mainScriptUri = this.getMainScriptUri(uri);
     try {
       if (mainScriptUri) {
+        const previousProgram = this.getProgramState(mainScriptUri).program;
         result = await this.compileDocument(mainScriptUri);
+        programUnchanged = result.program === previousProgram;
         this.getProgramState(mainScriptUri).program = result.program;
         if (result.program.scripts) {
           for (const [uri, version] of Object.entries(result.program.scripts)) {
@@ -768,7 +776,9 @@ export abstract class SparkdownWorkspace {
             state.program = result.program;
             state.compilingDocumentVersion = undefined;
             state.compiledDocumentVersion = version;
-            state.version++;
+            if (!programUnchanged) {
+              state.version++;
+            }
             this._onNextCompiled.get(uri)?.forEach((c) => c?.(result?.program));
             this._onNextCompiled.delete(uri);
           }
@@ -777,12 +787,16 @@ export abstract class SparkdownWorkspace {
       if (uri !== mainScriptUri && result?.program?.scripts[uri] == null) {
         // Target script is not included by main,
         // So it must be parsed on its own to report diagnostics
+        const previousProgram = this.getProgramState(uri).program;
         result = await this.compileDocument(uri);
+        programUnchanged = result.program === previousProgram;
         const state = this.getProgramState(uri);
         state.program = result.program;
         state.compilingDocumentVersion = undefined;
         state.compiledDocumentVersion = result.program?.scripts[uri];
-        state.version++;
+        if (!programUnchanged) {
+          state.version++;
+        }
         this._onNextCompiled.get(uri)?.forEach((c) => c?.(result?.program));
         this._onNextCompiled.delete(uri);
       }
@@ -806,7 +820,9 @@ export abstract class SparkdownWorkspace {
     }
     if (result?.program) {
       const state = this.getProgramState(uri);
-      result.program.version = state.version;
+      if (!programUnchanged) {
+        result.program.version = state.version;
+      }
       // With slimProgramNotifications, relay only what the notification's
       // consumers actually read instead of the whole program (which is ~9MB on
       // a large project and re-broadcast on EVERY compile; the receiver pays a


### PR DESCRIPTION
Stacked on #296.

A forced recompile with zero changes still cost ~449ms on the R&B project — ExportRuntime, ToJson, validation, and location population all re-ran to produce a bit-identical program. PLAY and init paths re-request compiles without any edit having happened, and the per-host compile debounce (from #296) can also fire after a force compile already covered the same versions.

The compiler now caches its last successful compile keyed on (root uri, every script version the compile actually read, a file-registry epoch bumped by add/update/remove/configure, countAllVisits) and serves it verbatim on a match — re-stamping per-request fields (startFrom) and still firing compile listeners so downstream consumers observe the compile normally. A compile that threw is never cached.

Measured on R&B: no-change forced recompile **449ms → 0.0ms**; steady-state per-edit compile now med 157ms (the #296 parse/registry work compounds inside the compile as well — audit baseline was 450–470ms). Compiler + incremental + inkjs-utils suites green (666).

The remaining structural work (per-flow incremental ExportRuntime / tiered compile) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)