### PR TITLE
perf(compiler): incremental ExportRuntime via constructed-flow reuse (#298)

### DIFF
--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -239,11 +239,11 @@ export class SparkdownCompiler {
   // for the old signature and the callee pops a different number of values,
   // silently and with no diagnostic.
   protected _prevFlowSignatures?: Map<string, string>;
-  // Per-file identity sequence of ROOT-REGION chunks (loose content before
-  // the first flow, externals, post-external loose content, include/run
-  // sites). Any change there can shift consts/globals whose values were
-  // INLINED into flows at generation — all reuse is disabled that compile.
-  protected _lastRootBlocksByUri?: Map<string, object[]>;
+  // Per-file ordered ROOT-REGION STRUCTURE descriptors — `include`/`run`
+  // targets and `EXTERNAL` name+arity. A change to this sequence disables all
+  // reuse for that compile; ordinary root content (front matter, loose text,
+  // globals) is deliberately excluded. See the guard for the full rationale.
+  protected _lastRootBlocksByUri?: Map<string, string[]>;
   // Reuse kill-switches. `_flowReuseDisabled` is recomputed per compile;
   // starts true so the first compile after construction never reuses.
   protected _flowReuseDisabled = true;
@@ -254,8 +254,30 @@ export class SparkdownCompiler {
   // computed once per chunk identity.
   protected _chunkReuseScan?: WeakMap<
     object,
-    { disqualifies: boolean; invalidatesGlobals: boolean }
+    {
+      disqualifies: boolean;
+      invalidatesGlobals: boolean;
+      constNames: string[];
+    }
   >;
+  // Census of every constant and global NAME declared anywhere in the
+  // program, accumulated across all files of one compile and compared against
+  // the previous compile's. Two distinct generation-time dependencies make a
+  // reused flow's bytecode sensitive to names declared OUTSIDE it:
+  //
+  //   - a constant is INLINED BY VALUE into every referencing flow, so a
+  //     constant that disappears leaves stale inlined bytecode behind; and
+  //   - `Divert.ResolveTargetContent` runs during GENERATION and consults
+  //     `story.variableDeclarations`, so a global whose name matches a flow
+  //     shadows it and flips every call site from knot-call codegen (which
+  //     emits `PackTuple`/padding derived from the callee's parameters) to
+  //     variable-target codegen, which emits none of that.
+  //
+  // Neither is visible to the per-chunk scan: a DELETED declaration appears
+  // in no chunk at all. Names only — values may change freely, so editing a
+  // `store`'s value still keeps reuse.
+  protected _censusEntries?: string[];
+  protected _prevCensusKey?: string;
   // [container, previous parent] for every container committed to reuse this
   // compile — restored if the compile throws, so the previous RuntimeStory
   // (still live in the checkpoint-builder Game) isn't left holding containers
@@ -751,6 +773,7 @@ export class SparkdownCompiler {
     this._nextFlowRuns = new Map();
     this._reuseParentBackups = undefined;
     this._renamedFlowNames = undefined;
+    this._censusEntries = [];
 
     try {
       profile("start", this._profilerId, "ink/parse", uri);
@@ -782,6 +805,14 @@ export class SparkdownCompiler {
       // current signatures aren't known until assembly finishes, so this is
       // a post-hoc check that feeds the same demotion path as a
       // late-discovered global change.
+      // Declared-name census across every file of this compile — see
+      // `_censusEntries`. Compared here (not per file) so includes can't
+      // clobber each other's census.
+      const censusKey = (this._censusEntries ?? []).sort().join("");
+      if (this._prevCensusKey !== undefined && this._prevCensusKey !== censusKey) {
+        this._flowReuseDisabled = true;
+      }
+      this._prevCensusKey = censusKey;
       const flowSignatures = this.collectFlowSignatures(parsedStory);
       if (this._prevFlowSignatures && !this._flowReuseDisabled) {
         const prev = this._prevFlowSignatures;
@@ -953,6 +984,9 @@ export class SparkdownCompiler {
       // drop all reuse records so the next compile rebuilds from scratch.
       this._prevFlowRuns = undefined;
       this._lastRootBlocksByUri = undefined;
+      // The census may be half-collected (the throw can land mid-parse), so
+      // drop it rather than compare a truncated one next compile.
+      this._prevCensusKey = undefined;
       this._disableFlowReuseNextCompile = true;
     }
 
@@ -1166,13 +1200,18 @@ export class SparkdownCompiler {
     // is also why a CHANGED chunk containing one disables reuse globally.
     const scanChunkForReuse = (
       block: any,
-    ): { disqualifies: boolean; invalidatesGlobals: boolean } => {
+    ): {
+      disqualifies: boolean;
+      invalidatesGlobals: boolean;
+      constNames: string[];
+    } => {
       let cached = this._chunkReuseScan?.get(block);
       if (cached) {
         return cached;
       }
       let disqualifies = false;
       let invalidatesGlobals = false;
+      const declaredNames: string[] = [];
       const scan = (nodes: ParsedObject[]) => {
         for (const n of nodes) {
           if (
@@ -1181,14 +1220,30 @@ export class SparkdownCompiler {
           ) {
             disqualifies = true;
             invalidatesGlobals = true;
+            const constName =
+              n instanceof ConstantDeclaration
+                ? n.constantName
+                : n.identifier?.name;
+            if (constName) {
+              declaredNames.push(`c:${constName}`);
+            }
           } else if (
             n instanceof ExternalDeclaration ||
             n instanceof StructDefinition ||
             (n instanceof ParsedVariableAssignment && n.isGlobalDeclaration)
           ) {
             disqualifies = true;
+            const globalName =
+              n instanceof ParsedVariableAssignment
+                ? n.variableName
+                : n.identifier?.name;
+            if (globalName) {
+              declaredNames.push(`g:${globalName}`);
+            }
           }
-          if (n.content && !(invalidatesGlobals && disqualifies)) {
+          // Always recurse: the NAME census below must be complete, so this
+          // can't early-out once the boolean verdicts are both decided.
+          if (n.content) {
             scan(n.content);
           }
         }
@@ -1196,54 +1251,81 @@ export class SparkdownCompiler {
       if (block?.content) {
         scan(block.content);
       }
-      cached = { disqualifies, invalidatesGlobals };
+      cached = { disqualifies, invalidatesGlobals, declaredNames };
       (this._chunkReuseScan ??= new WeakMap()).set(block, cached);
       return cached;
     };
 
     // ---- Flow-reuse guards computed from this file's chunk list ----
-    // (1) ROOT-REGION identity: loose content before the first flow,
-    // externals, post-external loose content, and include/run sites define
-    // consts/globals whose values were inlined into flows at generation. ANY
-    // change to that sequence (add/remove/modify) disables all reuse.
+    // (1) ROOT-REGION STRUCTURE: the ordered sequence of `include`/`run`
+    // targets and `EXTERNAL` signatures. These change which files contribute
+    // flows, and which call sites compile to external calls — neither of
+    // which a reused flow can re-derive on its own. Compared by DESCRIPTOR
+    // (the target string / the external's name+arity), NOT by chunk identity:
+    // an identity comparison also fired for a re-lowered-but-unchanged chunk,
+    // and the incremental parser's reparse window routinely re-lowers a root
+    // chunk adjacent to an edit — which is why editing the front matter, or
+    // the first scene, used to kill reuse for that whole compile.
+    //
+    // Deliberately NOT part of the descriptor: front matter, loose top-level
+    // content, and top-level `store`/`var`/`define` declarations. None of
+    // them can alter a reused flow's bytecode — top-level flows are
+    // name-addressed in `namedOnlyContent`, so their internal paths don't
+    // shift when top-level content grows or shrinks, and globals are read
+    // through runtime variable lookups rather than inlined. Constants ARE
+    // inlined, and are covered precisely by (2).
+    //
     // (2) A changed chunk containing a const/list declaration anywhere
     // disables all reuse (value inlining into other flows).
     {
-      const rootBlocks: object[] = [];
-      let attachesToFlow = false;
+      const rootDescriptors: string[] = [];
       for (const rec of chunkRecords) {
         const block = rec.block as any;
-        if (block.include || block.run) {
-          rootBlocks.push(block);
+        if (block.include) {
+          rootDescriptors.push(`inc:${block.include}`);
         }
-        const kind = chunkFlowKind(block);
-        if (kind === "knot" || kind === "stitch") {
-          attachesToFlow = true;
-        } else if (kind === "external") {
-          attachesToFlow = false;
-          rootBlocks.push(block);
-        } else if (kind === "body" && !attachesToFlow) {
-          rootBlocks.push(block);
+        if (block.run) {
+          rootDescriptors.push(`run:${block.run}`);
         }
-        if (
-          !this._flowReuseDisabled &&
-          block.content &&
-          this._prevCompilationIds &&
-          !this._prevCompilationIds.has(block) &&
-          scanChunkForReuse(block).invalidatesGlobals
-        ) {
-          this._flowReuseDisabled = true;
+        if (chunkFlowKind(block) === "external") {
+          const ext = block.content?.[0] as ExternalDeclaration | undefined;
+          rootDescriptors.push(
+            `ext:${ext?.identifier?.name ?? "?"}/${
+              ext?.argumentNames?.length ?? 0
+            }`,
+          );
+        }
+        if (block.content) {
+          const scan = scanChunkForReuse(block);
+          // Declared-NAME census (see `_censusEntries`). Cached per chunk
+          // identity, so unchanged chunks cost a map lookup. Accumulated
+          // across the WHOLE compile rather than per file — this function
+          // recurses once per `include`/`run`, so a per-file key would be
+          // overwritten by each included file and then compared against a
+          // different file's census on the next compile, permanently
+          // disabling reuse for any multi-file project.
+          for (const name of scan.declaredNames) {
+            this._censusEntries?.push(`${uri}|${name}`);
+          }
+          if (
+            !this._flowReuseDisabled &&
+            this._prevCompilationIds &&
+            !this._prevCompilationIds.has(block) &&
+            scan.invalidatesGlobals
+          ) {
+            this._flowReuseDisabled = true;
+          }
         }
       }
-      const prevRootBlocks = this._lastRootBlocksByUri?.get(uri);
+      const prevRootDescriptors = this._lastRootBlocksByUri?.get(uri);
       if (
-        !prevRootBlocks ||
-        prevRootBlocks.length !== rootBlocks.length ||
-        rootBlocks.some((b, i) => prevRootBlocks[i] !== b)
+        !prevRootDescriptors ||
+        prevRootDescriptors.length !== rootDescriptors.length ||
+        rootDescriptors.some((d, i) => prevRootDescriptors[i] !== d)
       ) {
         this._flowReuseDisabled = true;
       }
-      (this._lastRootBlocksByUri ??= new Map()).set(uri, rootBlocks);
+      (this._lastRootBlocksByUri ??= new Map()).set(uri, rootDescriptors);
     }
 
     // Chunks whose content-assembly is skipped because they feed a flow
@@ -2539,6 +2621,27 @@ export class SparkdownCompiler {
         }
         if (!sameSet) {
           effPrevCache = undefined;
+        }
+      }
+      // A flow's cached locations are keyed by INDEX-addressed runtime paths,
+      // and an unchanged flow's subtree can still change SHAPE when something
+      // before it changes: a constant is inlined at generation, and how many
+      // runtime objects it expands to is type-dependent (a string emits
+      // BeginString/StringValue/EndString, a number emits one value). So
+      // retyping or removing a constant shifts sibling indices inside flows
+      // whose own source shows no changed chunk, and replaying their cached
+      // keys would map real paths to wrong lines. Apply the same global guard
+      // `computeFlowReuse` uses for the bytecode cache: if any changed chunk
+      // starts before the first flow, reuse nothing this compile.
+      if (effPrevCache && this._changedChunkRanges?.length) {
+        const firstStart = starts.length
+          ? starts[0]!
+          : Number.POSITIVE_INFINITY;
+        for (const [changedStart] of this._changedChunkRanges) {
+          if (changedStart < firstStart) {
+            effPrevCache = undefined;
+            break;
+          }
         }
       }
       for (const f of flows) {

--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -12,7 +12,11 @@ import GRAMMAR_DEFINITION from "../../../language/sparkdown.language-grammar.jso
 import { IFileHandler } from "../../inkjs/compiler/IFileHandler";
 import { ErrorType } from "../../inkjs/compiler/Parser/ErrorType";
 import { Choice } from "../../inkjs/compiler/Parser/ParsedHierarchy/Choice";
+import { ConstantDeclaration } from "../../inkjs/compiler/Parser/ParsedHierarchy/Declaration/ConstantDeclaration";
 import { ExternalDeclaration } from "../../inkjs/compiler/Parser/ParsedHierarchy/Declaration/ExternalDeclaration";
+import { ListDefinition } from "../../inkjs/compiler/Parser/ParsedHierarchy/List/ListDefinition";
+import { StructDefinition } from "../../inkjs/compiler/Parser/ParsedHierarchy/Struct/StructDefinition";
+import { VariableAssignment as ParsedVariableAssignment } from "../../inkjs/compiler/Parser/ParsedHierarchy/Variable/VariableAssignment";
 import { Divert } from "../../inkjs/compiler/Parser/ParsedHierarchy/Divert/Divert";
 import { FlowBase } from "../../inkjs/compiler/Parser/ParsedHierarchy/Flow/FlowBase";
 import { Gather } from "../../inkjs/compiler/Parser/ParsedHierarchy/Gather/Gather";
@@ -192,6 +196,66 @@ export class SparkdownCompiler {
   // cross-flow fingerprint matches AND no header/global chunk changed (const
   // inlining / global decl) — see the `flowMemo` in `compile`.
   protected _flowJsonCache?: Map<string, { fp: string; value: any }>;
+
+  // ---- Incremental ExportRuntime: constructed-flow reuse ------------------
+  // A top-level flow (knot/scene/function, plus its stitches) is assembled
+  // from a RUN of chunks: the declaration chunk plus every body chunk that
+  // attached content into it. When the whole run is carried forward
+  // unchanged, last compile's CONSTRUCTED flow node — with its registered
+  // temps/args, weave state, and (crucially) its cached runtime container
+  // subtree — is pushed into the fresh Story as-is and `ExportRuntime` skips
+  // regenerating it entirely (the `runtimeObject` getter returns the cached
+  // container). `ResolveReferences` still runs over the full tree every
+  // compile, so cross-flow paths, count flags, and resolve-time diagnostics
+  // are re-derived; see `Divert.targetContent`'s epoch guard and
+  // `FlattenContainersIn`'s count-flag reconcile for the state that makes
+  // re-resolution over reused containers sound.
+  //
+  // `_prevFlowRuns`: last compile's run record per DECLARATION chunk
+  // identity. `_nextFlowRuns` accumulates this compile's records (fresh
+  // constructions AND committed reuses) and is promoted on success.
+  protected _prevFlowRuns?: Map<
+    object,
+    { flow: FlowBase; contentChunks: object[] }
+  >;
+  protected _nextFlowRuns?: Map<
+    object,
+    { flow: FlowBase; contentChunks: object[] }
+  >;
+  // Line offset each content chunk's debugMetadata was last stamped at —
+  // a reused chunk whose offset is unchanged skips the restamp walk entirely.
+  protected _chunkStampOffset = new WeakMap<object, number>();
+  // Constructed flows that raised a diagnostic during GENERATION (reuse skips
+  // generation, which would silently drop the diagnostic — such flows are
+  // barred from reuse and rebuilt so the diagnostic re-emits).
+  protected _flowsWithGenDiagnostics = new WeakSet<object>();
+  // Per-file identity sequence of ROOT-REGION chunks (loose content before
+  // the first flow, externals, post-external loose content, include/run
+  // sites). Any change there can shift consts/globals whose values were
+  // INLINED into flows at generation — all reuse is disabled that compile.
+  protected _lastRootBlocksByUri?: Map<string, object[]>;
+  // Reuse kill-switches. `_flowReuseDisabled` is recomputed per compile;
+  // starts true so the first compile after construction never reuses.
+  protected _flowReuseDisabled = true;
+  protected _disableFlowReuseNextCompile = false;
+  protected _lastReuseCountAllVisits = false;
+  protected _reusedFlowsThisCompile?: Set<FlowBase>;
+  // Per-chunk reuse-disqualifier scan results (see `scanChunkForReuse`),
+  // computed once per chunk identity.
+  protected _chunkReuseScan?: WeakMap<
+    object,
+    { disqualifies: boolean; invalidatesGlobals: boolean }
+  >;
+  // [container, previous parent] for every container committed to reuse this
+  // compile — restored if the compile throws, so the previous RuntimeStory
+  // (still live in the checkpoint-builder Game) isn't left holding containers
+  // whose parents were stolen by a discarded half-built tree.
+  protected _reuseParentBackups?: Array<[Container, InkObject | null]>;
+  // Top-level flow names whose subtree was touched by a synthetic rename this
+  // compile — their serialized-JSON cache entries must not be reused (the
+  // cross-flow fingerprint records nothing for pure content, so a renamed
+  // `__synth_<n>` temp inside an unchanged flow would otherwise serve stale).
+  protected _renamedFlowNames?: Set<string>;
 
   // Bumped whenever the file registry changes (assets added/updated/removed,
   // or a reconfigure). Part of the no-change compile short-circuit key:
@@ -637,6 +701,44 @@ export class SparkdownCompiler {
     this._changedChunkRanges = [];
 
     let compileThrew = false;
+    // ---- Incremental ExportRuntime: per-compile flow-reuse guards ----
+    this._flowReuseDisabled = this._disableFlowReuseNextCompile;
+    this._disableFlowReuseNextCompile = false;
+    const reuseCountAllVisits = !!params.countAllVisits;
+    if (reuseCountAllVisits || reuseCountAllVisits !== this._lastReuseCountAllVisits) {
+      // countAllVisits changes what GENERATION bakes into every container
+      // (count flags), which reuse skips. Only test harnesses set it.
+      this._flowReuseDisabled = true;
+    }
+    this._lastReuseCountAllVisits = reuseCountAllVisits;
+    if (
+      this._lastCompileResult &&
+      this._lastCompileResult.uri === uri &&
+      this._lastCompileResult.filesEpoch === this._filesEpoch
+    ) {
+      // A change in any NON-entry script (includes / `run` files) can shift
+      // consts/globals whose values were INLINED into other files' flows at
+      // generation — and the include site may come after flows that would
+      // already have committed reuse, so it must be decided up front.
+      for (const [scriptUri, scriptVersion] of Object.entries(
+        this._lastCompileResult.scripts,
+      )) {
+        if (
+          scriptUri !== uri &&
+          this.documents.get(scriptUri)?.version !== scriptVersion
+        ) {
+          this._flowReuseDisabled = true;
+          break;
+        }
+      }
+    } else {
+      this._flowReuseDisabled = true;
+    }
+    this._reusedFlowsThisCompile = new Set();
+    this._nextFlowRuns = new Map();
+    this._reuseParentBackups = undefined;
+    this._renamedFlowNames = undefined;
+
     try {
       profile("start", this._profilerId, "ink/parse", uri);
       const parsedStory = this.parseIncrementally(
@@ -661,15 +763,52 @@ export class SparkdownCompiler {
       // carried-forward chunk re-emits the same diagnostics a cold compile
       // would, without a per-compile tree walk.)
       //
+      // Late-discovered global change (e.g. a mid-file `run` whose .luau
+      // source changed re-lowered its virtual file's root region): demote any
+      // reuse already committed before the discovery so this compile
+      // regenerates those flows from their (intact) parsed content.
+      if (this._flowReuseDisabled && this._reusedFlowsThisCompile?.size) {
+        for (const flow of this._reusedFlowsThisCompile) {
+          this.resetSubtreeRuntime(flow);
+        }
+        this._reusedFlowsThisCompile.clear();
+      }
       // Canonicalize offset-derived synthetic names over the fully-assembled
       // tree so incremental compiles emit byte-identical bytecode to cold ones
       // (see method doc) — must run before ExportRuntime resolves references.
       profile("start", this._profilerId, "ink/canonicalizeSyntheticNames", uri);
-      this.canonicalizeSyntheticFlowNames(parsedStory);
+      const renamedTopLevel = this.canonicalizeSyntheticFlowNames(parsedStory);
       profile("end", this._profilerId, "ink/canonicalizeSyntheticNames", uri);
+      // Positional synthetic renames can land INSIDE an unchanged flow
+      // (adding an anonymous fn earlier renumbers every later `__synth_<n>`).
+      // Names are baked into runtime objects at GENERATION time, so a REUSED
+      // flow touched by a rename must be regenerated — and any renamed flow's
+      // serialized-JSON cache entry must lapse (the cross-flow fingerprint
+      // records nothing for pure content, so it can't catch the rename).
+      if (renamedTopLevel) {
+        for (const flow of renamedTopLevel) {
+          if (this._reusedFlowsThisCompile?.has(flow as FlowBase)) {
+            this.resetSubtreeRuntime(flow);
+            this._reusedFlowsThisCompile?.delete(flow as FlowBase);
+          }
+          const flowName =
+            flow instanceof FlowBase ? flow.identifier?.name : undefined;
+          if (flowName) {
+            (this._renamedFlowNames ??= new Set()).add(flowName);
+          }
+        }
+      }
       profile("start", this._profilerId, "ink/compile", uri);
       const story = parsedStory.ExportRuntime(onDiagnostic);
       profile("end", this._profilerId, "ink/compile", uri);
+      // Bar flows that raised GENERATION-time diagnostics from future reuse —
+      // reuse skips generation, which would silently drop them next compile.
+      for (const flow of parsedStory.flowsWithGenerationDiagnostics) {
+        this._flowsWithGenDiagnostics.add(flow);
+      }
+      if (parsedStory.hadUnattributableGenerationDiagnostic) {
+        this._disableFlowReuseNextCompile = true;
+      }
       if (story) {
         profile("start", this._profilerId, "ink/json", uri);
         const writer = new SimpleJson.Writer();
@@ -680,6 +819,14 @@ export class SparkdownCompiler {
         // cross-flow bits that change without the flow's own source changing.
         const { reusable: reusableFlows, ok: flowReuseOk } =
           this.computeFlowReuse(story);
+        if (this._renamedFlowNames) {
+          // A synthetic rename inside a flow changes its serialized bytes in
+          // ways the fingerprint can't see — its cached JSON must not be
+          // served (see the canonicalize step above).
+          for (const renamed of this._renamedFlowNames) {
+            reusableFlows.delete(renamed);
+          }
+        }
         if (!flowReuseOk) {
           // The global guard failed (a changed chunk sits before the first flow,
           // so an inlined const may have shifted): no flow can be reused this
@@ -749,11 +896,27 @@ export class SparkdownCompiler {
         // Carry this compile's chunk-identity set forward so the next compile
         // can tell which chunks are unchanged.
         this._prevCompilationIds = this._compilationIds;
+        // Promote this compile's flow-run records (fresh constructions and
+        // committed reuses) for the next compile's reuse decisions.
+        this._prevFlowRuns = this._nextFlowRuns;
         profile("end", this._profilerId, "populateLocations", uri);
       }
     } catch (e) {
       compileThrew = true;
       console.error(e);
+      // Restore the parents of containers committed to reuse — the previous
+      // RuntimeStory is still live (checkpoint-builder Game) and generation
+      // may have re-parented them into the now-discarded half-built tree.
+      if (this._reuseParentBackups) {
+        for (const [container, parent] of this._reuseParentBackups) {
+          container.parent = parent;
+        }
+      }
+      // A threw compile can leave carried parsed/runtime state half-mutated;
+      // drop all reuse records so the next compile rebuilds from scratch.
+      this._prevFlowRuns = undefined;
+      this._lastRootBlocksByUri = undefined;
+      this._disableFlowReuseNextCompile = true;
     }
 
     this.populateFiles(program);
@@ -878,15 +1041,249 @@ export class SparkdownCompiler {
       }
     };
 
+    // Restamp-only variant of `remapContent` for chunks feeding a REUSED
+    // flow: rebase debugMetadata source positions in place (shared by
+    // reference with the cached runtime objects, so they auto-shift) WITHOUT
+    // touching cached runtime state — not resetting is the reuse.
+    const restampContent = (
+      content: ParsedObject[],
+      lineNumberOffset: number,
+    ) => {
+      for (const c of content) {
+        if (c.debugMetadata) {
+          this.offsetDebugMetadata(c.debugMetadata, lineNumberOffset, version);
+          c.debugMetadata.fileName = fileName;
+          c.debugMetadata.filePath = uri;
+        }
+        if (
+          "identifier" in c &&
+          c.identifier instanceof Identifier &&
+          c.identifier?.debugMetadata
+        ) {
+          this.offsetDebugMetadata(
+            c.identifier.debugMetadata,
+            lineNumberOffset,
+            version,
+          );
+          c.identifier.debugMetadata.fileName = fileName;
+          c.identifier.debugMetadata.filePath = uri;
+        }
+        if ("pathIdentifiers" in c && Array.isArray(c.pathIdentifiers)) {
+          for (const p of c.pathIdentifiers) {
+            if (p instanceof Identifier && p.debugMetadata) {
+              this.offsetDebugMetadata(p.debugMetadata, lineNumberOffset, version);
+              p.debugMetadata.fileName = fileName;
+              p.debugMetadata.filePath = uri;
+            }
+          }
+        }
+        if (c.content) {
+          restampContent(c.content, lineNumberOffset);
+        }
+      }
+    };
+
     const document = this.documents.get(uri);
     const annotations = this.documents.annotations(uri);
-    const cur = annotations.compilations.iter();
     const topLevelIncludedFileObjs: IncludedFile[] = [];
     const topLevelFlowBaseObjs: FlowBase[] = [];
     const topLevelWeaveObjs: ParsedObject[] = [];
     const topLevelContent: (FlowBase | Weave)[] = [];
 
-    while (cur.value) {
+    // Materialize the chunk list so flow-run reuse decisions can look AHEAD —
+    // a flow's reusability depends on ALL the body chunks that fed it last
+    // compile reappearing unchanged, in order.
+    const chunkRecords: { block: any; from: number; to: number }[] = [];
+    {
+      const cur = annotations.compilations.iter();
+      while (cur.value) {
+        chunkRecords.push({
+          block: cur.value.type,
+          from: cur.from,
+          to: cur.to,
+        });
+        cur.next();
+      }
+    }
+
+    // Where a chunk's content ATTACHES during assembly, discriminated the
+    // same way the assembly branches below do (first content object).
+    const chunkFlowKind = (
+      block: any,
+    ): "knot" | "stitch" | "external" | "body" | "none" => {
+      const first = block?.content?.[0];
+      if (first instanceof Knot) return "knot";
+      if (first instanceof Stitch) return "stitch";
+      if (first instanceof ExternalDeclaration) return "external";
+      if (first) return "body";
+      return "none";
+    };
+
+    // Reuse-disqualifier scan, computed ONCE per chunk identity (carried
+    // chunks keep their result). A flow whose run contains any of these can
+    // never be reused, because skipping its generation loses a story-global
+    // side effect: global `var`/`store` declarations register into the fresh
+    // Story's variableDeclarations, EXTERNALs into `story.externals`, and
+    // const/list/struct declarations feed story-level maps AND (for
+    // consts/lists) are INLINED BY VALUE into other flows' bytecode — which
+    // is also why a CHANGED chunk containing one disables reuse globally.
+    const scanChunkForReuse = (
+      block: any,
+    ): { disqualifies: boolean; invalidatesGlobals: boolean } => {
+      let cached = this._chunkReuseScan?.get(block);
+      if (cached) {
+        return cached;
+      }
+      let disqualifies = false;
+      let invalidatesGlobals = false;
+      const scan = (nodes: ParsedObject[]) => {
+        for (const n of nodes) {
+          if (
+            n instanceof ConstantDeclaration ||
+            n instanceof ListDefinition
+          ) {
+            disqualifies = true;
+            invalidatesGlobals = true;
+          } else if (
+            n instanceof ExternalDeclaration ||
+            n instanceof StructDefinition ||
+            (n instanceof ParsedVariableAssignment && n.isGlobalDeclaration)
+          ) {
+            disqualifies = true;
+          }
+          if (n.content && !(invalidatesGlobals && disqualifies)) {
+            scan(n.content);
+          }
+        }
+      };
+      if (block?.content) {
+        scan(block.content);
+      }
+      cached = { disqualifies, invalidatesGlobals };
+      (this._chunkReuseScan ??= new WeakMap()).set(block, cached);
+      return cached;
+    };
+
+    // ---- Flow-reuse guards computed from this file's chunk list ----
+    // (1) ROOT-REGION identity: loose content before the first flow,
+    // externals, post-external loose content, and include/run sites define
+    // consts/globals whose values were inlined into flows at generation. ANY
+    // change to that sequence (add/remove/modify) disables all reuse.
+    // (2) A changed chunk containing a const/list declaration anywhere
+    // disables all reuse (value inlining into other flows).
+    {
+      const rootBlocks: object[] = [];
+      let attachesToFlow = false;
+      for (const rec of chunkRecords) {
+        const block = rec.block as any;
+        if (block.include || block.run) {
+          rootBlocks.push(block);
+        }
+        const kind = chunkFlowKind(block);
+        if (kind === "knot" || kind === "stitch") {
+          attachesToFlow = true;
+        } else if (kind === "external") {
+          attachesToFlow = false;
+          rootBlocks.push(block);
+        } else if (kind === "body" && !attachesToFlow) {
+          rootBlocks.push(block);
+        }
+        if (
+          !this._flowReuseDisabled &&
+          block.content &&
+          this._prevCompilationIds &&
+          !this._prevCompilationIds.has(block) &&
+          scanChunkForReuse(block).invalidatesGlobals
+        ) {
+          this._flowReuseDisabled = true;
+        }
+      }
+      const prevRootBlocks = this._lastRootBlocksByUri?.get(uri);
+      if (
+        !prevRootBlocks ||
+        prevRootBlocks.length !== rootBlocks.length ||
+        rootBlocks.some((b, i) => prevRootBlocks[i] !== b)
+      ) {
+        this._flowReuseDisabled = true;
+      }
+      (this._lastRootBlocksByUri ??= new Map()).set(uri, rootBlocks);
+    }
+
+    // Chunks whose content-assembly is skipped because they feed a flow
+    // reused from last compile's construction.
+    const reuseSkipBlocks = new Set<object>();
+    // The flow currently receiving body content in the NORMAL assembly path,
+    // recorded so next compile knows each flow's full chunk run.
+    let currentRun: { flow: FlowBase; contentChunks: object[] } | undefined;
+
+    // Try to reuse last compile's constructed flow for the run declared by
+    // `declBlock`: every content chunk of the recorded run must reappear
+    // identically in order (interleaved content-less chunks — includes,
+    // context-only — are transparent), no run chunk may carry a reuse
+    // disqualifier, the flow must not have raised generation-time
+    // diagnostics, and the chunk FOLLOWING the run must not be one that
+    // would attach new body content into this flow.
+    const tryReuseFlowRun = (
+      declBlock: object,
+      startIdx: number,
+    ): FlowBase | undefined => {
+      if (this._flowReuseDisabled || !this._prevFlowRuns) {
+        return undefined;
+      }
+      const prevRun = this._prevFlowRuns.get(declBlock);
+      if (!prevRun || this._flowsWithGenDiagnostics.has(prevRun.flow)) {
+        return undefined;
+      }
+      const runChunks = prevRun.contentChunks;
+      let k = 0;
+      let j = startIdx;
+      while (k < runChunks.length) {
+        if (j >= chunkRecords.length) {
+          return undefined;
+        }
+        const cb = chunkRecords[j]!.block as any;
+        if (!cb.content) {
+          j++;
+          continue;
+        }
+        if (cb !== runChunks[k] || scanChunkForReuse(cb).disqualifies) {
+          return undefined;
+        }
+        j++;
+        k++;
+      }
+      for (let m = j; m < chunkRecords.length; m++) {
+        const cb = chunkRecords[m]!.block as any;
+        if (!cb.content) {
+          continue;
+        }
+        const kind = chunkFlowKind(cb);
+        if (kind !== "knot" && kind !== "external") {
+          return undefined;
+        }
+        break;
+      }
+      for (const c of runChunks) {
+        reuseSkipBlocks.add(c);
+      }
+      this._nextFlowRuns?.set(declBlock, prevRun);
+      this._reusedFlowsThisCompile?.add(prevRun.flow);
+      // Record the reused container's current parent so an aborted compile
+      // can restore it — the previous RuntimeStory is still live in the
+      // checkpoint-builder Game, and generation re-parents this container
+      // into the (then discarded) new root.
+      const reusedContainer = (prevRun.flow as any)._runtimeObject;
+      if (reusedContainer) {
+        (this._reuseParentBackups ??= []).push([
+          reusedContainer,
+          reusedContainer.parent,
+        ]);
+      }
+      return prevRun.flow;
+    };
+
+    for (let chunkIdx = 0; chunkIdx < chunkRecords.length; chunkIdx++) {
+      const rec = chunkRecords[chunkIdx]!;
       const {
         include,
         run,
@@ -897,18 +1294,18 @@ export class SparkdownCompiler {
         defaultDefinitions,
         uuid,
         hoistedKnots,
-      } = cur.value.type;
-      const lineNumberOffset = document?.lineAt(cur.from) ?? 0;
+      } = rec.block;
+      const lineNumberOffset = document?.lineAt(rec.from) ?? 0;
       // Track chunk identity for the incremental location cache. A chunk whose
       // CompiledBlock object is carried forward from the previous compile (same
       // identity) is unchanged; a new identity means it was re-lowered. Record
       // changed chunks' 0-based source line ranges so `populateAllLocations` can
       // tell which flows' subtrees must be recomputed vs reused.
-      const compiledBlock = cur.value.type as object;
+      const compiledBlock = rec.block as object;
       this._compilationIds?.add(compiledBlock);
       if (this._prevCompilationIds && !this._prevCompilationIds.has(compiledBlock)) {
         const chunkStart = lineNumberOffset;
-        const chunkEnd = document?.lineAt(cur.to) ?? chunkStart;
+        const chunkEnd = document?.lineAt(rec.to) ?? chunkStart;
         this._changedChunkRanges?.push([chunkStart, chunkEnd]);
       }
       // Anonymous function literals lowered at chunk-top-level (i.e.
@@ -1080,7 +1477,34 @@ export class SparkdownCompiler {
         }
       }
       if (content) {
+        // ---- Incremental ExportRuntime: flow-run reuse decision ----
+        if (!reuseSkipBlocks.has(compiledBlock)) {
+          const first = content[0];
+          const declaresTopLevelFlow =
+            first instanceof Knot ||
+            (first instanceof Stitch &&
+              !(topLevelContent.at(-1) instanceof Knot));
+          if (declaresTopLevelFlow) {
+            currentRun = undefined;
+            const reusedFlow = tryReuseFlowRun(compiledBlock, chunkIdx);
+            if (reusedFlow) {
+              topLevelFlowBaseObjs.push(reusedFlow);
+              topLevelContent.push(reusedFlow as Knot | Stitch);
+            }
+          }
+        }
+        if (reuseSkipBlocks.has(compiledBlock)) {
+          // This chunk feeds a REUSED flow: keep its cached runtime subtree
+          // intact (skipping ResetRuntime IS the reuse) and skip re-assembly —
+          // the constructed flow already holds this chunk's parsed content by
+          // identity. Only re-stamp source positions if the chunk moved.
+          if (this._chunkStampOffset.get(compiledBlock) !== lineNumberOffset) {
+            restampContent(content, lineNumberOffset);
+          }
+          this._chunkStampOffset.set(compiledBlock, lineNumberOffset);
+        } else {
         remapContent(content, lineNumberOffset);
+        this._chunkStampOffset.set(compiledBlock, lineNumberOffset);
         const flow = content[0];
         if (flow) {
           if (flow instanceof Knot) {
@@ -1111,6 +1535,8 @@ export class SparkdownCompiler {
             }
             topLevelFlowBaseObjs.push(knot);
             topLevelContent.push(knot);
+            currentRun = { flow: knot, contentChunks: [compiledBlock] };
+            this._nextFlowRuns?.set(compiledBlock, currentRun);
           } else if (flow instanceof Stitch) {
             const rootWeave = new Weave([]);
             const stitch = new Stitch(
@@ -1137,14 +1563,18 @@ export class SparkdownCompiler {
                 last.content.pop();
               }
               last.AddContent(stitch);
+              currentRun?.contentChunks.push(compiledBlock);
             } else {
               topLevelFlowBaseObjs.push(stitch);
               topLevelContent.push(stitch);
+              currentRun = { flow: stitch, contentChunks: [compiledBlock] };
+              this._nextFlowRuns?.set(compiledBlock, currentRun);
             }
           } else if (flow instanceof ExternalDeclaration) {
             const weave = new Weave([flow]);
             topLevelWeaveObjs.push(weave);
             topLevelContent.push(weave);
+            currentRun = undefined;
           } else if (flow instanceof Weave) {
             // This chunk's body weave is about to be UNWRAPPED — its children
             // are re-parented directly under the closest existing weave (e.g.
@@ -1201,12 +1631,15 @@ export class SparkdownCompiler {
                 closestWeave.content.pop();
               }
               closestWeave.AddContent(flowContent);
+              currentRun?.contentChunks.push(compiledBlock);
             } else {
               const weave = new Weave(flowContent);
               topLevelWeaveObjs.push(weave);
               topLevelContent.push(weave);
+              currentRun = undefined;
             }
           }
+        }
         }
       }
       if (context) {
@@ -1295,7 +1728,6 @@ export class SparkdownCompiler {
           state.defaultDefinitions[type] ??= struct;
         }
       }
-      cur.next();
     }
 
     // Scene/`end` (and branch) pairing validation. This is a CROSS-CHUNK
@@ -1389,7 +1821,27 @@ export class SparkdownCompiler {
   // and all of its references share the exact same string and are emitted within
   // the same chunk, so a uniform string→string remap suffices (no need to link
   // references back to definitions).
-  protected canonicalizeSyntheticFlowNames(root: ParsedObject): void {
+  // Recursively clear cached runtime objects under a constructed flow so the
+  // next `ExportRuntime` regenerates it from its (intact) parsed content —
+  // used to DEMOTE a flow whose committed reuse turned out to be invalid
+  // (late-discovered global change, synthetic rename in its subtree).
+  protected resetSubtreeRuntime(node: ParsedObject): void {
+    node.ResetRuntime();
+    const identifier = (node as { identifier?: unknown }).identifier;
+    if (identifier instanceof Identifier) {
+      identifier.ResetRuntime();
+    }
+    const content = node.content;
+    if (content) {
+      for (const c of content) {
+        this.resetSubtreeRuntime(c);
+      }
+    }
+  }
+
+  protected canonicalizeSyntheticFlowNames(
+    root: ParsedObject,
+  ): Set<ParsedObject> | undefined {
     // Every offset-derived synthetic family minted in the lowerers — PLUS the
     // canonical `__synth_<n>` form this pass itself produces. The pass mutates
     // the parsed IR in place and the incremental pipeline carries those nodes
@@ -1411,7 +1863,7 @@ export class SparkdownCompiler {
     // e.g. `identifier` and a `pathIdentifiers` entry) so each object is
     // rewritten exactly once — rewriting twice could CHAIN through the remap
     // now that canonical `__synth_<n>` names are themselves remappable.
-    const matchedIds: Identifier[] = [];
+    const matchedIds: Array<{ id: Identifier; owner: ParsedObject }> = [];
     const seenIds = new Set<Identifier>();
     const matchedStrings: Array<{ node: any; field: string }> = [];
     const flowsToRekey: FlowBase[] = [];
@@ -1426,12 +1878,12 @@ export class SparkdownCompiler {
         }
       }
     };
-    const considerId = (id: Identifier) => {
+    const considerId = (id: Identifier, owner: ParsedObject) => {
       const name = id.name;
       if (name && SYNTH.test(name) && !seenIds.has(id)) {
         seenIds.add(id);
         considerName(name);
-        matchedIds.push(id);
+        matchedIds.push({ id, owner });
       }
     };
     // A few nodes hold a synthetic name as a PLAIN STRING (not an Identifier) and
@@ -1470,11 +1922,11 @@ export class SparkdownCompiler {
       for (const f of IDENTIFIER_FIELDS) {
         const val = (node as any)[f];
         if (val instanceof Identifier) {
-          considerId(val);
+          considerId(val, node);
         } else if (Array.isArray(val)) {
           for (const el of val) {
             if (el instanceof Identifier) {
-              considerId(el);
+              considerId(el, node);
             }
           }
         }
@@ -1498,15 +1950,30 @@ export class SparkdownCompiler {
     };
     collect(root);
     if (!changed) {
-      return;
+      return undefined;
     }
 
     // Rewrite phase: only the recorded matches, then re-key each FlowBase's
     // `_subFlowsByName` index (built from the pre-rename identifiers at
-    // lowering time) after all names are final.
-    for (const id of matchedIds) {
+    // lowering time) after all names are final. Every node whose name
+    // actually CHANGED marks its enclosing top-level flow — the caller uses
+    // that to demote reused flows and lapse stale serialized-JSON entries.
+    const renamedTopLevelFlows = new Set<ParsedObject>();
+    const markRenamed = (owner: ParsedObject) => {
+      let n: ParsedObject | null = owner;
+      while (n && n.parent && !(n.parent instanceof Story)) {
+        n = n.parent;
+      }
+      if (n && n.parent instanceof Story) {
+        renamedTopLevelFlows.add(n);
+      }
+    };
+    for (const { id, owner } of matchedIds) {
       const next = id.name ? remap.get(id.name) : undefined;
       if (next) {
+        if (next !== id.name) {
+          markRenamed(owner);
+        }
         id.name = next;
       }
     }
@@ -1514,6 +1981,9 @@ export class SparkdownCompiler {
       const v = node[field];
       const next = typeof v === "string" ? remap.get(v) : undefined;
       if (next) {
+        if (next !== v) {
+          markRenamed(node);
+        }
         node[field] = next;
       }
     }
@@ -1527,6 +1997,7 @@ export class SparkdownCompiler {
       }
       flow._subFlowsByName = next;
     }
+    return renamedTopLevelFlows;
   }
 
   populateLocations(

--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -229,6 +229,16 @@ export class SparkdownCompiler {
   // generation, which would silently drop the diagnostic — such flows are
   // barred from reuse and rebuilt so the diagnostic re-emits).
   protected _flowsWithGenDiagnostics = new WeakSet<object>();
+  // Signature (arity + per-parameter flags) of every named flow last compile.
+  // A CALL SITE's bytecode depends on its CALLEE's parameter list — a trailing
+  // `...` makes the caller emit a `PackTuple` to fill the callee's varargs
+  // slot (see `Divert.GenerateRuntimeObject`) — and that is baked in at the
+  // CALLER's generation time. So editing a callee's signature must invalidate
+  // reuse of every flow that might call it, even though the caller's own
+  // chunks are untouched; otherwise the caller keeps argument-push bytecode
+  // for the old signature and the callee pops a different number of values,
+  // silently and with no diagnostic.
+  protected _prevFlowSignatures?: Map<string, string>;
   // Per-file identity sequence of ROOT-REGION chunks (loose content before
   // the first flow, externals, post-external loose content, include/run
   // sites). Any change there can shift consts/globals whose values were
@@ -512,6 +522,9 @@ export class SparkdownCompiler {
     this._filesEpoch++;
     this.files.remove(params);
     const file = params.file;
+    // Drop the root-region record for this file — it strongly references that
+    // file's chunk IR, and nothing else prunes this map.
+    this._lastRootBlocksByUri?.delete(file.uri);
     const removed = this.documents.remove({ textDocument: { uri: file.uri } });
     this._events[RemovedCompilerFileMessage.method].forEach((l) => {
       l?.({ textDocument: { uri: file.uri } });
@@ -763,10 +776,34 @@ export class SparkdownCompiler {
       // carried-forward chunk re-emits the same diagnostics a cold compile
       // would, without a per-compile tree walk.)
       //
+      // A callee's signature is baked into its CALLERS' bytecode at their
+      // generation time, so a signature change invalidates reuse of flows
+      // whose own chunks are untouched (see `_prevFlowSignatures`). The
+      // current signatures aren't known until assembly finishes, so this is
+      // a post-hoc check that feeds the same demotion path as a
+      // late-discovered global change.
+      const flowSignatures = this.collectFlowSignatures(parsedStory);
+      if (this._prevFlowSignatures && !this._flowReuseDisabled) {
+        const prev = this._prevFlowSignatures;
+        let signaturesChanged = flowSignatures.size !== prev.size;
+        if (!signaturesChanged) {
+          for (const [name, sig] of flowSignatures) {
+            if (prev.get(name) !== sig) {
+              signaturesChanged = true;
+              break;
+            }
+          }
+        }
+        if (signaturesChanged) {
+          this._flowReuseDisabled = true;
+        }
+      }
+      this._prevFlowSignatures = flowSignatures;
       // Late-discovered global change (e.g. a mid-file `run` whose .luau
-      // source changed re-lowered its virtual file's root region): demote any
-      // reuse already committed before the discovery so this compile
-      // regenerates those flows from their (intact) parsed content.
+      // source changed re-lowered its virtual file's root region), or a
+      // callee-signature change discovered just above: demote any reuse
+      // already committed before the discovery so this compile regenerates
+      // those flows from their (intact) parsed content.
       if (this._flowReuseDisabled && this._reusedFlowsThisCompile?.size) {
         for (const flow of this._reusedFlowsThisCompile) {
           this.resetSubtreeRuntime(flow);
@@ -1821,6 +1858,32 @@ export class SparkdownCompiler {
   // and all of its references share the exact same string and are emitted within
   // the same chunk, so a uniform string→string remap suffices (no need to link
   // references back to definitions).
+  // Call-relevant signature of every named flow, keyed by name. Walks the
+  // flow tree only (each flow's named sub-flows), never the full parsed tree,
+  // so this is O(flows) — negligible next to a compile. See
+  // `_prevFlowSignatures` for why call sites depend on it.
+  protected collectFlowSignatures(
+    flow: FlowBase,
+    into: Map<string, string> = new Map(),
+  ): Map<string, string> {
+    for (const sub of flow.subFlowsByName.values()) {
+      const name = sub.identifier?.name;
+      if (name) {
+        const args = (sub.args ?? [])
+          .map(
+            (a) =>
+              `${a.isVararg ? "*" : ""}${a.isByReference ? "&" : ""}${
+                a.isDivertTarget ? ">" : ""
+              }`,
+          )
+          .join(",");
+        into.set(name, `${sub.isFunction ? "fn" : "knot"}(${args})`);
+      }
+      this.collectFlowSignatures(sub, into);
+    }
+    return into;
+  }
+
   // Recursively clear cached runtime objects under a constructed flow so the
   // next `ExportRuntime` regenerates it from its (intact) parsed content —
   // used to DEMOTE a flow whose committed reuse turned out to be invalid

--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Divert/Divert.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Divert/Divert.ts
@@ -407,6 +407,18 @@ export class Divert extends ParsedObject {
     let isBuiltIn: boolean = false;
     let isExternal: boolean = false;
 
+    // NOTE for incremental reuse: the external branch below is a one-way door
+    // like the target paths above (it sets `isExternal`/`externalArgs` and
+    // flips `pushesToStack` to false), but it deliberately gets NO reset here.
+    // A correct reset would have to restore `pushesToStack` to its
+    // GENERATION-time value (set true for calls/tunnels at
+    // `GenerateRuntimeObject`), which resolution cannot recompute — and a
+    // partial reset would half-decay the divert, which is worse than none.
+    // Instead, adding, removing, renaming, or re-arity-ing an `EXTERNAL` is a
+    // structural change that disables flow reuse for that compile (see the
+    // root-region descriptor in `SparkdownCompiler.parseIncrementally`), so a
+    // reused divert can never outlive its external declaration.
+
     if (!this.target) {
       throw new Error();
     } else if (this.target.numberOfComponents === 1) {

--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Divert/Divert.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Divert/Divert.ts
@@ -12,6 +12,7 @@ import { ClosestFlowBase } from "../Flow/ClosestFlowBase";
 import { FlowBase } from "../Flow/FlowBase";
 import { FunctionCall } from "../FunctionCall";
 import { Identifier } from "../Identifier";
+import { currentCompileEpoch } from "../CompileEpoch";
 import { ParsedObject } from "../Object";
 import { Path } from "../Path";
 import { Story } from "../Story";
@@ -23,7 +24,32 @@ export class Divert extends ParsedObject {
 
   public readonly pathIdentifiers: Identifier[] | null = null;
   public readonly target: Path | null = null;
-  public targetContent: ParsedObject | null = null;
+
+  // Cross-node cache of the resolved target PARSED node, epoch-guarded: a
+  // reused (not regenerated) divert would otherwise keep pointing at a STALE
+  // node when its target flow was rebuilt or deleted — validating arity
+  // against the old signature and skipping "target not found". A stale epoch
+  // reads as `null`, which makes `ResolveTargetContent`'s short-circuit
+  // re-resolve once per compile. Within one compile the behavior is
+  // unchanged (generation and resolve share the epoch).
+  private _targetContent: ParsedObject | null = null;
+  private _targetContentEpoch: number = -1;
+  // Epoch of the last `runtimeDivert.variableDivertName` assignment (variable
+  // targets and the unresolved-call promotion below). A reused divert keeps
+  // its runtime object across compiles, so a stale variable-divert must be
+  // cleared and re-derived — otherwise `-> foo` promoted while `foo` was
+  // missing would never resolve back to the knot once `foo` exists again.
+  private _variableDivertEpoch: number = -1;
+  get targetContent(): ParsedObject | null {
+    return this._targetContentEpoch === currentCompileEpoch()
+      ? this._targetContent
+      : null;
+  }
+  set targetContent(value: ParsedObject | null) {
+    this._targetContent = value;
+    this._targetContentEpoch = value === null ? -1 : currentCompileEpoch();
+  }
+
   private _runtimeDivert: RuntimeDivert | null = null;
   get runtimeDivert(): RuntimeDivert {
     if (!this._runtimeDivert) {
@@ -293,6 +319,7 @@ export class Divert extends ParsedObject {
             }
 
             this.runtimeDivert.variableDivertName = variableTargetName;
+            this._variableDivertEpoch = currentCompileEpoch();
             return;
           }
         }
@@ -313,6 +340,16 @@ export class Divert extends ParsedObject {
       throw new Error();
     }
 
+    // A variable-divert derived in a PREVIOUS compile (reused runtime object)
+    // must be re-derived against the current tree — see
+    // `_variableDivertEpoch`. Clearing it re-opens both retry paths below.
+    if (
+      this.runtimeDivert.variableDivertName != null &&
+      this._variableDivertEpoch !== currentCompileEpoch()
+    ) {
+      this.runtimeDivert.variableDivertName = null;
+    }
+
     // Retry variable-target resolution. `ResolveTargetContent` ran
     // early during `GenerateRuntimeObject` so the runtime tree could
     // be built; at that point Luau auto-globals (`Y = function...`)
@@ -331,6 +368,13 @@ export class Divert extends ParsedObject {
 
     if (this.targetContent) {
       this.runtimeDivert.targetPath = this.targetContent.runtimePath;
+    } else if (this.runtimeDivert.variableDivertName == null) {
+      // Re-resolution found no target this compile. A REUSED runtime divert
+      // may still hold the path it resolved in a previous compile (e.g. its
+      // target flow was since deleted) — restore the fresh-generation state
+      // so serialization and diagnostics match a cold compile. (Externals
+      // re-derive their path in the external branch below.)
+      this.runtimeDivert.targetPath = null;
     }
 
     // Resolve children (the arguments)
@@ -431,6 +475,7 @@ export class Divert extends ParsedObject {
         this.target.firstComponent
       ) {
         this.runtimeDivert.variableDivertName = this.target.firstComponent;
+        this._variableDivertEpoch = currentCompileEpoch();
         return;
       }
       this.Error(

--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Divert/DivertTarget.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Divert/DivertTarget.ts
@@ -174,9 +174,21 @@ export class DivertTarget extends Expression {
     }
 
     // Main resolve
-    this.runtimeDivert.targetPath &&
-      (this.runtimeDivertTargetValue.targetPath =
-        this.runtimeDivert.targetPath);
+    if (this.runtimeDivert.targetPath) {
+      this.runtimeDivertTargetValue.targetPath = this.runtimeDivert.targetPath;
+    } else {
+      // Re-resolution found no target this compile. A REUSED runtime value
+      // survives generation across compiles, so it would otherwise keep the
+      // path it resolved when the target still existed — restore the
+      // fresh-generation state instead (mirrors the same repair in
+      // `Divert.ResolveReferences`). Assign the backing field: the
+      // `targetPath` setter takes a non-null Path, and its getter throws on
+      // null, which is exactly the "unresolved" state a cold compile has.
+      // Defense-in-depth today: deleting a top-level flow also changes the
+      // flow-name map, which disables reuse for that compile. This becomes
+      // load-bearing as soon as those guards are narrowed.
+      this.runtimeDivertTargetValue.value = null;
+    }
 
     // Tell hard coded (yet variable) divert targets that they also need to be counted
     // TODO: Only detect DivertTargets that are values rather than being used directly for

--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Object.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Object.ts
@@ -258,6 +258,12 @@ export abstract class ParsedObject {
     message: string,
     source: ParsedObject | Identifier | DebugMetadata | null = null,
     isWarning: boolean = false,
+    // The node that RAISED this diagnostic, forwarded unchanged as the error
+    // bubbles up to the Story. `source` is chosen for dedup//reporting and is
+    // often an `Identifier` or raw `DebugMetadata` — neither has a parent
+    // chain — so it can't be used to attribute the diagnostic to a flow. The
+    // raiser always can. See `Story.Error`'s generation-phase attribution.
+    raiser: ParsedObject = this,
   ): void {
     if (source === null) {
       source = this;
@@ -282,7 +288,7 @@ export abstract class ParsedObject {
     }
 
     if (this.parent) {
-      this.parent.Error(message, source, isWarning);
+      this.parent.Error(message, source, isWarning, raiser);
     } else {
       throw new Error(`No parent object to send error to: ${message}`);
     }

--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Story.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Story.ts
@@ -584,6 +584,9 @@ export class Story extends FlowBase {
     message: string,
     source: ParsedObject | DebugMetadata | null | undefined,
     isWarning: boolean | null | undefined,
+    // Node that raised the diagnostic (see `ParsedObject.Error`). Defaults to
+    // `source` for the direct callers that don't bubble through a parent.
+    raiser?: ParsedObject,
   ) => {
     let errorType: ErrorType = isWarning ? ErrorType.Warning : ErrorType.Error;
 
@@ -595,8 +598,15 @@ export class Story extends FlowBase {
     // chain) — then the diagnostic can't be attributed and the compiler must
     // assume the worst.
     if (this._generationPhase) {
+      // Prefer the raiser: `source` is frequently an `Identifier` or raw
+      // `DebugMetadata` (chosen for dedup/reporting), and neither carries a
+      // parent chain to attribute from.
       let node: ParsedObject | null =
-        source instanceof DebugMetadata ? null : (source ?? null);
+        raiser ??
+        (source instanceof DebugMetadata ? null : (source ?? null));
+      if (!(node instanceof ParsedObject)) {
+        node = null;
+      }
       while (node && node.parent && !(node.parent instanceof Story)) {
         node = node.parent;
       }

--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Story.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Story.ts
@@ -69,9 +69,24 @@ export class Story extends FlowBase {
   private _errorHandler: ErrorHandler | null = null;
   private _hadError: boolean = false;
   private _hadWarning: boolean = false;
-  private _dontFlattenContainers: Set<RuntimeContainer> = new Set();
   private _listDefs: Map<string, ListDefinition> = new Map();
   private _structDefs: Map<string, StructDefinition> = new Map();
+
+  // True while `ExportRuntime` is materializing runtime objects (generation),
+  // false during the later `ResolveReferences` pass. Diagnostics raised during
+  // GENERATION are attributed to their enclosing top-level flow below — the
+  // incremental compiler skips generation for unchanged flows, which would
+  // silently drop such a diagnostic on the next compile, so any flow that
+  // produced one is barred from reuse (resolve-time diagnostics re-emit
+  // naturally because resolution always runs over the full tree).
+  private _generationPhase: boolean = false;
+
+  // Top-level flows that raised a diagnostic during generation this export,
+  // plus a flag for diagnostics that couldn't be attributed to one (no parsed
+  // source or no top-level ancestor) — the compiler reacts by disabling flow
+  // reuse entirely for the next compile.
+  public flowsWithGenerationDiagnostics: Set<ParsedObject> = new Set();
+  public hadUnattributableGenerationDiagnostic: boolean = false;
 
   get flowLevel(): FlowLevel {
     return FlowLevel.Story;
@@ -281,6 +296,14 @@ export class Story extends FlowBase {
     // errors when name resolution failed.)
     this.ResolveWeavePointNaming();
 
+    // Everything from here until `ResolveReferences` is GENERATION — see
+    // `_generationPhase`. Diagnostics raised in this window are attributed to
+    // their top-level flow so the incremental compiler can bar that flow from
+    // reuse (reuse skips generation, which would drop the diagnostic).
+    this._generationPhase = true;
+    this.flowsWithGenerationDiagnostics = new Set();
+    this.hadUnattributableGenerationDiagnostic = false;
+
     // Get default implementation of runtimeObject, which calls ContainerBase's generation method
     const rootContainer = this.runtimeObject as RuntimeContainer;
 
@@ -390,6 +413,9 @@ export class Story extends FlowBase {
     );
 
     this.runtimeObject = runtimeStory;
+
+    // Generation is complete (FlattenContainersIn emits no diagnostics).
+    this._generationPhase = false;
 
     // Optimisation step - inline containers that can be
     this.FlattenContainersIn(rootContainer);
@@ -501,6 +527,23 @@ export class Story extends FlowBase {
     }
 
     for (const innerContainer of innerContainers) {
+      // Count-flag reconcile for incremental container reuse. This walk runs
+      // after ALL generation and before `ResolveReferences`, and visits every
+      // container in the tree exactly once, so it doubles as the reconcile
+      // point: a container seen for the FIRST time (fresh this compile) has
+      // flags that are purely generation-derived — snapshot them as its
+      // intrinsic state. A REUSED container additionally carries last
+      // compile's resolve-time cross-flow sets — restore it to intrinsic so
+      // this compile's resolve pass re-derives exactly the sets that still
+      // exist (a deleted remote read-count decays instead of sticking).
+      if (innerContainer._intrinsicVisits === undefined) {
+        innerContainer._intrinsicVisits = innerContainer.visitsShouldBeCounted;
+        innerContainer._intrinsicTurns = innerContainer.turnIndexShouldBeCounted;
+      } else {
+        innerContainer.visitsShouldBeCounted = innerContainer._intrinsicVisits;
+        innerContainer.turnIndexShouldBeCounted =
+          innerContainer._intrinsicTurns!;
+      }
       this.TryFlattenContainer(innerContainer);
       this.FlattenContainersIn(innerContainer);
     }
@@ -510,7 +553,7 @@ export class Story extends FlowBase {
     if (
       (container.namedContent && container.namedContent.size > 0) ||
       container.hasValidName ||
-      this._dontFlattenContainers.has(container)
+      container._dontFlatten
     ) {
       return;
     }
@@ -546,6 +589,23 @@ export class Story extends FlowBase {
 
     this._hadError = errorType === ErrorType.Error;
     this._hadWarning = errorType === ErrorType.Warning;
+
+    // Attribute generation-time diagnostics to their top-level flow (see
+    // `_generationPhase`). `source` may be raw DebugMetadata (no parent
+    // chain) — then the diagnostic can't be attributed and the compiler must
+    // assume the worst.
+    if (this._generationPhase) {
+      let node: ParsedObject | null =
+        source instanceof DebugMetadata ? null : (source ?? null);
+      while (node && node.parent && !(node.parent instanceof Story)) {
+        node = node.parent;
+      }
+      if (node && node.parent instanceof Story) {
+        this.flowsWithGenerationDiagnostics.add(node);
+      } else {
+        this.hadUnattributableGenerationDiagnostic = true;
+      }
+    }
 
     if (this._errorHandler !== null) {
       const debugMetadata =
@@ -613,7 +673,10 @@ export class Story extends FlowBase {
   public readonly DontFlattenContainer = (
     container: RuntimeContainer,
   ): void => {
-    this._dontFlattenContainers.add(container);
+    // Marked on the container itself (not a per-compile Set on this Story) so
+    // the protection survives container reuse across compiles — a reused
+    // flow's generation is skipped, so it gets no chance to re-register here.
+    container._dontFlatten = true;
   };
 
   public readonly NameConflictError = (

--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/TunnelOnwards.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/TunnelOnwards.ts
@@ -104,6 +104,11 @@ export class TunnelOnwards extends ParsedObject {
     if (this.divertAfter && this.divertAfter.targetContent) {
       this._overrideDivertTarget!.targetPath =
         this.divertAfter.targetContent.runtimePath;
+    } else if (this._overrideDivertTarget) {
+      // No target this compile: a REUSED override value would otherwise keep
+      // last compile's path. Restore fresh-generation state — see the same
+      // repair in `DivertTarget`/`Divert.ResolveReferences`.
+      this._overrideDivertTarget.value = null;
     }
   }
 

--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Variable/VariableReference.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Variable/VariableReference.ts
@@ -86,6 +86,17 @@ export class VariableReference extends Expression {
   public override ResolveReferences(context: Story): void {
     super.ResolveReferences(context);
 
+    // Read-count conversion below (`name = null` + `pathForCount = ...`) is a
+    // one-way door on the runtime object. Under incremental container reuse
+    // the SAME runtime object is re-resolved on later compiles — restore it
+    // to its generated form first so the conversion is re-derived from the
+    // CURRENT tree (a deleted target flow decays back to a plain variable
+    // reference exactly like a cold compile).
+    if (this._runtimeVarRef && this._runtimeVarRef.name === null) {
+      this._runtimeVarRef.name = this.name;
+      this._runtimeVarRef.pathForCount = null;
+    }
+
     // Work is already done if it's a constant or list item reference
     if (this.isConstantReference || this.isListItemReference) {
       return;

--- a/packages/sparkdown/src/inkjs/engine/Container.ts
+++ b/packages/sparkdown/src/inkjs/engine/Container.ts
@@ -19,6 +19,28 @@ export class Container extends InkObject implements INamedContent {
   public turnIndexShouldBeCounted: boolean = false;
   public countingAtStartOnly: boolean = false;
 
+  // Compiler-only bookkeeping for incremental ExportRuntime (never
+  // serialized, never read by the runtime): containers of unchanged flows are
+  // REUSED across compiles instead of regenerated, so state that a fresh
+  // compile would rebuild from scratch must be reconstructible on reuse.
+  //
+  // `_dontFlatten`: `Parsed.Story.DontFlattenContainer` protection. Lives on
+  // the container (not a per-compile Set on the parsed Story) so a reused
+  // container whose generation was skipped keeps its protection — otherwise
+  // `TryFlattenContainer` would splice sequence/conditional branch containers
+  // it must not.
+  //
+  // `_intrinsicVisits`/`_intrinsicTurns`: snapshot of the count flags as set
+  // at GENERATION time (self-flow: Gather/Choice/Sequence/countAllVisits).
+  // Resolve-time cross-flow sets (DivertTarget/VariableReference/FunctionCall
+  // targeting this container from elsewhere) are re-derived every compile, so
+  // before each `ResolveReferences` pass a reused container is restored to
+  // this intrinsic state — otherwise a deleted remote read-count would leave
+  // a stale `#f` flag behind forever.
+  public _dontFlatten?: boolean;
+  public _intrinsicVisits?: boolean;
+  public _intrinsicTurns?: boolean;
+
   public _pathToFirstLeafContent: Path | null = null;
 
   get hasValidName() {

--- a/packages/sparkdown/src/tests/compiler/incrementalCalleeSignature.test.ts
+++ b/packages/sparkdown/src/tests/compiler/incrementalCalleeSignature.test.ts
@@ -1,0 +1,235 @@
+// Callee-signature reuse oracle (regression for a bug the general
+// incremental-vs-cold oracles CANNOT generate).
+//
+// A call site's bytecode is derived from its CALLEE's parameter list at the
+// CALLER's generation time: a trailing `...` makes the caller emit a
+// `PackTuple` to fill the callee's varargs slot (Divert.GenerateRuntimeObject).
+// Incremental ExportRuntime reuses a flow whose OWN chunks are unchanged — so
+// without a guard, editing a callee's signature leaves every reused caller
+// emitting argument pushes for the old signature. The callee then pops a
+// different number of values than the caller pushed, silently and with no
+// diagnostic.
+//
+// `incrementalEquivalence`'s fixture has a single non-variadic function and
+// never edits a parameter list, and the cumulative fuzz alphabet contains
+// neither "..." nor "," — so neither oracle can construct this. Hence a
+// dedicated fixture: no front matter (zero root blocks) so the root-region
+// guard stays quiet and flow reuse genuinely engages on the edit under test.
+import "../../inkjs/engine/Container";
+import { describe, it, expect } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+
+const URI = "inmemory:///main.sd";
+
+function pick(p: any) {
+  return {
+    compiled: p.compiled,
+    diagnostics: p.diagnostics,
+  };
+}
+
+function stable(value: unknown): string {
+  const seen = new WeakSet();
+  const walk = (v: any): any => {
+    if (v && typeof v === "object") {
+      if (seen.has(v)) return "[Circular]";
+      seen.add(v);
+      if (Array.isArray(v)) return v.map(walk);
+      const out: Record<string, any> = {};
+      for (const k of Object.keys(v).sort()) out[k] = walk(v[k]);
+      return out;
+    }
+    return v;
+  };
+  return JSON.stringify(walk(value));
+}
+
+function coldCompile(text: string) {
+  const c = new SparkdownCompiler();
+  c.configure({
+    files: [
+      {
+        uri: URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text,
+        version: 1,
+        languageId: "sparkdown",
+      },
+    ],
+  });
+  return pick(c.compile({ textDocument: { uri: URI } }).program);
+}
+
+function posAt(text: string, offset: number) {
+  let line = 0;
+  let lineStart = 0;
+  for (let i = 0; i < offset; i++) {
+    if (text[i] === "\n") {
+      line++;
+      lineStart = i + 1;
+    }
+  }
+  return { line, character: offset - lineStart };
+}
+
+const quiet = <T>(fn: () => T): T => {
+  const w = console.warn;
+  const e = console.error;
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    return fn();
+  } finally {
+    console.warn = w;
+    console.error = e;
+  }
+};
+
+function runScenario(
+  name: string,
+  base: string,
+  steps: { find: string; replace: string }[],
+) {
+  const log: string[] = [];
+  let text = base;
+  const incr = new SparkdownCompiler();
+  incr.configure({
+    files: [
+      {
+        uri: URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text,
+        version: 1,
+        languageId: "sparkdown",
+      },
+    ],
+  });
+  incr.compile({ textDocument: { uri: URI } });
+  let version = 1;
+  for (const [i, step] of steps.entries()) {
+    const offset = text.indexOf(step.find);
+    if (offset < 0) throw new Error(`${name}: not found: ${step.find}`);
+    const start = posAt(text, offset);
+    const end = posAt(text, offset + step.find.length);
+    version += 1;
+    incr.updateDocument({
+      textDocument: { uri: URI, version },
+      contentChanges: [{ range: { start, end }, text: step.replace }],
+    });
+    text =
+      text.slice(0, offset) +
+      step.replace +
+      text.slice(offset + step.find.length);
+    const prog = incr.compile({ textDocument: { uri: URI } }).program;
+    const reused = [...((incr as any)._reusedFlowsThisCompile ?? [])].map(
+      (f: any) => f?.identifier?.name,
+    );
+    const a = stable(pick(prog));
+    const b = stable(coldCompile(text));
+    const tag = `${name} step${i + 1} reused=[${reused.join(",")}] disabled=${(incr as any)._flowReuseDisabled}`;
+    if (a !== b) {
+      let k = 0;
+      while (k < a.length && k < b.length && a[k] === b[k]) k++;
+      log.push(
+        `${tag} DIVERGED at ${k}\n  INCR: ${a.slice(Math.max(0, k - 200), k + 400)}\n  COLD: ${b.slice(Math.max(0, k - 200), k + 400)}`,
+      );
+    } else {
+      log.push(`${tag} ok`);
+    }
+  }
+  return log;
+}
+
+// No front matter at all -> zero root blocks -> stable reuse.
+function doc(fnDecl: string, callSite: string) {
+  return [
+    fnDecl,
+    "  return 1",
+    "",
+    "scene alpha",
+    ":",
+    "  Alpha action.",
+    callSite,
+    "-> DONE",
+    "end",
+    "",
+    "scene beta",
+    ":",
+    "  Beta action",
+    "-> DONE",
+    "end",
+    "",
+  ].join("\n");
+}
+
+const WARM = (n: number) => ({
+  find: `Beta action${"!".repeat(n)}`,
+  replace: `Beta action${"!".repeat(n + 1)}`,
+});
+
+describe("incremental callee-signature reuse", () => {
+  it("callee arity change while caller flow is reused", () => {
+    const out = quiet(() =>
+      runScenario("arity", doc("function addup(a):", "& local r = addup(2)"), [
+        WARM(0),
+        WARM(1),
+        { find: "function addup(a):", replace: "function addup(a, b):" },
+        WARM(2),
+        WARM(3),
+      ]),
+    );
+    console.info(out.join("\n"));
+    expect(out.filter((s) => s.includes("DIVERGED"))).toEqual([]);
+  });
+
+  it("callee becomes variadic while caller flow is reused", () => {
+    const out = quiet(() =>
+      runScenario("vararg", doc("function addup(a):", "& local r = addup(2)"), [
+        WARM(0),
+        WARM(1),
+        { find: "function addup(a):", replace: "function addup(a, ...):" },
+        WARM(2),
+        WARM(3),
+      ]),
+    );
+    console.info(out.join("\n"));
+    expect(out.filter((s) => s.includes("DIVERGED"))).toEqual([]);
+  });
+
+  it("callee stops being variadic while caller flow is reused", () => {
+    const out = quiet(() =>
+      runScenario(
+        "unvararg",
+        doc("function addup(a, ...):", "& local r = addup(2, 3, 4)"),
+        [
+          WARM(0),
+          WARM(1),
+          {
+            find: "function addup(a, ...):",
+            replace: "function addup(a, b, c):",
+          },
+          WARM(2),
+          WARM(3),
+        ],
+      ),
+    );
+    console.info(out.join("\n"));
+    expect(out.filter((s) => s.includes("DIVERGED"))).toEqual([]);
+  });
+
+  it("baseline: plain edits reuse", () => {
+    const out = quiet(() =>
+      runScenario("baseline", doc("function addup(a):", "& local r = addup(2)"), [
+        WARM(0),
+        WARM(1),
+        WARM(2),
+      ]),
+    );
+    console.info(out.join("\n"));
+    expect(out.filter((s) => s.includes("DIVERGED"))).toEqual([]);
+  });
+});

--- a/packages/sparkdown/src/tests/compiler/incrementalConstCensus.test.ts
+++ b/packages/sparkdown/src/tests/compiler/incrementalConstCensus.test.ts
@@ -1,0 +1,146 @@
+// Constant-census oracle for incremental ExportRuntime.
+//
+// A constant reference is INLINED: generation copies the constant's whole
+// expression bytecode into every referencing flow. Flow reuse skips
+// generation, so any change to the set of declared constants must invalidate
+// reuse or a reused flow keeps last compile's inlined value.
+//
+// Changing or adding a constant is caught by the per-chunk scan (its chunk is
+// new AND contains a ConstantDeclaration). DELETING one is not: the constant
+// then appears in no chunk at all. This pins the census comparison that
+// covers deletion — the case the root-region identity guard used to catch
+// incidentally, before that guard was narrowed to structural descriptors.
+import "../../inkjs/engine/Container";
+import { describe, it, expect } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+const URI = "inmemory:///main.sd";
+const pick = (p: any) => ({ compiled: p.compiled, diagnostics: p.diagnostics });
+const stable = (v: any): string => {
+  const seen = new WeakSet();
+  const walk = (x: any): any => {
+    if (x && typeof x === "object") {
+      if (seen.has(x)) return "[C]";
+      seen.add(x);
+      if (Array.isArray(x)) return x.map(walk);
+      const o: any = {}; for (const k of Object.keys(x).sort()) o[k] = walk(x[k]); return o;
+    }
+    return x;
+  };
+  return JSON.stringify(walk(v));
+};
+function posAt(t: string, off: number) {
+  let line = 0, ls = 0;
+  for (let i = 0; i < off; i++) if (t[i] === "\n") { line++; ls = i + 1; }
+  return { line, character: off - ls };
+}
+function conf(text: string) {
+  const c = new SparkdownCompiler();
+  c.configure({ files: [{ uri: URI, type: "script", name: "main", ext: "sd", text, version: 1, languageId: "sparkdown" }] } as any);
+  return c;
+}
+function base() {
+  const L: string[] = [];
+  L.push("const LIMIT = 5");
+  L.push("");
+  for (let s = 0; s < 4; s++) {
+    L.push(`scene scene_${s}`);
+    L.push(":");
+    L.push(`  Room ${s} limit is {LIMIT}.`);
+    L.push(`-> scene_${(s + 1) % 4}`);
+    L.push("end");
+    L.push("");
+  }
+  return L.join("\n");
+}
+describe("incremental constant census", () => {
+  it("deleting a const does not leave inlined values in reused flows", () => {
+    const w = console.warn, e = console.error;
+    console.warn = () => {}; console.error = () => {};
+    const log: string[] = [];
+    try {
+      let text = base();
+      const incr = conf(text);
+      incr.compile({ textDocument: { uri: URI } } as any);
+      let version = 1;
+      const steps = [
+        { find: "Room 3 limit", replace: "Room 3 Limit" },
+        { find: "Room 3 Limit", replace: "Room 3 LIMIT" },
+        { find: "const LIMIT = 5\n", replace: "" },   // DELETE the const
+        { find: "Room 3 LIMIT", replace: "Room 3 limit" },
+      ];
+      for (const [i, s] of steps.entries()) {
+        const off = text.indexOf(s.find);
+        expect(off, `find ${s.find}`).toBeGreaterThanOrEqual(0);
+        version++;
+        incr.updateDocument({ textDocument: { uri: URI, version }, contentChanges: [{ range: { start: posAt(text, off), end: posAt(text, off + s.find.length) }, text: s.replace }] } as any);
+        text = text.slice(0, off) + s.replace + text.slice(off + s.find.length);
+        const a = stable(pick((incr.compile({ textDocument: { uri: URI } } as any) as any).program));
+        const b = stable(pick((conf(text).compile({ textDocument: { uri: URI } } as any) as any).program));
+        const reused = (incr as any)._reusedFlowsThisCompile?.size ?? -1;
+        const dis = (incr as any)._flowReuseDisabled;
+        log.push(`step${i + 1} reused=${reused} disabled=${dis} ${a === b ? "ok" : "DIVERGED"}`);
+      }
+    } finally {
+      console.warn = w; console.error = e;
+      (console as any).warn("\n" + log.join("\n") + "\n");
+    }
+    expect(log.filter((l) => l.includes("DIVERGED"))).toEqual([]);
+  });
+});
+
+describe("incremental global-name census", () => {
+  it("a global shadowing a flow name does not leave stale call codegen", () => {
+    const w = console.warn, e = console.error;
+    console.warn = () => {}; console.error = () => {};
+    const log: string[] = [];
+    try {
+      // `addup` is variadic, so a knot-call emits PackTuple while a
+      // variable-target call does not. Declaring a global named `addup`
+      // shadows the flow at GENERATION time (Divert.ResolveTargetContent
+      // consults story.variableDeclarations), flipping every call site.
+      const L: string[] = [];
+      L.push("title: Shadow");
+      L.push("store anchor = 1");
+      L.push("");
+      L.push("function addup(a, ...):");
+      L.push("  return a");
+      L.push("");
+      for (let i = 0; i < 6; i++) {
+        L.push(`scene scene_${i}`);
+        L.push(":");
+        L.push(`  Room ${i}.`);
+        L.push(`& local r${i} = addup(1, 2, 3)`);
+        L.push(`-> scene_${(i + 1) % 6}`);
+        L.push("end");
+        L.push("");
+      }
+      let text = L.join("\n");
+      const incr = conf(text);
+      incr.compile({ textDocument: { uri: URI } } as any);
+      let version = 1;
+      const SHADOW = "store anchor = 1\nstore addup = 0";
+      const steps = [
+        { find: "Room 5.", replace: "Room 5!" },
+        // Shadow the function with a global of the same name...
+        { find: "store anchor = 1", replace: SHADOW },
+        // ...then remove it again: the program is valid, but any flow
+        // regenerated while shadowed must not keep variable-target codegen.
+        { find: SHADOW, replace: "store anchor = 1" },
+        { find: "Room 4.", replace: "Room 4!" },
+      ];
+      for (const [i, s] of steps.entries()) {
+        const off = text.indexOf(s.find);
+        expect(off, `find ${s.find}`).toBeGreaterThanOrEqual(0);
+        version++;
+        incr.updateDocument({ textDocument: { uri: URI, version }, contentChanges: [{ range: { start: posAt(text, off), end: posAt(text, off + s.find.length) }, text: s.replace }] } as any);
+        text = text.slice(0, off) + s.replace + text.slice(off + s.find.length);
+        const a = stable(pick((incr.compile({ textDocument: { uri: URI } } as any) as any).program));
+        const b = stable(pick((conf(text).compile({ textDocument: { uri: URI } } as any) as any).program));
+        log.push(`step${i + 1} ${a === b ? "ok" : "DIVERGED"}`);
+      }
+    } finally {
+      console.warn = w; console.error = e;
+    }
+    expect(log.filter((l) => l.includes("DIVERGED"))).toEqual([]);
+  });
+});

--- a/packages/sparkdown/src/tests/compiler/incrementalEquivalence.test.ts
+++ b/packages/sparkdown/src/tests/compiler/incrementalEquivalence.test.ts
@@ -228,6 +228,114 @@ describe("compiler incremental equivalence", () => {
     }
   });
 
+  it("incremental == cold across reuse-repair sequences (flow-reuse hazards)", () => {
+    // Multi-step sequences targeting the incremental-ExportRuntime failure
+    // modes that only appear when an UNCHANGED (reused) flow's cached runtime
+    // subtree must be repaired by re-resolution:
+    //  - read-count removal: the target flow's `#f` count flag must DECAY on
+    //    its reused container (set-only cross-flow flag reconcile);
+    //  - rename-then-rename-back: a reused flow's divert must drop its stale
+    //    resolved path when the target vanishes AND re-resolve when it
+    //    returns (epoch-guarded targetContent + targetPath restore);
+    //  - a global `store` declared INSIDE a scene registers into the story
+    //    at GENERATION time, so that scene must be disqualified from reuse;
+    //  - an anonymous fn added EARLIER renumbers `__synth_<n>` ordinals baked
+    //    into a LATER unchanged flow at generation (rename demotion).
+    const SCENARIOS: {
+      name: string;
+      steps: { find: string; replace: string }[];
+    }[] = [
+      {
+        name: "remove last read-count reference, then edit elsewhere",
+        steps: [
+          // scene_2 holds the ONLY read-count of scene_3; removing it must
+          // clear scene_3's visit flag even though scene_3 is reused.
+          { find: "read-count {scene_3} here.", replace: "read-count gone." },
+          { find: "Not yet in scene 9.", replace: "Not yet in scene 9!" },
+        ],
+      },
+      {
+        name: "rename a divert target away and back",
+        steps: [
+          { find: "scene scene_4", replace: "scene scene_4x" },
+          { find: "scene scene_4x", replace: "scene scene_4" },
+        ],
+      },
+      {
+        name: "global store declared inside a scene, then edit elsewhere",
+        steps: [
+          {
+            find: "  Action describing room 5 in some detail here.",
+            replace:
+              "  Action describing room 5 in some detail here.\nstore inscene_flag = 7",
+          },
+          { find: "Not yet in scene 10.", replace: "Not yet in scene 10?" },
+        ],
+      },
+      {
+        name: "anonymous fn added earlier renumbers later synthetics",
+        steps: [
+          // Seed a synthetic in a LATE scene first...
+          {
+            find: "  Action describing room 11 in some detail here.",
+            replace:
+              "  Action describing room 11 in some detail here.\n& local f11 = function(x) return x + 1 end",
+          },
+          // ...then add one EARLIER: scene_11 is unchanged (reused) but its
+          // `__synth_<n>` ordinal shifts, so it must be regenerated.
+          {
+            find: "  Action describing room 1 in some detail here.",
+            replace:
+              "  Action describing room 1 in some detail here.\n& local f1 = function(x) return x + 2 end",
+          },
+          { find: "Not yet in scene 12.", replace: "Not yet in scene 12!!" },
+        ],
+      },
+    ];
+    const realWarn = console.warn;
+    const realError = console.error;
+    console.warn = () => {};
+    console.error = () => {};
+    try {
+      for (const scenario of SCENARIOS) {
+        let text = coupledScreenplay();
+        const incr = new SparkdownCompiler();
+        incr.configure({
+          files: [{ uri: URI, type: "script", name: "main", ext: "sd", text, version: 1, languageId: "sparkdown" }],
+        });
+        incr.compile({ textDocument: { uri: URI } });
+        let version = 1;
+        for (const [stepIdx, step] of scenario.steps.entries()) {
+          const offset = text.indexOf(step.find);
+          expect(
+            offset,
+            `${scenario.name}: find "${step.find}" present`,
+          ).toBeGreaterThanOrEqual(0);
+          const start = posAt(text, offset);
+          const end = posAt(text, offset + step.find.length);
+          version += 1;
+          incr.updateDocument({
+            textDocument: { uri: URI, version },
+            contentChanges: [{ range: { start, end }, text: step.replace }],
+          });
+          text =
+            text.slice(0, offset) +
+            step.replace +
+            text.slice(offset + step.find.length);
+          const incrProg = pick(incr.compile({ textDocument: { uri: URI } }).program);
+          const coldProg = coldCompile(text);
+          expect(
+            stable(incrProg),
+            `${scenario.name}: step ${stepIdx + 1}`,
+          ).toBe(stable(coldProg));
+        }
+      }
+    } finally {
+      console.warn = realWarn;
+      console.error = realError;
+    }
+  });
+
   it("incremental == cold location maps when a structural edit changes the flow set", () => {
     // Breaking the FIRST scene's header removes it from the flow set and shifts
     // the document-global `dataLocations` ownership (the first `& trust =`, which

--- a/packages/sparkdown/src/tests/compiler/incrementalEquivalence.test.ts
+++ b/packages/sparkdown/src/tests/compiler/incrementalEquivalence.test.ts
@@ -239,11 +239,13 @@ describe("compiler incremental equivalence", () => {
     //    returns (epoch-guarded targetContent + targetPath restore);
     //  - a global `store` declared INSIDE a scene registers into the story
     //    at GENERATION time, so that scene must be disqualified from reuse;
-    //  - an anonymous fn added EARLIER renumbers `__synth_<n>` ordinals baked
-    //    into a LATER unchanged flow at generation (rename demotion).
+    //  - an anonymous fn added MID-DOCUMENT renumbers `__synth_<n>` ordinals
+    //    baked into a LATER unchanged flow at generation (rename demotion).
     const SCENARIOS: {
       name: string;
       steps: { find: string; replace: string }[];
+      /** Assert the reuse-demotion path actually ran (see that scenario). */
+      expectsDemotion?: boolean;
     }[] = [
       {
         name: "remove last read-count reference, then edit elsewhere",
@@ -273,7 +275,14 @@ describe("compiler incremental equivalence", () => {
         ],
       },
       {
-        name: "anonymous fn added earlier renumbers later synthetics",
+        name: "anonymous fn added mid-document renumbers later synthetics",
+        // Both inserts land MID-document on purpose. An insert near the top
+        // re-lowers the front-matter chunk, which trips the root-region guard
+        // and disables reuse for that compile — the scenario would then pass
+        // without ever exercising demotion (verified: it did exactly that
+        // before this was moved down). `expectsDemotion` asserts the path
+        // really runs, so a future guard change can't silently un-cover it.
+        expectsDemotion: true,
         steps: [
           // Seed a synthetic in a LATE scene first...
           {
@@ -281,12 +290,13 @@ describe("compiler incremental equivalence", () => {
             replace:
               "  Action describing room 11 in some detail here.\n& local f11 = function(x) return x + 1 end",
           },
-          // ...then add one EARLIER: scene_11 is unchanged (reused) but its
-          // `__synth_<n>` ordinal shifts, so it must be regenerated.
+          // ...then add one EARLIER-BUT-STILL-MID: scenes after it are
+          // unchanged (reused) yet their `__synth_<n>` ordinals shift, so they
+          // must be demoted and regenerated.
           {
-            find: "  Action describing room 1 in some detail here.",
+            find: "  Action describing room 6 in some detail here.",
             replace:
-              "  Action describing room 1 in some detail here.\n& local f1 = function(x) return x + 2 end",
+              "  Action describing room 6 in some detail here.\n& local f6 = function(x) return x + 2 end",
           },
           { find: "Not yet in scene 12.", replace: "Not yet in scene 12!!" },
         ],
@@ -300,6 +310,17 @@ describe("compiler incremental equivalence", () => {
       for (const scenario of SCENARIOS) {
         let text = coupledScreenplay();
         const incr = new SparkdownCompiler();
+        // Count demotions (a committed reuse invalidated mid-compile and
+        // regenerated) so `expectsDemotion` can prove the path was covered.
+        let demotions = 0;
+        const anyIncr = incr as unknown as {
+          resetSubtreeRuntime: (n: unknown) => void;
+        };
+        const originalReset = anyIncr.resetSubtreeRuntime;
+        anyIncr.resetSubtreeRuntime = function (n: unknown) {
+          demotions += 1;
+          return originalReset.call(this, n);
+        };
         incr.configure({
           files: [{ uri: URI, type: "script", name: "main", ext: "sd", text, version: 1, languageId: "sparkdown" }],
         });
@@ -328,6 +349,12 @@ describe("compiler incremental equivalence", () => {
             stable(incrProg),
             `${scenario.name}: step ${stepIdx + 1}`,
           ).toBe(stable(coldProg));
+        }
+        if (scenario.expectsDemotion) {
+          expect(
+            demotions,
+            `${scenario.name}: expected the reuse-demotion path to run`,
+          ).toBeGreaterThan(0);
         }
       }
     } finally {

--- a/packages/sparkdown/src/tests/compiler/incrementalRootRegionReuse.test.ts
+++ b/packages/sparkdown/src/tests/compiler/incrementalRootRegionReuse.test.ts
@@ -1,0 +1,190 @@
+// Root-region guard scope: which top-of-file edits keep flow reuse.
+//
+// Reuse is disabled for a whole compile when the root region's STRUCTURE
+// changes — the ordered `include`/`run` targets and `EXTERNAL` signatures —
+// because those decide which files contribute flows and which call sites
+// compile to external calls, neither of which a reused flow re-derives.
+//
+// Everything else up there is deliberately NOT structural: front matter,
+// loose top-level content, and top-level `store`/`var` declarations cannot
+// alter a reused flow's bytecode (top-level flows are name-addressed in
+// `namedOnlyContent`, so their internal paths don't shift, and globals are
+// read through runtime lookups rather than inlined). Constants ARE inlined
+// and keep their own precise guard.
+//
+// This pins BOTH halves. Correctness alone would pass trivially if the guard
+// were re-broadened, so each case also asserts whether reuse actually
+// happened — that is the property under test.
+import "../../inkjs/engine/Container";
+import { describe, it, expect } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+
+const URI = "inmemory:///main.sd";
+
+const pick = (p: any) => ({
+  compiled: p.compiled,
+  diagnostics: p.diagnostics,
+  pathLocationsOrder: Object.keys(p.pathLocations ?? {}),
+});
+
+function stable(value: unknown): string {
+  const seen = new WeakSet();
+  const walk = (v: any): any => {
+    if (v && typeof v === "object") {
+      if (seen.has(v)) return "[Circular]";
+      seen.add(v);
+      if (Array.isArray(v)) return v.map(walk);
+      const out: Record<string, any> = {};
+      for (const k of Object.keys(v).sort()) out[k] = walk(v[k]);
+      return out;
+    }
+    return v;
+  };
+  return JSON.stringify(walk(value));
+}
+
+function posAt(text: string, offset: number) {
+  let line = 0;
+  let lineStart = 0;
+  for (let i = 0; i < offset; i++) {
+    if (text[i] === "\n") {
+      line++;
+      lineStart = i + 1;
+    }
+  }
+  return { line, character: offset - lineStart };
+}
+
+const quiet = <T,>(fn: () => T): T => {
+  const w = console.warn;
+  const e = console.error;
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    return fn();
+  } finally {
+    console.warn = w;
+    console.error = e;
+  }
+};
+
+function configured(text: string) {
+  const c = new SparkdownCompiler();
+  c.configure({
+    files: [
+      {
+        uri: URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text,
+        version: 1,
+        languageId: "sparkdown",
+      },
+    ],
+  } as never);
+  return c;
+}
+
+function script(): string {
+  const L: string[] = [];
+  L.push("title: Root Region");
+  L.push("author: Anonymous");
+  L.push("");
+  L.push("store trust = 0");
+  L.push("");
+  for (let s = 0; s < 8; s++) {
+    L.push(`scene scene_${s}`);
+    L.push(":");
+    L.push(`  Action in room ${s} with {trust}.`);
+    L.push(`-> scene_${(s + 1) % 8}`);
+    L.push("end");
+    L.push("");
+  }
+  return L.join("\n");
+}
+
+/**
+ * Apply one warm-up edit far from the top (so reuse records exist), then the
+ * edit under test. Returns how many flows were reused on the edit under test
+ * and whether the program matched a cold compile of the same text.
+ */
+function measure(find: string, replace: string) {
+  let text = script();
+  const incr = configured(text);
+  incr.compile({ textDocument: { uri: URI } } as never);
+
+  const warmFind = "Action in room 7";
+  const warmOffset = text.indexOf(warmFind);
+  incr.updateDocument({
+    textDocument: { uri: URI, version: 2 },
+    contentChanges: [
+      {
+        range: {
+          start: posAt(text, warmOffset),
+          end: posAt(text, warmOffset + warmFind.length),
+        },
+        text: "Action in room 7!",
+      },
+    ],
+  } as never);
+  text =
+    text.slice(0, warmOffset) +
+    "Action in room 7!" +
+    text.slice(warmOffset + warmFind.length);
+  incr.compile({ textDocument: { uri: URI } } as never);
+
+  const offset = text.indexOf(find);
+  if (offset < 0) throw new Error(`not found: ${find}`);
+  incr.updateDocument({
+    textDocument: { uri: URI, version: 3 },
+    contentChanges: [
+      {
+        range: {
+          start: posAt(text, offset),
+          end: posAt(text, offset + find.length),
+        },
+        text: replace,
+      },
+    ],
+  } as never);
+  text = text.slice(0, offset) + replace + text.slice(offset + find.length);
+
+  const incrProg = (incr.compile({ textDocument: { uri: URI } } as never) as any)
+    .program;
+  const coldProg = (
+    configured(text).compile({ textDocument: { uri: URI } } as never) as any
+  ).program;
+  return {
+    reused: ((incr as any)._reusedFlowsThisCompile?.size ?? 0) as number,
+    matchesCold: stable(pick(incrProg)) === stable(pick(coldProg)),
+  };
+}
+
+describe("root-region guard scope", () => {
+  it("front-matter text edits keep flow reuse", () => {
+    const r = quiet(() => measure("title: Root Region", "title: Root Region X"));
+    expect(r.matchesCold).toBe(true);
+    expect(r.reused).toBeGreaterThan(0);
+  });
+
+  it("top-level store VALUE edits keep flow reuse", () => {
+    const r = quiet(() => measure("store trust = 0", "store trust = 5"));
+    expect(r.matchesCold).toBe(true);
+    expect(r.reused).toBeGreaterThan(0);
+  });
+
+  it("editing the FIRST scene keeps reuse of the others", () => {
+    const r = quiet(() => measure("Action in room 0", "Action in room 0!"));
+    expect(r.matchesCold).toBe(true);
+    expect(r.reused).toBeGreaterThan(0);
+  });
+
+  it("adding an `external` declaration is structural and disables reuse", () => {
+    const r = quiet(() =>
+      measure("store trust = 0", "store trust = 0\nexternal beep(a)"),
+    );
+    expect(r.matchesCold).toBe(true);
+    expect(r.reused).toBe(0);
+  });
+});

--- a/packages/sparkdown/src/tests/compiler/incrementalStaleTargetPaths.test.ts
+++ b/packages/sparkdown/src/tests/compiler/incrementalStaleTargetPaths.test.ts
@@ -1,0 +1,197 @@
+// Stale-resolved-path oracle for incremental ExportRuntime.
+//
+// Resolution writes a resolved path INTO a runtime object. Under flow reuse
+// that runtime object survives across compiles, so every such write needs a
+// matching "no target this compile" reset or the reused flow keeps a path to
+// something that no longer exists. `Divert.ResolveReferences` got that reset
+// with the reuse work; these cover the two OTHER runtime values that hold an
+// independently-resolved path:
+//
+//   - `DivertTarget` -> `runtimeDivertTargetValue` (a `-> knot` used as a
+//     VALUE, e.g. inside `TURNS_SINCE(-> gamma)`)
+//   - `TunnelOnwards` -> `_overrideDivertTarget` (`->-> gamma`)
+//
+// Both are reached by deleting a divert target while an unrelated flow that
+// references it stays unchanged (and therefore reused). The general
+// incremental-vs-cold oracles never construct that shape.
+//
+// SCOPE, measured rather than assumed: with the callee-signature guard in
+// place these tests do NOT isolate the resets. Deleting a top-level flow
+// changes the flow-name map, which disables reuse for that compile, so the
+// invariant holds even with the resets removed (verified by removing them —
+// both tests still passed). What they pin is the end-to-end invariant
+// (incremental == cold when a divert target disappears), whichever guard
+// upholds it. The resets stay as defense-in-depth: they become load-bearing
+// the moment a guard is narrowed, and narrowing the guards is exactly the
+// planned follow-up. Isolating them needs a target whose removal does not
+// change the flow set (a labelled gather inside a `choose` block).
+import "../../inkjs/engine/Container";
+import { describe, it, expect } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+
+const URI = "inmemory:///main.sd";
+
+const pick = (p: any) => ({ compiled: p.compiled, diagnostics: p.diagnostics });
+
+function stable(value: unknown): string {
+  const seen = new WeakSet();
+  const walk = (v: any): any => {
+    if (v && typeof v === "object") {
+      if (seen.has(v)) return "[Circular]";
+      seen.add(v);
+      if (Array.isArray(v)) return v.map(walk);
+      const out: Record<string, any> = {};
+      for (const k of Object.keys(v).sort()) out[k] = walk(v[k]);
+      return out;
+    }
+    return v;
+  };
+  return JSON.stringify(walk(value));
+}
+
+function posAt(text: string, offset: number) {
+  let line = 0;
+  let lineStart = 0;
+  for (let i = 0; i < offset; i++) {
+    if (text[i] === "\n") {
+      line++;
+      lineStart = i + 1;
+    }
+  }
+  return { line, character: offset - lineStart };
+}
+
+const quiet = <T,>(fn: () => T): T => {
+  const w = console.warn;
+  const e = console.error;
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    return fn();
+  } finally {
+    console.warn = w;
+    console.error = e;
+  }
+};
+
+function configured(text: string) {
+  const c = new SparkdownCompiler();
+  c.configure({
+    files: [
+      {
+        uri: URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text,
+        version: 1,
+        languageId: "sparkdown",
+      },
+    ],
+  } as never);
+  return c;
+}
+
+// No front matter: zero root-region chunks, so the root-region guard stays
+// quiet and flow reuse genuinely engages on the edit under test.
+function doc(callerLine: string): string {
+  const L: string[] = [];
+  L.push("scene caller");
+  L.push(":");
+  L.push("  Caller action.");
+  L.push(callerLine);
+  L.push("-> DONE");
+  L.push("end");
+  L.push("");
+  for (let i = 0; i < 3; i++) {
+    L.push(`scene filler_${i}`);
+    L.push(":");
+    L.push(`  Filler action ${i}.`);
+    L.push("-> DONE");
+    L.push("end");
+    L.push("");
+  }
+  L.push("scene gamma");
+  L.push(":");
+  L.push("  Gamma action.");
+  L.push("-> DONE");
+  L.push("end");
+  L.push("");
+  return L.join("\n");
+}
+
+const GAMMA_BLOCK = "scene gamma\n:\n  Gamma action.\n-> DONE\nend\n";
+
+/** Drive edits through one compiler, comparing to a cold compile each step. */
+function runSteps(base: string, steps: { find: string; replace: string }[]) {
+  const incr = configured(base);
+  incr.compile({ textDocument: { uri: URI } } as never);
+  let text = base;
+  let version = 1;
+  const divergences: string[] = [];
+  for (const [i, step] of steps.entries()) {
+    const offset = text.indexOf(step.find);
+    if (offset < 0) throw new Error(`step ${i}: not found: ${step.find}`);
+    version += 1;
+    incr.updateDocument({
+      textDocument: { uri: URI, version },
+      contentChanges: [
+        {
+          range: {
+            start: posAt(text, offset),
+            end: posAt(text, offset + step.find.length),
+          },
+          text: step.replace,
+        },
+      ],
+    } as never);
+    text =
+      text.slice(0, offset) + step.replace + text.slice(offset + step.find.length);
+    const incrProg = pick(
+      (incr.compile({ textDocument: { uri: URI } } as never) as any).program,
+    );
+    const coldProg = pick(
+      (configured(text).compile({ textDocument: { uri: URI } } as never) as any)
+        .program,
+    );
+    if (stable(incrProg) !== stable(coldProg)) {
+      divergences.push(`step ${i + 1} ("${step.find.slice(0, 30)}")`);
+    }
+  }
+  return divergences;
+}
+
+// Warm-up edits in a filler scene, so `caller` is untouched and gets reused,
+// then delete the target `caller` points at.
+const WARM = (n: number) => ({
+  find: `Filler action 1.${"!".repeat(n)}`,
+  replace: `Filler action 1.${"!".repeat(n + 1)}`,
+});
+
+describe("incremental stale resolved paths", () => {
+  it("divert-target VALUE decays when its target is deleted", () => {
+    const divergences = quiet(() =>
+      runSteps(doc("  Caller action {TURNS_SINCE(-> gamma)}."), [
+        WARM(0),
+        WARM(1),
+        WARM(2),
+        { find: GAMMA_BLOCK, replace: "" },
+        WARM(3),
+      ]),
+    );
+    expect(divergences).toEqual([]);
+  });
+
+  it("tunnel-onwards override decays when its target is deleted", () => {
+    const divergences = quiet(() =>
+      runSteps(doc("->-> gamma"), [
+        WARM(0),
+        WARM(1),
+        WARM(2),
+        { find: GAMMA_BLOCK, replace: "" },
+        WARM(3),
+      ]),
+    );
+    expect(divergences).toEqual([]);
+  });
+});


### PR DESCRIPTION
Phase 1 of #298: `ExportRuntime` was the last fully non-incremental compile stage — every keystroke regenerated the entire runtime container graph for the whole story. This PR makes runtime generation incremental at top-level-flow granularity.

## Design: constructed-flow reuse + whole-story re-resolution

A top-level flow (knot/scene/function, plus its stitches) is assembled from a *run* of chunks: the declaration chunk plus every body chunk that attached content into it. When the entire run is carried forward unchanged, the compiler now reuses last compile's **constructed flow node** — with its registered temps/args, weave state, and (crucially) its cached runtime container subtree — as a child of the fresh Story. `ExportRuntime`'s generation then skips that flow automatically: the `runtimeObject` getter memo returns the cached container.

`ResolveReferences` still runs whole-story every compile as the repair pass, so cross-flow divert paths, count flags, and resolve-time diagnostics are re-derived against the current tree. The state that makes re-resolution over reused containers sound:

- **`Divert.targetContent` / `variableDivertName` are compile-epoch-guarded** — a reused divert re-resolves each compile instead of trusting a stale parsed-node pointer (which would validate arity against a rebuilt flow's old signature, miss "target not found", or keep a stale unresolved-call promotion). An unresolved re-resolution also clears the previously-resolved runtime `targetPath` (the oracle's fuzz caught this one).
- **`VariableReference` restores its runtime ref's generated form** before re-deriving the read-count conversion, so a deleted target decays back to a plain variable reference exactly like a cold compile.
- **Cross-flow count flags** (`visitsShouldBeCounted`/`turnIndexShouldBeCounted`) are set-only; each container's generation-time (intrinsic) flags are snapshotted on first sight and restored before every resolve pass, piggybacked on the `FlattenContainersIn` walk. A removed remote read-count now decays instead of sticking forever.
- **`DontFlatten` protection moved onto the container** (was a per-compile Set on the parsed Story) so reused sequence/conditional branch containers stay protected from flattening even though their generation — which registered the protection — was skipped.
- **Generation-time diagnostics bar a flow from reuse** (reuse skips generation, which would silently drop them; resolve-time diagnostics re-emit naturally via the existing compile-epoch dedup).
- **Disqualifiers:** flows containing global `var`/`store`, `EXTERNAL`, const, list, or struct declarations never reuse — those register story-level state as a *generation side effect*. A **changed** chunk containing a const/list disables all reuse for that compile (values are inlined into other flows' bytecode), as does any root-region change, any include/`run` file change, or a `countAllVisits` flip.
- **Synthetic `__synth_<n>` renames** (positional ordinals shift when an anonymous fn is added/removed earlier in the document) demote any reused flow they touch — names are baked into runtime objects at generation — and lapse that flow's ToJson cache entry, which the cross-flow fingerprint cannot do (it records nothing for pure content).
- **Throw path:** parents of reused containers are restored (the checkpoint-builder Game still holds the previous story live) and all reuse records are dropped so the next compile rebuilds from scratch.

## Measured (R&B: 8.3k-line main.sd + 7 includes)

Interleaved A/B on thermally-matched runs (untouched phases within 5% confirm fairness), steady-state 1-char edits at ~line 6000, 40 edits/run:

| per-edit avg | before | after |
|---|---|---|
| `ink/parse` (remapContent) | 23.3ms | **13.3ms (−43%)** |
| `ink/compile` (ExportRuntime) | 108.8ms | **96.2ms (−12%)** |
| compile() median | 201ms | 189ms |

6 of R&B's 7 top-level ACT flows reuse per edit; the edited ACT still regenerates fully — **flow count is the granularity ceiling** for this phase. Follow-ups that build on this foundation: stitch-level segments, scoped `CollectByType`, the `validateReferences`/`resolveSelector` cache, and a per-chunk `canonicalizeSyntheticFlowNames` memo (each ~4–13ms/edit).

## Verification

- `incrementalEquivalence` oracle (byte-identical program vs cold compile per edit, incl. randomized structural fuzz): 14/14
- `incrementalCumulativeEquivalence` (~400 edits through one persistent compiler): 2/2
- **New multi-step reuse-repair scenarios** added to the oracle: remove-last-read-count (flag decay), rename-a-divert-target-away-and-back, global `store` declared inside a scene (disqualification), anonymous-fn insertion renumbering later flows' synthetics (demotion)
- Full sparkdown suite: 142 files / 1767 tests passed (incl. complete luau-conformance + runtime suites)
- Live editor on R&B: load, diagnostics, typing bursts deep in the script, PLAY before/after edits — game renders and keeps running

## Adversarial review (post-hoc, applied)

A multi-agent adversarial review of this branch confirmed five defects, each reproduced against the committed code before being fixed (commit 3). Notably, three independent review dimensions converged on the same critical one.

- **Critical — callee-signature changes miscompiled reused callers.** A call site's bytecode is derived from its *callee's* parameter list at the *caller's* generation time: a trailing `...` makes the caller emit a `PackTuple` to fill the callee's varargs slot. Reuse was decided purely from the caller's own chunks, so adding or removing `...` left every reused caller pushing arguments for the old signature while the callee popped a different count — silently, with no diagnostic. Every named flow's signature (arity plus per-parameter vararg/by-ref/divert-target flags) is now compared across compiles, and any change demotes that compile's committed reuses.
- **Major ×2 — stale resolved paths.** `DivertTarget`'s value (`TURNS_SINCE(-> gamma)`) and `TunnelOnwards`' override (`->-> gamma`) each hold an independently-resolved path with no "no target this compile" reset, so a reused flow kept a path to a deleted target. Both now mirror the reset `Divert.ResolveReferences` already had.
- **Major — generation-diagnostic attribution.** Attribution walked `source.parent`, but `source` is often an `Identifier` or raw `DebugMetadata`, neither of which has a parent chain. Every such diagnostic was unattributable and disabled *all* flow reuse on the next compile — permanently for any script that emits one every compile. The raising node is now threaded up the `Error` chain and used for attribution.
- **Minor — unpruned cache.** `_lastRootBlocksByUri` strongly holds each file's chunk IR (and via parent pointers, a whole compile generation's parsed tree). Removed files now drop their entry.

Two new oracles cover what the general incremental-vs-cold oracles provably cannot generate — their fixtures contain no variadic function and the cumulative fuzz alphabet contains neither `...` nor `,`. The callee-signature oracle was verified to fail without the guard. The stale-path oracle pins the end-to-end invariant but does **not** isolate the two resets: deleting a top-level flow also changes the flow map, which disables reuse, so those resets are documented as defense-in-depth that becomes load-bearing once the guards are narrowed. R&B still reuses 6/7 flows per edit with the new guard, so it costs nothing on the common typing path.

## Root-region guard narrowed (4th commit)

Reuse used to be disabled for a whole compile whenever any root-region chunk changed IDENTITY — that region being every chunk not inside a flow. Since the incremental parser's reparse window routinely re-lowers a root chunk next to an edit, this fired for edits that weren't in the root region at all. The guard now compares a structural descriptor sequence (ordered `include`/`run` targets and `external` name+arity) instead.

Measured live in the editor on R&B: a front-matter edit now reuses **7/7** flows and an edit near the first content **6/7**, both previously 0. The tests assert reuse actually happened, not merely that output stayed correct, and were verified to fail if the guard is re-broadened.

Narrowing removed a guard that was incidentally covering three real dependencies. An adversarial audit aimed specifically at what the narrowing exposed, plus my own probing, found each of them; all were reproduced before being fixed:

- **A top-level global whose NAME matches a flow shadows it.** `Divert.ResolveTargetContent` runs during *generation* and consults `story.variableDeclarations`, so every call site flips from knot-call codegen (which emits `PackTuple` derived from the callee's parameters) to variable-target codegen, which emits none. Removing the shadowing global afterwards does **not** heal it: flows regenerated while shadowed keep the wrong codegen indefinitely in a program with zero diagnostics. This invalidated the original rationale that globals are only ever runtime lookups.
- **Deleting a constant escaped the const guard**, which fires for a *changed chunk that still contains* a `ConstantDeclaration` — a deleted constant is in no chunk. Reused flows kept the inlined value.
- **`_locCache` lacked the global kill-switch** the bytecode cache has. A constant's inlined expansion is type-dependent (a string emits three runtime objects, a number one), so retyping one shifts index-addressed sibling paths inside flows whose own source is unchanged.

The first two are now covered by a declared-name census (constants and globals, uri-qualified) accumulated across every file of a compile. Names only, so editing a global's *value* still keeps reuse. The census is per-compile rather than per-file on purpose: `parseIncrementally` recurses once per `include`, so a per-file key would be overwritten by each included file and compared against a different file's census next compile — which would have left reuse permanently dead for any multi-file project, R&B included.

Externals deliberately get no resolve-time reset. Undoing that one-way door correctly would require restoring `pushesToStack` to its generation-time value, which resolution cannot recompute, and a partial reset is worse than none — so they stay structurally guarded.

Full suite: 146 files / 1780 tests, run twice cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
