### PR TITLE
feat(compiler): emit const references as variable lookups (#309)

### DIFF
--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -257,7 +257,7 @@ export class SparkdownCompiler {
     {
       disqualifies: boolean;
       invalidatesGlobals: boolean;
-      constNames: string[];
+      declaredNames: string[];
     }
   >;
   // Census of every constant and global NAME declared anywhere in the
@@ -265,8 +265,8 @@ export class SparkdownCompiler {
   // the previous compile's. Two distinct generation-time dependencies make a
   // reused flow's bytecode sensitive to names declared OUTSIDE it:
   //
-  //   - a constant is INLINED BY VALUE into every referencing flow, so a
-  //     constant that disappears leaves stale inlined bytecode behind; and
+  //   - a LIST is inlined by value into every referencing flow, so one that
+  //     disappears leaves stale inlined bytecode behind; and
   //   - `Divert.ResolveTargetContent` runs during GENERATION and consults
   //     `story.variableDeclarations`, so a global whose name matches a flow
   //     shadows it and flips every call site from knot-call codegen (which
@@ -1195,15 +1195,17 @@ export class SparkdownCompiler {
     // never be reused, because skipping its generation loses a story-global
     // side effect: global `var`/`store` declarations register into the fresh
     // Story's variableDeclarations, EXTERNALs into `story.externals`, and
-    // const/list/struct declarations feed story-level maps AND (for
-    // consts/lists) are INLINED BY VALUE into other flows' bytecode — which
-    // is also why a CHANGED chunk containing one disables reuse globally.
+    // const/list/struct declarations feed story-level maps, and a LIST is
+    // additionally INLINED BY VALUE into other flows' bytecode — which is why
+    // a CHANGED chunk containing a list disables reuse globally. Constants
+    // are no longer inlined (#309), so they only cost the declaring flow its
+    // own reuse, not everyone else's.
     const scanChunkForReuse = (
       block: any,
     ): {
       disqualifies: boolean;
       invalidatesGlobals: boolean;
-      constNames: string[];
+      declaredNames: string[];
     } => {
       let cached = this._chunkReuseScan?.get(block);
       if (cached) {
@@ -1214,18 +1216,30 @@ export class SparkdownCompiler {
       const declaredNames: string[] = [];
       const scan = (nodes: ParsedObject[]) => {
         for (const n of nodes) {
-          if (
-            n instanceof ConstantDeclaration ||
-            n instanceof ListDefinition
-          ) {
+          if (n instanceof ListDefinition) {
+            // List items are still resolved and inlined at generation time.
             disqualifies = true;
             invalidatesGlobals = true;
-            const constName =
-              n instanceof ConstantDeclaration
-                ? n.constantName
-                : n.identifier?.name;
-            if (constName) {
-              declaredNames.push(`c:${constName}`);
+            const listName = n.identifier?.name;
+            if (listName) {
+              declaredNames.push(`c:${listName}`);
+            }
+          } else if (n instanceof ConstantDeclaration) {
+            // Constants are no longer inlined into referencing flows (#309),
+            // so a constant's VALUE changing can't invalidate anyone else's
+            // bytecode and `invalidatesGlobals` is not set — editing a
+            // constant no longer kills flow reuse program-wide.
+            //
+            // The NAME still matters, and for the same reason a global's
+            // does: constants are registered in `story.variableDeclarations`,
+            // which `Divert.ResolveTargetContent` consults during GENERATION,
+            // so a constant named like a flow shadows it and changes call-site
+            // codegen. Hence a `g:` census entry, not the retired `c:` one.
+            // `disqualifies` also stays: the declaring flow still performs a
+            // story-global registration when it generates.
+            disqualifies = true;
+            if (n.constantName) {
+              declaredNames.push(`g:${n.constantName}`);
             }
           } else if (
             n instanceof ExternalDeclaration ||
@@ -1272,11 +1286,13 @@ export class SparkdownCompiler {
     // them can alter a reused flow's bytecode — top-level flows are
     // name-addressed in `namedOnlyContent`, so their internal paths don't
     // shift when top-level content grows or shrinks, and globals are read
-    // through runtime variable lookups rather than inlined. Constants ARE
-    // inlined, and are covered precisely by (2).
+    // through runtime variable lookups rather than inlined — as are
+    // constants since #309. Their NAMES still matter, and are covered by the
+    // declared-name census (see `_censusEntries`); LIST values are still
+    // inlined and are covered by (2).
     //
-    // (2) A changed chunk containing a const/list declaration anywhere
-    // disables all reuse (value inlining into other flows).
+    // (2) A changed chunk containing a list declaration anywhere disables all
+    // reuse (value inlining into other flows).
     {
       const rootDescriptors: string[] = [];
       for (const rec of chunkRecords) {

--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Declaration/ConstantDeclaration.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Declaration/ConstantDeclaration.ts
@@ -4,6 +4,7 @@ import { InkObject as RuntimeObject } from "../../../../engine/Object";
 import { Story } from "../Story";
 import { SymbolType } from "../SymbolType";
 import { Identifier } from "../Identifier";
+import { VariableReference } from "../Variable/VariableReference";
 
 export class ConstantDeclaration extends ParsedObject {
   get constantName(): string | undefined {
@@ -45,5 +46,35 @@ export class ConstantDeclaration extends ParsedObject {
   public override ResolveReferences(context: Story) {
     super.ResolveReferences(context);
     context.CheckForNamingCollisions(this, this.identifier, SymbolType.Var);
+
+    // A constant is initialized before every mutable global, so it can only be
+    // built from other constants — reading a `store` here would see nil. This
+    // used to fail as a silent whole-program compile failure instead.
+    for (const name of context.NonConstantInitializerRefs(this)) {
+      this.Error(
+        `A const must be initialized to a constant expression; \`${name}\` is not a const.`,
+        this.identifier,
+      );
+    }
+
+    // Reading a constant that itself couldn't be registered (cycle member, or
+    // transitively invalid) is the same failure one step removed. Reporting
+    // it here means every member of a bad chain gets a diagnostic instead of
+    // only the one where the problem was first detected.
+    const invalidRefs = this.expression
+      .FindAll(VariableReference)()
+      .map((ref) => ref.name)
+      .filter(
+        (name): name is string =>
+          Boolean(name) &&
+          name !== this.constantName &&
+          context.unregisterableConstants.has(name!),
+      );
+    for (const name of invalidRefs) {
+      this.Error(
+        `A const must be initialized to a constant expression; \`${name}\` is not a valid const.`,
+        this.identifier,
+      );
+    }
   }
 }

--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Expression/Expression.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Expression/Expression.ts
@@ -6,7 +6,6 @@ import { InkObject as RuntimeObject } from "../../../../engine/Object";
 export abstract class Expression extends ParsedObject {
   public abstract GenerateIntoContainer: (container: RuntimeContainer) => void;
 
-  private _prototypeRuntimeConstantExpression: RuntimeContainer | null = null;
   public outputWhenComplete: boolean = false;
 
   public readonly GenerateRuntimeObject = (): RuntimeObject => {
@@ -28,28 +27,12 @@ export abstract class Expression extends ParsedObject {
     return container;
   };
 
-  // When generating the value of a constant expression,
-  // we can't just keep generating the same constant expression into
-  // different places where the constant value is referenced, since then
-  // the same runtime objects would be used in multiple places, which
-  // is impossible since each runtime object should have one parent.
-  // Instead, we generate a prototype of the runtime object(s), then
-  // copy them each time they're used.
-  public readonly GenerateConstantIntoContainer = (
-    container: RuntimeContainer,
-  ): void => {
-    if (this._prototypeRuntimeConstantExpression === null) {
-      this._prototypeRuntimeConstantExpression = new RuntimeContainer();
-      this.GenerateIntoContainer(this._prototypeRuntimeConstantExpression);
-    }
-
-    for (const runtimeObj of this._prototypeRuntimeConstantExpression.content) {
-      const copy = runtimeObj.Copy();
-      if (copy) {
-        container.AddContent(copy);
-      }
-    }
-  };
+  // (Constants used to be materialized here, once per reference site, by
+  // copying a prototype of their runtime objects — each runtime object can
+  // only have one parent, so the copy was unavoidable. That approach threw
+  // outright for any initializer containing an operator, because
+  // `NativeFunctionCall` implements no `Copy()`. Constants are now
+  // initialized once as ordinary globals, so nothing needs copying.)
 
   get typeName(): string {
     return "Expression";
@@ -62,7 +45,4 @@ export abstract class Expression extends ParsedObject {
 
   public readonly toString = () => "No string value in JavaScript.";
 
-  override OnResetRuntime(): void {
-    this._prototypeRuntimeConstantExpression = null;
-  }
 }

--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Flow/FlowBase.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Flow/FlowBase.ts
@@ -229,6 +229,16 @@ export abstract class FlowBase extends ParsedObject implements INamedContent {
         return;
       }
 
+      // A collision with a constant is already reported — with real source
+      // provenance — by `Story.CheckForNamingCollisions`, which the colliding
+      // declaration runs during ResolveReferences. The synthetic declaration
+      // minted per constant by `Story.RegisterConstantGlobals` carries no
+      // debugMetadata, so reporting here too would only add an
+      // indistinguishable duplicate pointing at a null location.
+      if (varab.isConstantDeclaration && !varDecl.isConstantDeclaration) {
+        return;
+      }
+
       if (!varDecl.isPropertyDeclaration) {
         this.Error(
           `Duplicate identifier \`${varName}\`. A ${varab.typeName.toLowerCase()} named \`${varName}\` already exists on ${

--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Story.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Story.ts
@@ -235,6 +235,20 @@ export class Story extends FlowBase {
       this.constants.set(constDecl.constantName!, constDecl);
     }
 
+    // Constants are ordinary runtime globals: each gets a synthetic
+    // declaration registered here, BEFORE any generation runs, so that
+    // `variableDeclarations` (an insertion-ordered Map, which the global-init
+    // container is emitted from) lists every constant ahead of every
+    // store/define. That ordering is what lets `store B = SOME_CONST` work
+    // regardless of the order they appear in the source.
+    //
+    // They used to be inlined into each reference site instead, which made
+    // ordering irrelevant but copied the constant's whole runtime-object
+    // graph per reference — and threw outright for any initializer
+    // containing an operator, because `NativeFunctionCall` has no `Copy()`.
+    this.unregisterableConstants = new Set<string>();
+    this.RegisterConstantGlobals();
+
     // List definitions are treated like constants too - they should be usable
     // from other variable declarations.
     this._listDefs = new Map();
@@ -412,6 +426,16 @@ export class Story extends FlowBase {
       runtimeStructs,
     );
 
+    // Publish the constant names so the runtime can keep them read-only and
+    // out of save data while still exposing them as inspectable globals.
+    // Only the ones actually registered: a constant that failed validation
+    // has no initializer in `global decl`, so it is not a global at all.
+    for (const [name] of this.constants) {
+      if (this.variableDeclarations.get(name)?.isConstantDeclaration) {
+        runtimeStory.constantNames.add(name);
+      }
+    }
+
     this.runtimeObject = runtimeStory;
 
     // Generation is complete (FlattenContainersIn emits no diagnostics).
@@ -437,6 +461,111 @@ export class Story extends FlowBase {
     runtimeStory.ResetState();
 
     return runtimeStory;
+  };
+
+  /**
+   * Register one synthetic global declaration per constant, ordered so that a
+   * constant always precedes any constant that references it.
+   *
+   * Iterates `this.constants` rather than the raw declaration list so a
+   * duplicated name registers once (the duplicate is already diagnosed where
+   * the map is built). A dependency cycle is reported and the members fall
+   * back to source order, so the compile still produces a program.
+   */
+  /**
+   * Names a constant's initializer reads that are NOT themselves constants.
+   *
+   * A constant may only be built from other constants: constants are
+   * initialized ahead of every mutable global, so reading a `store` here would
+   * see nil. Such a constant is neither registered nor initialized (the nil
+   * arithmetic would throw out of `ResetState` and cost the whole program its
+   * bytecode), and `ConstantDeclaration.ResolveReferences` reports it.
+   */
+  /**
+   * Constants that could NOT be registered as globals — built from a
+   * non-constant, part of a dependency cycle, or reading one of those. They
+   * emit no initializer, so their references read nil; each is reported by
+   * `ConstantDeclaration.ResolveReferences`.
+   */
+  public unregisterableConstants: Set<string> = new Set<string>();
+
+  public readonly NonConstantInitializerRefs = (
+    constDecl: ConstantDeclaration,
+  ): string[] =>
+    constDecl.expression
+      .FindAll(VariableReference)()
+      .map((ref) => ref.name)
+      .filter(
+        (name): name is string =>
+          Boolean(name) && !this.constants.has(name!),
+      );
+
+  protected readonly RegisterConstantGlobals = (): void => {
+    const visited = new Set<string>();
+    const onStack = new Set<string>();
+
+    const visit = (name: string): void => {
+      if (visited.has(name)) {
+        return;
+      }
+      const constDecl = this.constants.get(name);
+      if (!constDecl) {
+        return;
+      }
+      if (onStack.has(name)) {
+        this.Error(
+          `Circular constant definition: \`${name}\` depends on itself.`,
+          constDecl,
+          false,
+        );
+        // Poison EVERY member of the cycle, not just the name we re-entered:
+        // registering any of them emits an initializer that reads one of the
+        // others before it exists, and the resulting nil arithmetic throws
+        // out of `ResetState`, costing the whole program its bytecode.
+        for (const member of onStack) {
+          this.unregisterableConstants.add(member);
+        }
+        return;
+      }
+      onStack.add(name);
+      // Emit every constant this one reads first, so its initializer sees a
+      // value rather than nil. A self-reference is deliberately NOT filtered
+      // out here — walking it is what lets `onStack` detect it.
+      const refs = constDecl.expression.FindAll(VariableReference)();
+      for (const ref of refs) {
+        if (ref.name && this.constants.has(ref.name)) {
+          visit(ref.name);
+        }
+      }
+      onStack.delete(name);
+      visited.add(name);
+
+      // Not registerable if it is built from a non-constant, is a cycle
+      // member, or reads a constant that itself failed — each case would
+      // otherwise emit an initializer reading an uninitialized global.
+      // Dependencies are visited above, so their verdicts are already known.
+      const readsUnregisterable = refs.some(
+        (ref) => ref.name && this.unregisterableConstants.has(ref.name),
+      );
+      if (
+        this.unregisterableConstants.has(name) ||
+        readsUnregisterable ||
+        this.NonConstantInitializerRefs(constDecl).length > 0
+      ) {
+        this.unregisterableConstants.add(name);
+        return;
+      }
+
+      const declaration = new VariableAssignment({
+        variableIdentifier: constDecl.identifier!,
+        constantExpression: constDecl.expression,
+      });
+      this.AddNewVariableDeclaration(declaration);
+    };
+
+    for (const name of this.constants.keys()) {
+      visit(name);
+    }
   };
 
   public readonly ResolveStruct = (

--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Variable/VariableAssignment.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Variable/VariableAssignment.ts
@@ -30,9 +30,16 @@ export class VariableAssignment extends ParsedObject {
   // defined type names when computing IMPLICIT parent types
   // (`as character` where `character` is never `define`d).
   public isDefineDeclaration: boolean = false;
+  // True for the synthetic declaration minted per `const` so constants
+  // participate in normal global initialization (see
+  // `Story.RegisterConstantGlobals`). Constants used to be inlined into every
+  // reference site instead of being initialized once.
+  public isConstantDeclaration: boolean = false;
 
   override get typeName() {
-    if (this.listDefinition !== null) {
+    if (this.isConstantDeclaration) {
+      return "const";
+    } else if (this.listDefinition !== null) {
       return "list";
     } else if (this.structDefinition !== null) {
       return "define";
@@ -57,6 +64,7 @@ export class VariableAssignment extends ParsedObject {
 
   constructor({
     assignedExpression,
+    constantExpression,
     isGlobalDeclaration,
     isPropertyDeclaration,
     isTemporaryNewDeclaration,
@@ -66,6 +74,11 @@ export class VariableAssignment extends ParsedObject {
     variableIdentifier,
   }: {
     readonly assignedExpression?: Expression;
+    /**
+     * The expression of an existing `ConstantDeclaration`, adopted WITHOUT
+     * `AddContent` — see the constructor body.
+     */
+    readonly constantExpression?: Expression;
     readonly isGlobalDeclaration?: boolean;
     readonly isPropertyDeclaration?: boolean;
     readonly isTemporaryNewDeclaration?: boolean;
@@ -105,6 +118,19 @@ export class VariableAssignment extends ParsedObject {
       }
     } else if (assignedExpression) {
       this.expression = this.AddContent(assignedExpression) as Expression;
+    } else if (constantExpression) {
+      // Adopted by DIRECT ASSIGNMENT, deliberately not `AddContent`.
+      // `AddContent` REPARENTS its argument, which would move the expression
+      // off its `ConstantDeclaration` and onto this synthetic node — and this
+      // node is never added to the parse tree, so its own `parent` is null.
+      // The expression's `story` getter (which walks parents to the root)
+      // would then return this VariableAssignment instead of the Story, and
+      // `Error()` would throw "No parent object to send error to" instead of
+      // reporting a diagnostic. Sharing the expression is safe because it is
+      // generated exactly once, into the global-init container.
+      this.expression = constantExpression;
+      this.isConstantDeclaration = true;
+      this.isGlobalDeclaration = true;
     }
   }
 
@@ -177,6 +203,30 @@ export class VariableAssignment extends ParsedObject {
       }
     }
 
+    // Constants are immutable. This has to be checked OUTSIDE the
+    // "unresolved name" branch below: constants are now registered in
+    // `variableDeclarations`, so `ResolveVariableWithName` finds them and
+    // that branch never runs for a constant. (The check that used to live
+    // there was dead anyway — it tested `name in someMap`, which is always
+    // false for a Map.) Without this, assigning to a constant silently
+    // mutates it, and because the value then differs from its default it
+    // would also start being written into save files.
+    if (
+      !this.isDeclaration &&
+      !this.isConstantDeclaration &&
+      this.story.constants.has(this.variableName) &&
+      // Only when the name actually BINDS to the constant. A local or
+      // parameter of the same name shadows it — that already reports its own
+      // `Duplicate identifier`, and adding this on top would be misleading.
+      this.story.variableDeclarations.get(this.variableName)
+        ?.isConstantDeclaration
+    ) {
+      this.Error(
+        `Cannot re-assign the const \`${this.variableName}\`.`,
+        this.identifier,
+      );
+    }
+
     if (!this.isNewTemporaryDeclaration) {
       const resolvedVarAssignment = context.ResolveVariableWithName(
         this.variableName,
@@ -184,9 +234,6 @@ export class VariableAssignment extends ParsedObject {
       );
 
       if (!resolvedVarAssignment.found) {
-        if (this.variableName in this.story.constants) {
-          this.Error(`Cannot re-assign a const variable`, this);
-        }
         // Luau auto-global semantics: a bare `x = expr` that doesn't
         // resolve to any local-in-scope or existing global becomes a
         // global creation at execution time. The runtime side handles
@@ -195,7 +242,7 @@ export class VariableAssignment extends ParsedObject {
         // so we just suppress the compile-time error here and let the
         // runtime auto-create the global. Mark the runtime assignment
         // as global so the dispatcher routes correctly.
-        else if (this._runtimeAssignment) {
+        if (this._runtimeAssignment) {
           this._runtimeAssignment.isGlobal = true;
           // ALSO register the auto-global in the story's variable
           // declarations so downstream `Divert.ResolveTargetContent`

--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Variable/VariableReference.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Variable/VariableReference.ts
@@ -25,8 +25,18 @@ export class VariableReference extends Expression {
     return this.pathIdentifiers.map((id) => id.name!).filter(filterUndef);
   }
 
+  /**
+   * Derived, not a generation-time flag: constants are known before any
+   * generation runs, and a stored flag would be STICKY across compiles.
+   * Incremental ExportRuntime reuses a flow without regenerating it, so a
+   * reference that was constant when it was last generated would keep
+   * claiming so after the constant is deleted — silently suppressing the
+   * `Cannot find variable named` warning a cold compile emits.
+   */
+  get isConstantReference(): boolean {
+    return this.story.constants.has(this.name);
+  }
   // Only known after GenerateIntoContainer has run
-  public isConstantReference: boolean = false;
   public isListItemReference: boolean = false;
 
   get runtimeVarRef() {
@@ -45,16 +55,15 @@ export class VariableReference extends Expression {
   public readonly GenerateIntoContainer = (
     container: RuntimeContainer,
   ): void => {
-    let constantValue = this.story.constants.get(this.name);
-
-    // If it's a constant reference, just generate the literal expression value
-    // It's okay to access the constants at code generation time, since the
-    // first thing the ExportRuntime function does it search for all the constants
-    // in the story hierarchy, so they're all available.
-    if (constantValue) {
-      constantValue.expression.GenerateConstantIntoContainer(container);
-      this.isConstantReference = true;
-
+    // Constants are ordinary runtime globals now, initialized ahead of every
+    // other global in the "global decl" container, so a reference is a plain
+    // variable lookup. This used to COPY the constant's entire runtime-object
+    // graph in here, once per reference site — which also meant any
+    // initializer containing an operator threw outright, because
+    // `NativeFunctionCall` has no `Copy()`.
+    if (this.story.constants.has(this.name)) {
+      this._runtimeVarRef = new RuntimeVariableReference(this.name);
+      container.AddContent(this._runtimeVarRef);
       return;
     }
 

--- a/packages/sparkdown/src/inkjs/engine/Story.ts
+++ b/packages/sparkdown/src/inkjs/engine/Story.ts
@@ -915,6 +915,16 @@ export class Story extends InkObject {
           JsonSerialisation.JTokenToListDefinitions(listDefsObj);
       }
 
+      // Names declared with `const`. They initialize like any other global
+      // (so they are inspectable at runtime — e.g. by the debug adapter),
+      // but they are immutable and fully reconstructed from the bytecode on
+      // every run, so they are never written to a save and never restored
+      // from one. See `VariablesState.constantNames`.
+      const constantsObj = rootObject["constants"];
+      if (Array.isArray(constantsObj)) {
+        this._constantNames = new Set<string>(constantsObj as string[]);
+      }
+
       this._mainContentContainer = asOrThrows(
         JsonSerialisation.JTokenToRuntimeObject(rootToken),
         Container,
@@ -983,6 +993,13 @@ export class Story extends InkObject {
       writer.WritePropertyEnd();
     }
 
+    // Names declared with `const`. Shipped so the runtime can keep them
+    // read-only and out of save data while still exposing them as ordinary
+    // inspectable globals — see `VariablesState.constantNames`.
+    if (this._constantNames.size > 0) {
+      writer.InjectObject("constants", [...this._constantNames]);
+    }
+
     if (
       this._structDefinitions != null &&
       Object.keys(this._structDefinitions).length > 0
@@ -1022,6 +1039,9 @@ export class Story extends InkObject {
   }
 
   public ResetGlobals() {
+    // Re-published on every reset so a reloaded//swapped story can't leave the
+    // previous program's constant set behind.
+    this.state.variablesState.constantNames = this._constantNames;
     if (this._mainContentContainer.namedContent.get("global decl")) {
       let originalPointer = this.state.currentPointer.copy();
 
@@ -5062,6 +5082,11 @@ export class Story extends InkObject {
    */
   private _mainContentContainer!: Container;
   private _listDefinitions: ListDefinitionsOrigin | null = null;
+  /** Names declared with `const` — see where `rootObject["constants"]` is read. */
+  private _constantNames: Set<string> = new Set<string>();
+  get constantNames(): Set<string> {
+    return this._constantNames;
+  }
   private _structDefinitions: Record<string, any> | null = null;
 
   private _externals: Map<string, Story.ExternalFunctionDef>;

--- a/packages/sparkdown/src/inkjs/engine/VariablesState.ts
+++ b/packages/sparkdown/src/inkjs/engine/VariablesState.ts
@@ -200,10 +200,28 @@ export class VariablesState extends VariablesStateAccessor<
     this.patch = null;
   }
 
+  /**
+   * Names declared with `const`, published by `Story.ResetGlobals`.
+   *
+   * A constant IS a real global — it initializes from the `global decl`
+   * container and is therefore visible to anything inspecting runtime state
+   * (notably the debug adapter). But its value is fully determined by the
+   * compiled program, so it must never round-trip through a save: it is
+   * neither written by `WriteJson` nor restored by `SetJsonToken`. Without
+   * that, a save written when the name was still a mutable `store` would
+   * overwrite the compiled constant on load and pin it forever.
+   */
+  public constantNames: Set<string> = new Set<string>();
+
   public SetJsonToken(jToken: Record<string, any>) {
     this._globalVariables.clear();
 
     for (let [varValKey, varValValue] of this._defaultGlobalVariables) {
+      // Always take the compiled value for a constant, never the saved one.
+      if (this.constantNames.has(varValKey)) {
+        this._globalVariables.set(varValKey, varValValue);
+        continue;
+      }
       let loadedToken = jToken[varValKey];
       if (typeof loadedToken !== "undefined") {
         let tokenInkObject =
@@ -245,6 +263,8 @@ export class VariablesState extends VariablesStateAccessor<
     // they'd silently vanish on load.
     for (const key of Object.keys(jToken)) {
       if (this._defaultGlobalVariables.has(key)) continue;
+      // A stale save may carry a key that has since become a constant.
+      if (this.constantNames.has(key)) continue;
       const tokenInkObject = JsonSerialisation.JTokenToRuntimeObject(
         jToken[key],
       );
@@ -261,6 +281,12 @@ export class VariablesState extends VariablesStateAccessor<
     for (let [keyValKey, keyValValue] of this._globalVariables) {
       let name = keyValKey;
       let val = keyValValue;
+
+      // Constants are reconstructed from the bytecode on every run, so they
+      // are never persisted — see `constantNames`.
+      if (this.constantNames.has(name)) {
+        continue;
+      }
 
       // Store-keyed rule for define tables: persistence follows the
       // `store` marker, NOT value-equality. A define with no store state

--- a/packages/sparkdown/src/tests/compiler/constDeclarationValidity.test.ts
+++ b/packages/sparkdown/src/tests/compiler/constDeclarationValidity.test.ts
@@ -1,0 +1,125 @@
+// Invalid `const` declarations must be REPORTED, never silently fatal.
+//
+// A constant is initialized once, ahead of every mutable global, so its
+// initializer can only read other constants. When that doesn't hold — it
+// reads a `store`, it is part of a dependency cycle, or it reads a constant
+// that itself failed — the constant is left unregistered and diagnosed.
+//
+// The failure mode being guarded against is severe and was real: an
+// unregistered constant that still emitted an initializer would read an
+// uninitialized global, and the resulting nil arithmetic throws out of
+// `ResetState`, so `program.compiled` came back undefined and the author got
+// NO diagnostic at all — the game simply didn't run.
+import "../../inkjs/engine/Container";
+import { describe, expect, it } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+
+const URI = "inmemory:///main.sd";
+
+function compile(text: string) {
+  const c = new SparkdownCompiler();
+  c.configure({
+    files: [
+      {
+        uri: URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text,
+        version: 1,
+        languageId: "sparkdown",
+      },
+    ],
+  } as never);
+  return (c.compile({ textDocument: { uri: URI } } as never) as any).program;
+}
+
+const errorsOf = (p: any) =>
+  (Array.isArray(p.diagnostics)
+    ? p.diagnostics
+    : Object.values(p.diagnostics ?? {}).flat()
+  ).filter((d: any) => d.severity === 1);
+
+/** Compile `body` plus a scene that references SHOW. */
+function check(body: string) {
+  const realWarn = console.warn;
+  const realError = console.error;
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    const p = compile(
+      body + "\nscene main\n:\n  Value {SHOW}.\n-> DONE\nend\n",
+    );
+    return {
+      hasProgram: Boolean(p.compiled),
+      errors: errorsOf(p).length,
+      constants: (p.compiled?.constants ?? null) as string[] | null,
+    };
+  } finally {
+    console.warn = realWarn;
+    console.error = realError;
+  }
+}
+
+describe("const declaration validity", () => {
+  it("a valid const compiles and is published as a runtime constant", () => {
+    const r = check("const SHOW = 5");
+    expect(r.hasProgram).toBe(true);
+    expect(r.errors).toBe(0);
+    expect(r.constants).toEqual(["SHOW"]);
+  });
+
+  it("a self-referential const is reported, not silently fatal", () => {
+    const r = check("const SHOW = SHOW + 1");
+    expect(r.hasProgram).toBe(true);
+    expect(r.errors).toBeGreaterThan(0);
+    // Never published as a constant: it has no initializer.
+    expect(r.constants).toBeNull();
+  });
+
+  it("a mutual cycle is reported and the program survives", () => {
+    const r = check("const A = B + 1\nconst B = A + 1\nconst SHOW = 1");
+    expect(r.hasProgram).toBe(true);
+    expect(r.errors).toBeGreaterThan(0);
+    // The unrelated constant is unaffected.
+    expect(r.constants).toEqual(["SHOW"]);
+  });
+
+  it("a longer cycle reports every member", () => {
+    const r = check(
+      "const A = B + 1\nconst B = C + 1\nconst C = A + 1\nconst SHOW = 1",
+    );
+    expect(r.hasProgram).toBe(true);
+    // One per cycle member, not just the one where it was detected.
+    expect(r.errors).toBeGreaterThanOrEqual(3);
+  });
+
+  it("a const built from a mutable global is reported", () => {
+    const r = check("store s = 1\nconst SHOW = s + 1");
+    expect(r.hasProgram).toBe(true);
+    expect(r.errors).toBeGreaterThan(0);
+    expect(r.constants).toBeNull();
+  });
+
+  it("a const built from an INVALID const is reported too", () => {
+    const r = check("store s = 1\nconst A = s + 1\nconst SHOW = A + 1");
+    expect(r.hasProgram).toBe(true);
+    // Both the direct failure and the one that depends on it.
+    expect(r.errors).toBeGreaterThanOrEqual(2);
+    expect(r.constants).toBeNull();
+  });
+
+  it("assigning to a const is an error", () => {
+    const r = check("const SHOW = 5\n& SHOW = 6");
+    expect(r.hasProgram).toBe(true);
+    expect(r.errors).toBeGreaterThan(0);
+  });
+
+  it("a local of the same name shadows without a spurious const error", () => {
+    const r = check(
+      "const SHOW = 5\nfunction f():\n  local SHOW = 1\n  return SHOW",
+    );
+    expect(r.hasProgram).toBe(true);
+    expect(r.errors).toBe(0);
+  });
+});

--- a/packages/sparkdown/src/tests/compiler/incrementalConstCensus.test.ts
+++ b/packages/sparkdown/src/tests/compiler/incrementalConstCensus.test.ts
@@ -1,15 +1,17 @@
-// Constant-census oracle for incremental ExportRuntime.
+// Declared-name census oracle for incremental ExportRuntime.
 //
-// A constant reference is INLINED: generation copies the constant's whole
-// expression bytecode into every referencing flow. Flow reuse skips
-// generation, so any change to the set of declared constants must invalidate
-// reuse or a reused flow keeps last compile's inlined value.
+// Constants and globals are registered in `story.variableDeclarations`, which
+// `Divert.ResolveTargetContent` consults during GENERATION. So a name that
+// enters or leaves that set can change other flows' call-site codegen, and a
+// reused flow (whose generation is skipped) would keep the old shape. The
+// census compares the whole declared-NAME set across compiles to catch it —
+// including DELETIONS, which the per-chunk scan cannot see because a deleted
+// declaration appears in no chunk at all.
 //
-// Changing or adding a constant is caught by the per-chunk scan (its chunk is
-// new AND contains a ConstantDeclaration). DELETING one is not: the constant
-// then appears in no chunk at all. This pins the census comparison that
-// covers deletion — the case the root-region identity guard used to catch
-// incidentally, before that guard was narrowed to structural descriptors.
+// Since #309 a constant's VALUE is no longer inlined into referencing flows —
+// it is initialized once as an ordinary global — so editing a constant's
+// value no longer has to invalidate anything. The last test pins that
+// distinction, which is the whole point of that change.
 import "../../inkjs/engine/Container";
 import { describe, it, expect } from "vitest";
 import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
@@ -85,6 +87,49 @@ describe("incremental constant census", () => {
       (console as any).warn("\n" + log.join("\n") + "\n");
     }
     expect(log.filter((l) => l.includes("DIVERGED"))).toEqual([]);
+  });
+
+  // The #309 payoff. A constant's value is initialized once rather than
+  // copied into each referencing flow, so changing it cannot invalidate any
+  // other flow's bytecode and must NOT cost reuse. Its NAME still enters the
+  // census (constants live in `variableDeclarations`, which generation reads
+  // when resolving call targets), so removing one still does.
+  it("editing a const's VALUE keeps reuse; removing the const does not", () => {
+    const w = console.warn, e = console.error;
+    console.warn = () => {}; console.error = () => {};
+    const seen: { reused: number; matches: boolean }[] = [];
+    try {
+      let text = base();
+      const incr = conf(text);
+      incr.compile({ textDocument: { uri: URI } } as any);
+      let version = 1;
+      const steps = [
+        { find: "Room 3 limit", replace: "Room 3 Limit" }, // warm up reuse
+        { find: "const LIMIT = 5", replace: "const LIMIT = 6" }, // VALUE edit
+        { find: "const LIMIT = 6\n", replace: "" }, // removal
+      ];
+      for (const s of steps) {
+        const off = text.indexOf(s.find);
+        expect(off, `find ${s.find}`).toBeGreaterThanOrEqual(0);
+        version++;
+        incr.updateDocument({ textDocument: { uri: URI, version }, contentChanges: [{ range: { start: posAt(text, off), end: posAt(text, off + s.find.length) }, text: s.replace }] } as any);
+        text = text.slice(0, off) + s.replace + text.slice(off + s.find.length);
+        const a = stable(pick((incr.compile({ textDocument: { uri: URI } } as any) as any).program));
+        const b = stable(pick((conf(text).compile({ textDocument: { uri: URI } } as any) as any).program));
+        seen.push({
+          reused: (incr as any)._reusedFlowsThisCompile?.size ?? -1,
+          matches: a === b,
+        });
+      }
+    } finally {
+      console.warn = w; console.error = e;
+    }
+    // Every step must still match a cold compile.
+    expect(seen.map((s) => s.matches)).toEqual([true, true, true]);
+    // Editing the value keeps flows reused (this is what #309 bought)...
+    expect(seen[1]!.reused).toBeGreaterThan(0);
+    // ...while removing the declaration still invalidates via the census.
+    expect(seen[2]!.reused).toBe(0);
   });
 });
 

--- a/packages/sparkdown/src/tests/runtime/ConstSaveIsolation.test.ts
+++ b/packages/sparkdown/src/tests/runtime/ConstSaveIsolation.test.ts
@@ -1,0 +1,58 @@
+// Constants must not round-trip through save data.
+//
+// A `const` is a real runtime global (so it is inspectable — the debug adapter
+// can show it like any other variable), but its value comes entirely from the
+// compiled program. If it were persisted or restored like a mutable global,
+// a save written when the name was still a `store` would overwrite the
+// compiled constant on load and pin it to the stale value forever — editing
+// the `const` in the script would then have no effect for existing players.
+//
+// Both directions are pinned here: never written, and never restored.
+import "../../inkjs/engine/Container";
+import { describe, expect, test } from "vitest";
+import { makeRuntimeStoryFromSource, runToEnd } from "./runtimeTestHarness";
+
+describe("const save isolation", () => {
+  test("a stale save cannot overwrite a compiled constant", () => {
+    // v1: `LIMIT` is a mutable global, mutated to 99 and saved.
+    const v1 = makeRuntimeStoryFromSource(
+      ["store LIMIT = 5", "& LIMIT = 99", "{LIMIT}"].join("\n"),
+    );
+    expect(v1.errorMessages).toEqual([]);
+    expect(runToEnd(v1.story)).toBe("99\n");
+    const staleSave = v1.story.state.ToJson();
+    expect(staleSave).toContain("LIMIT");
+
+    // v2: the author has since turned `LIMIT` into a constant with a new
+    // value. Loading the old save must NOT resurrect 99.
+    const v2 = makeRuntimeStoryFromSource(
+      ["const LIMIT = 6", "{LIMIT}"].join("\n"),
+    );
+    expect(v2.errorMessages).toEqual([]);
+    v2.story.state.LoadJson(staleSave);
+    expect(v2.story.variablesState.$("LIMIT")).toBe(6);
+  });
+
+  test("a constant is never written into save data", () => {
+    const ctx = makeRuntimeStoryFromSource(
+      ["const LIMIT = 6", "store other = 1", "& other = 2", "{LIMIT}"].join("\n"),
+    );
+    expect(ctx.errorMessages).toEqual([]);
+    runToEnd(ctx.story);
+    const save = ctx.story.state.ToJson();
+    const variablesState = JSON.parse(save).variablesState ?? {};
+    expect(Object.keys(variablesState)).not.toContain("LIMIT");
+    // The mutable global still persists, so this isn't vacuously passing.
+    expect(Object.keys(variablesState)).toContain("other");
+  });
+
+  test("a constant is still an inspectable runtime global", () => {
+    const ctx = makeRuntimeStoryFromSource(
+      ["const LIMIT = 6", "{LIMIT}"].join("\n"),
+    );
+    expect(ctx.errorMessages).toEqual([]);
+    runToEnd(ctx.story);
+    // Visible through the same API a debugger would use.
+    expect(ctx.story.variablesState.$("LIMIT")).toBe(6);
+  });
+});

--- a/packages/sparkdown/src/tests/runtime/Variables.test.ts
+++ b/packages/sparkdown/src/tests/runtime/Variables.test.ts
@@ -56,6 +56,26 @@ describe("Variables (ported from inkjs)", () => {
     expect(runToEnd(ctx.story)).toBe("54\n");
   });
 
+  // Constants are runtime globals initialized ahead of every other global,
+  // rather than expressions copied into each reference site. These two shapes
+  // were impossible under the old inlining: copying the constant's runtime
+  // objects hit `NativeFunctionCall`, which has no `Copy()`, so ANY constant
+  // whose initializer contained an operator threw and the whole program
+  // compiled to nothing — with no diagnostic at all.
+  test("const with an expression initializer", () => {
+    const ctx = makeRuntimeStoryFromFile("variables", "const-expression");
+    expect(ctx.errorMessages).toEqual([]);
+    expect(runToEnd(ctx.story)).toBe("5\n");
+  });
+
+  // Declaration order must not matter: constants are emitted in dependency
+  // order, so a constant may be built from one declared later in the file.
+  test("const built from a const declared later", () => {
+    const ctx = makeRuntimeStoryFromFile("variables", "const-from-const-forward");
+    expect(ctx.errorMessages).toEqual([]);
+    expect(runToEnd(ctx.story)).toBe("10\n");
+  });
+
   // The Luau-style port `varStr == CONST_STR and "success" or ""` works
   // because `NativeFunctionCall.Call()` has a fast-path for `and`/`or` that
   // returns one operand based on truthiness, matching Luau's short-circuit

--- a/packages/sparkdown/src/tests/runtime/fixtures/variables/const-expression.sd
+++ b/packages/sparkdown/src/tests/runtime/fixtures/variables/const-expression.sd
@@ -1,0 +1,3 @@
+const AREA = 2 + 3
+store x = AREA
+{x}

--- a/packages/sparkdown/src/tests/runtime/fixtures/variables/const-from-const-forward.sd
+++ b/packages/sparkdown/src/tests/runtime/fixtures/variables/const-from-const-forward.sd
@@ -1,0 +1,4 @@
+const DOUBLED = BASE * 2
+const BASE = 5
+store x = DOUBLED
+{x}


### PR DESCRIPTION
Closes #309.

A `const` reference was **inlined**: generation copied the constant's entire expression bytecode into every referencing container. Constants are now ordinary runtime globals, initialized once, and a reference is a plain variable lookup.

## Why

**Inspectability.** A baked-in constant doesn't exist at runtime, so the debug adapter can't show it. It now appears like any other variable — which is the point, and what motivated doing this rather than patching around it.

Two pre-existing bugs fall out of the change:

**`const AREA = 2 + 3` produced no compiled program at all, with no diagnostic.** Inlining `Copy()`s the constant's runtime objects into each reference site, and only `Value` and `ControlCommand` implement `Copy()` — `NativeFunctionCall`, which any operator generates, inherits the base implementation that throws. `SparkdownCompiler.compile`'s catch swallowed it, so `program.compiled` was simply absent. It survived because both existing const fixtures use literals (`const c = 5`, `const kX = "hi"`), which are exactly the shapes that worked.

**Assigning to a constant was silently accepted.** The guard tested `name in someMap` on a `Map` — always false — and sat inside an unreachable branch. `const X = 5` followed by `& X = 6` compiled clean and emitted a real assignment while every read still inlined `5`. This had to be fixed in the same change: once constants are real variables, an accepted assignment genuinely mutates one.

## Design

Constants are registered into `variableDeclarations` before generation, in **dependency order**, so a constant may be built from one declared later in the file. Because that map is insertion-ordered and drives the `global decl` container, constants always initialize ahead of every mutable global.

Declarations that can't be honoured — built from a mutable global, part of a cycle, or reading a constant that itself failed — are reported and left unregistered. Emitting their initializer would read an uninitialized global, and the resulting nil arithmetic throws out of `ResetState`, costing the whole program its bytecode. Each of those shapes previously produced **no program and no diagnostic**.

The synthetic per-constant declaration adopts the `ConstantDeclaration`'s expression by direct assignment rather than `AddContent`, which reparents — that would detach the expression from the parse tree, so its `story` getter would return the detached node and `Error()` would throw "No parent object to send error to" instead of reporting a diagnostic.

## Save isolation (found by adversarial review)

I had verified constants are never *written* to saves and concluded there was no hazard. The review checked the other direction: `VariablesState.SetJsonToken` replaces any default global present in a loaded save. So a name that shipped as a `store` and later became a `const` would be pinned to the player's stale saved value forever, and editing the constant would have no effect for them. That's a regression versus inlining, where the value lived in bytecode and no save could reach it.

Constants now ship as a name set in the compiled program (`"constants"`, alongside `listDefs`). The engine keeps them as normal globals — so they stay inspectable — but never persists them and never restores them from a save.

## Incremental interaction (#298)

`isConstantReference` became a derived getter. As a stored generation-time flag it was sticky across incremental compiles, so a reused flow would keep claiming "constant" after the constant was deleted, suppressing a warning a cold compile emits.

A `ConstantDeclaration` no longer sets `invalidatesGlobals`, so editing a constant's **value** keeps flow reuse. Its **name** still enters the declared-name census, because constants live in `variableDeclarations`, which `Divert.ResolveTargetContent` consults during generation — a constant named like a flow shadows it and changes call-site codegen. Lists keep all three guard clauses; their values are still inlined.

## Payload: not a win

The issue claimed this would shrink `program.compiled`. Measured, it doesn't, for the common case. At 100 references:

| | before (inlining) | after (lookup) |
|---|---|---|
| numeric const, short name | 4,214 | **5,367** |
| numeric const, descriptive name | 4,214 | **7,993** |
| string const | 6,814 | 5,393 |
| expression const | *no program* | 5,373 |

A lookup token is larger than the literal it replaces and scales with the constant's name length. Strings shrink; expressions previously didn't compile. Accepted deliberately: inspectability is the goal, and the planned move to binary bytecode addresses size separately.

## Verification

- Full suite **148 files / 1794 tests** (main: 1780), including 759 luau-conformance and all runtime fixtures
- Two new **executing** fixtures for the previously-broken shapes (`const-expression`, `const-from-const-forward`), both confirmed to fail without the change via a stash round-trip
- `constDeclarationValidity` — 8 cases pinning that invalid constants are reported and the program survives
- `ConstSaveIsolation` — stale-save-cannot-overwrite, never-persisted, still-inspectable. The stale-save test was verified to fail without the engine guard; the never-persisted one passes either way because `dontSaveDefaultValues` already covers it, so that skip is defense-in-depth rather than something the test proves
- #298's incremental oracles still pass, with a new assertion that editing a constant's value keeps reuse while removing it invalidates

Also fixes a type/reality mismatch from #298 where the annotation said `constNames` while the code built and read `declaredNames` (no CI typecheck, so it shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
