### PR TITLE
perf(assets): content-signature asset URLs — stable across sessions, bust on write

### DIFF
--- a/impower-dev/src/workers/sw.ts
+++ b/impower-dev/src/workers/sw.ts
@@ -99,9 +99,9 @@ async function handleLocalAssetRequest(url: URL) {
  * A thin adapter over the shared generator: this supplies Cache Storage, the
  * generator owns sizing, encoding and the cache key. That key is the file's
  * STABLE signature (path + lastModified + size + width), NOT the request url —
- * the url carries a `?v=${Date.now()}` cache-bust the workspace re-stamps on
- * every load, so keying on it would regenerate every thumbnail on every page
- * load and leak orphaned entries.
+ * urls are now signature-stamped too (`?v=<mtime>-<size>`), but the stamp can
+ * fall back to a mint-time value when no mtime was known, so the cache keeps
+ * deriving its key from the file itself rather than trusting url parsing.
  */
 async function getOrCreateThumbnail(
   path: string,

--- a/packages/opfs-workspace/src/opfs-workspace.ts
+++ b/packages/opfs-workspace/src/opfs-workspace.ts
@@ -1306,9 +1306,18 @@ const updateFileMetaCache = (
   const name = getName(uri);
   const ext = getFileExtension(uri);
   const type = getFileType(uri);
+  // The `?v=` stamp is the file's CONTENT SIGNATURE (mtime-size), not a
+  // mint-time timestamp. The stamp's job is to bust the service worker's
+  // `immutable` responses when the bytes change — a signature does that
+  // while staying IDENTICAL across sessions for an unchanged file, so the
+  // browser's HTTP/renderer caches (and any URL-keyed downstream cache) keep
+  // working across reloads instead of re-fetching every asset because every
+  // load minted a fresh `Date.now()`. Falls back to a mint-time stamp only
+  // when no mtime is known (degrades to the old always-fresh behavior).
+  const resolvedModified = modified ?? existingFile?.modified ?? Date.now();
   let src = existingFile?.src || "";
   if (name && !src) {
-    src = getSrcFromUri(uri) + `?v=${Date.now()}`;
+    src = getSrcFromUri(uri) + `?v=${resolvedModified}-${size}`;
   }
   const file = {
     uri,
@@ -1318,7 +1327,7 @@ const updateFileMetaCache = (
     src,
     version: version ?? existingFile?.version ?? 0,
     size,
-    modified: modified ?? existingFile?.modified ?? Date.now(),
+    modified: resolvedModified,
     languageId: type === "script" ? LANGUAGE_ID : null,
     text: existingFile?.text,
   };
@@ -1375,9 +1384,17 @@ const updateFileCache = (
     return file;
   }
 
+  // Content-signature stamp (see updateFileMetaCache). On a write the caller
+  // passes the write time as `modified`, so the signature — and therefore the
+  // URL — advances and busts the `immutable` caches; on load it derives from
+  // the OPFS file's lastModified, so an unchanged file keeps the SAME url
+  // across sessions. (A write session stamps its own clock time, which can
+  // differ from the mtime OPFS persists by a few ms — costing at most one
+  // extra bust on the next load, never a stale serve.)
+  const resolvedModified = modified ?? existingFile?.modified ?? Date.now();
   if (name) {
     if (!src || overwrite) {
-      src = getSrcFromUri(uri) + `?v=${Date.now()}`;
+      src = getSrcFromUri(uri) + `?v=${resolvedModified}-${buffer.byteLength}`;
     }
   }
   const text =
@@ -1395,7 +1412,7 @@ const updateFileCache = (
     // Size from the buffer; modified from the OPFS file's lastModified on load
     // or the write time on a fresh write (falls back to the cached value).
     size: buffer.byteLength,
-    modified: modified ?? existingFile?.modified ?? Date.now(),
+    modified: resolvedModified,
     languageId: type === "script" ? LANGUAGE_ID : null,
     text,
   };

--- a/packages/opfs-workspace/test/cacheBusting.test.ts
+++ b/packages/opfs-workspace/test/cacheBusting.test.ts
@@ -10,17 +10,18 @@ import { getSrcFromUri } from "../src/utils/getSrcFromUri";
 // BroadcastChannel/postMessage/navigator side effects, no exports). We
 // reconstruct the EXACT src + version logic from that function using the REAL
 // importable utilities (`getSrcFromUri`, `getName`, `getFileExtension`) plus a
-// minimal in-memory `files` map standing in for `State.files`. `getFileType`
-// is replaced by a trivial "is this an asset" check that returns a non-empty
-// `name` so the src branch is exercised; the cache-bust logic depends only on
-// `name` being truthy and the `!src || overwrite` condition.
+// minimal in-memory `files` map standing in for `State.files`.
 //
 // The desired CONTRACT (per sw.ts serving assets `max-age, immutable`):
-//   (a) a freshly written/overwritten asset's src carries a `?v=` query;
-//   (b) overwriting the same asset yields a DIFFERENT src (busts immutable cache);
-//   (c) `version` advances on write.
-// `Date.now()` is non-deterministic, so we assert the `?v=` param EXISTS and
-// CHANGES, stubbing Date.now to force distinct values.
+//   (a) an asset's src carries a `?v=` query that is the file's CONTENT
+//       SIGNATURE (`<modified>-<size>`), not a mint-time timestamp;
+//   (b) a real write (new modified) yields a DIFFERENT src (busts the
+//       immutable cache), while re-resolving an UNCHANGED file — even from an
+//       empty cache, i.e. a fresh session — yields the SAME src, so browser
+//       and URL-keyed caches survive reloads;
+//   (c) `version` advances on write;
+//   (d) when no mtime is known, the stamp falls back to `Date.now()`
+//       (old always-fresh behavior — over-invalidates, never stale).
 
 interface CachedFile {
   uri: string;
@@ -28,6 +29,8 @@ interface CachedFile {
   ext: string;
   src: string;
   version: number;
+  size: number;
+  modified: number;
 }
 
 // Faithful reconstruction of the src/version portion of updateFileCache.
@@ -36,14 +39,17 @@ function updateFileCache(
   uri: string,
   overwrite: boolean,
   version?: number,
+  size = 100,
+  modified?: number,
 ): CachedFile {
   const existingFile = files.get(uri);
   let src = existingFile?.src || "";
   const name = getName(uri);
   const ext = getFileExtension(uri);
+  const resolvedModified = modified ?? existingFile?.modified ?? Date.now();
   if (name) {
     if (!src || overwrite) {
-      src = getSrcFromUri(uri) + `?v=${Date.now()}`;
+      src = getSrcFromUri(uri) + `?v=${resolvedModified}-${size}`;
     }
   }
   const file: CachedFile = {
@@ -52,6 +58,8 @@ function updateFileCache(
     ext,
     src,
     version: version ?? existingFile?.version ?? 0,
+    size,
+    modified: resolvedModified,
   };
   files.set(uri, file);
   return file;
@@ -72,38 +80,38 @@ describe("cache-busting src versioning", () => {
     vi.restoreAllMocks();
   });
 
-  it("(a) a freshly written asset's src carries a cache-busting ?v= query", () => {
+  it("(a) an asset's src carries its content signature as the ?v= query", () => {
     const files = new Map<string, CachedFile>();
     const uri = "file://proj/images/logo.png";
-    const file = updateFileCache(files, uri, true, 1);
-    expect(file.src).toContain("?v=");
-    expect(queryParam(file.src, "v")).not.toBeNull();
+    const file = updateFileCache(files, uri, true, 1, 2048, 555);
+    expect(queryParam(file.src, "v")).toBe("555-2048");
     // The path portion is still the resource URL.
     expect(file.src.startsWith(getSrcFromUri(uri))).toBe(true);
   });
 
-  it("(a) reading an existing asset (overwrite=false) still gets a ?v= on first cache", () => {
+  it("(b) a real write (new modified) yields a DIFFERENT src", () => {
     const files = new Map<string, CachedFile>();
     const uri = "file://proj/images/logo.png";
-    // First touch has no existing src -> `!src` is true -> gets ?v=.
-    const file = updateFileCache(files, uri, false, 0);
-    expect(file.src).toContain("?v=");
+    const first = updateFileCache(files, uri, true, 1, 2048, 555);
+    const second = updateFileCache(files, uri, true, 2, 2100, 900);
+    expect(second.src).not.toBe(first.src);
+    expect(queryParam(second.src, "v")).toBe("900-2100");
   });
 
-  it("(b) overwriting the same asset yields a DIFFERENT src (busts immutable cache)", () => {
-    const files = new Map<string, CachedFile>();
+  it("(b) an UNCHANGED file re-resolved from an empty cache (fresh session) keeps the SAME src", () => {
+    const sessionOne = new Map<string, CachedFile>();
+    const sessionTwo = new Map<string, CachedFile>();
     const uri = "file://proj/images/logo.png";
-    const first = updateFileCache(files, uri, true, 1);
-    const second = updateFileCache(files, uri, true, 2);
-    expect(second.src).not.toBe(first.src);
-    expect(queryParam(second.src, "v")).not.toBe(queryParam(first.src, "v"));
+    // Both sessions derive the stamp from the file's OPFS mtime + size.
+    const first = updateFileCache(sessionOne, uri, false, 0, 2048, 555);
+    const second = updateFileCache(sessionTwo, uri, false, 0, 2048, 555);
+    expect(second.src).toBe(first.src);
   });
 
   it("(b) a non-overwrite re-read does NOT change an already-cached src", () => {
     const files = new Map<string, CachedFile>();
     const uri = "file://proj/images/logo.png";
-    const first = updateFileCache(files, uri, true, 1);
-    // overwrite=false and src already set -> src stays put.
+    const first = updateFileCache(files, uri, true, 1, 2048, 555);
     const reread = updateFileCache(files, uri, false);
     expect(reread.src).toBe(first.src);
   });
@@ -111,8 +119,8 @@ describe("cache-busting src versioning", () => {
   it("(c) version advances on overwrite", () => {
     const files = new Map<string, CachedFile>();
     const uri = "file://proj/images/logo.png";
-    const first = updateFileCache(files, uri, true, 1);
-    const second = updateFileCache(files, uri, true, 2);
+    const first = updateFileCache(files, uri, true, 1, 2048, 555);
+    const second = updateFileCache(files, uri, true, 2, 2048, 900);
     expect(second.version).toBeGreaterThan(first.version);
     expect(second.version).toBe(2);
   });
@@ -120,15 +128,23 @@ describe("cache-busting src versioning", () => {
   it("(c) version is preserved across a non-overwrite re-read", () => {
     const files = new Map<string, CachedFile>();
     const uri = "file://proj/images/logo.png";
-    updateFileCache(files, uri, true, 5);
+    updateFileCache(files, uri, true, 5, 2048, 555);
     const reread = updateFileCache(files, uri, false);
     expect(reread.version).toBe(5);
+  });
+
+  it("(d) with no mtime known, the stamp falls back to a fresh mint time", () => {
+    const files = new Map<string, CachedFile>();
+    const uri = "file://proj/images/logo.png";
+    const file = updateFileCache(files, uri, true, 1, 2048, undefined);
+    // Date.now() is stubbed to advance; the stamp exists and is time-derived.
+    expect(queryParam(file.src, "v")).toMatch(/^\d+-2048$/);
   });
 
   it("nested asset paths keep their full resource path in the busted src", () => {
     const files = new Map<string, CachedFile>();
     const uri = "file://proj/images/ui/btn.png";
-    const file = updateFileCache(files, uri, true, 1);
+    const file = updateFileCache(files, uri, true, 1, 100, 555);
     expect(file.src.startsWith("/file:/proj/images/ui/btn.png?v=")).toBe(true);
   });
 });

--- a/packages/sparkdown/src/thumbnails/composeThumbnail.ts
+++ b/packages/sparkdown/src/thumbnails/composeThumbnail.ts
@@ -48,10 +48,12 @@ export const clampThumbnailWidth = (requested: unknown) => {
  * Cache key for a thumbnail of `sources` at `maxWidth`.
  *
  * Keyed by each layer's STABLE signature — path + lastModified + size — never
- * by its url. Asset urls carry a `?v=${Date.now()}` cache-buster that the
- * workspace re-stamps on load, so a url-derived key regenerates everything on
- * every page load and leaks orphaned entries. The signature only moves when
- * the bytes actually do, so a real edit still invalidates.
+ * by its url. Asset urls now carry a signature-derived `?v=<mtime>-<size>`
+ * stamp, but this cache still computes its own key from the file it was
+ * handed: the url stamp can fall back to a mint-time value when no mtime was
+ * known, and parsing identity back out of a url is exactly the coupling this
+ * key discipline exists to avoid. The signature only moves when the bytes
+ * actually do, so a real edit still invalidates.
  */
 export const thumbnailCacheKey = (
   sources: readonly Pick<


### PR DESCRIPTION
The `?v=` cache-bust on asset srcs was `Date.now()` at src-resolution time. Its only job is busting the service worker's `immutable` responses when a file's bytes change — but the workspace's file cache is in-memory, so every page load re-resolved every src and minted a fresh stamp. All ~628 asset URLs on the R&B project changed every session: the browser's HTTP/renderer caches never survived a reload, and URL-keyed downstream caching was categorically unsound (the thumbnail cache's signature-keying exists specifically to work around this).

This stamps `?v=<modified>-<size>` instead — the same content signature the thumbnail cache already computes — resolved from the same value stored as the file's `modified` metadata so URL and metadata always agree:

- **on load**, it derives from OPFS `lastModified` → an unchanged file keeps the **same URL across sessions**;
- **on write**, the caller passes the write time → the URL advances and busts exactly as before;
- with no mtime known it falls back to mint time (old always-fresh behavior; over-invalidates, never stale).

A write session stamps its own clock time, which can differ from the mtime OPFS persists by a few ms — costing at most one extra bust on the next load, never a stale serve.

## Verified

- **Live, R&B project (628 assets): all 628 srcs byte-identical across two reloads** (previously 0), signature-shaped (`?v=1785494583905-175662`); full game-preview render unchanged (portrait/backdrop/dialogue).
- `cacheBusting.test.ts` contract updated: 8 tests including the new load-bearing pin (unchanged file re-resolved from an empty cache — i.e. a fresh session — keeps the same src) and the write-busts pin.
- Stale comments in the thumbnail generator + editor SW updated; their signature-keyed caches are unaffected (they never trusted the URL, and still don't — the stamp can fall back to mint time).

## Why merge this before #303

Stable URLs make URL-keyed caching sound, which is the prerequisite for giving the cross-origin player SW a cache for on-demand filtered SVG variants (it can't do signature keying — it never sees file metadata, only relayed bytes). #303 will be updated to build on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)