### PR TITLE
fix(compiler): stop generation mutating the parsed tree (~5.5MB/keystroke leak)

### DIFF
--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Expression/ObjectExpression.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/Expression/ObjectExpression.ts
@@ -57,8 +57,18 @@ export class ObjectExpression extends Expression {
         // Static key — emitted by lowering a single-segment
         // StringExpression so the BeginString/EndString machinery
         // yields a StringValue on the eval stack.
+        //
+        // Parented, but deliberately NOT added to `content`: generation must
+        // not mutate the parsed tree. These nodes are carried forward across
+        // incremental compiles by chunk identity, so an `AddContent` here
+        // appended a fresh key expression on EVERY compile and never released
+        // the previous one — each accumulated `Text` then pinned a whole
+        // runtime container generation through its cached `_runtimeObject`'s
+        // parent chain (~5.5MB/keystroke; see issue #312). The parent link is
+        // all generation needs (`debugMetadata` and `story` walk it), and the
+        // key expression carries nothing for `ResolveReferences` to resolve.
         const keyExpr = new StringExpression([new Text(entry.key)]);
-        this.AddContent(keyExpr);
+        keyExpr.parent = this;
         keyExpr.GenerateIntoContainer(container);
       }
       // Value — already an Expression. Generate its runtime form inline so

--- a/packages/sparkdown/src/tests/compiler/generationTreeMutation.test.ts
+++ b/packages/sparkdown/src/tests/compiler/generationTreeMutation.test.ts
@@ -1,0 +1,204 @@
+// Generation must not mutate the parsed hierarchy.
+//
+// The incremental pipeline carries parsed chunks forward across compiles by
+// identity — that is the whole point of the design. So any node that MUTATES
+// itself while generating runtime objects accumulates one lowered generation
+// per compile and never releases the previous one.
+//
+// `ObjectExpression.GenerateIntoContainer` did exactly that: it built a fresh
+// `StringExpression`/`Text` per static key and `AddContent`-ed it to itself on
+// every generation pass. Each accumulated `Text` then pinned a whole runtime
+// container subtree through its cached `_runtimeObject`'s parent chain, so a
+// real editing session retained ~5.5MB per keystroke and eventually exhausted
+// the language-server worker heap (issue #312).
+//
+// These tests pin the invariant structurally rather than by measuring heap
+// bytes, so they are deterministic and cheap: generation is idempotent with
+// respect to the parsed tree, and repeated incremental compiles do not grow it.
+import "../../inkjs/engine/Container";
+import { describe, expect, it } from "vitest";
+import { Container as RuntimeContainer } from "../../inkjs/engine/Container";
+import {
+  ObjectExpression,
+  ObjectExpressionEntry,
+} from "../../inkjs/compiler/Parser/ParsedHierarchy/Expression/ObjectExpression";
+import { NumberExpression } from "../../inkjs/compiler/Parser/ParsedHierarchy/Expression/NumberExpression";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+
+const URI = "inmemory:///main.sd";
+
+const quiet = <T,>(fn: () => T): T => {
+  const w = console.warn;
+  const e = console.error;
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    return fn();
+  } finally {
+    console.warn = w;
+    console.error = e;
+  }
+};
+
+/**
+ * Sum of `content.length` over every `ObjectExpression` reachable from the
+ * compiler. Stays constant across compiles unless generation is appending to
+ * carried-forward parsed nodes.
+ */
+function objectExpressionContentTotal(root: object): {
+  nodes: number;
+  content: number;
+} {
+  const seen = new Set<unknown>([root]);
+  const queue: any[] = [root];
+  let nodes = 0;
+  let content = 0;
+  for (let head = 0; head < queue.length; head++) {
+    const cur = queue[head];
+    if (cur instanceof ObjectExpression) {
+      nodes += 1;
+      content += cur.content.length;
+    }
+    let children: unknown[];
+    if (Array.isArray(cur)) {
+      children = cur;
+    } else if (cur instanceof Set) {
+      children = [...cur];
+    } else if (cur instanceof Map) {
+      children = [...cur.keys(), ...cur.values()];
+    } else {
+      children = [];
+      for (const key of Object.getOwnPropertyNames(cur)) {
+        // Skip accessors — invoking a getter here could compute or throw.
+        const d = Object.getOwnPropertyDescriptor(cur, key);
+        if (d && !d.get) children.push(d.value);
+      }
+    }
+    for (const child of children) {
+      if (!child) continue;
+      const t = typeof child;
+      if (t !== "object" && t !== "function") continue;
+      if (seen.has(child)) continue;
+      seen.add(child);
+      queue.push(child);
+    }
+  }
+  return { nodes, content };
+}
+
+// A `define` block lowers to a `__def(...)` call whose argument is an
+// ObjectExpression with static keys — the exact shape that accumulated. The
+// edit target sits in a separate scene so the define chunk is carried forward
+// untouched, which is what makes its ObjectExpression a carried-forward node.
+const SOURCE = [
+  "define Portrait with",
+  "  image = 1",
+  "  offset = 2",
+  "  scale = 3",
+  "end",
+  "",
+  "define Backdrop with",
+  "  image = 4",
+  "  tint = 5",
+  "end",
+  "",
+  "scene one",
+  ":",
+  "  Action line in scene one.",
+  "-> DONE",
+  "end",
+  "",
+  "scene two",
+  ":",
+  "  Action line in scene two.",
+  "-> DONE",
+  "end",
+  "",
+].join("\n");
+
+// 0-based line of "  Action line in scene two." — the edit site.
+const EDIT_LINE = SOURCE.split("\n").indexOf(
+  "  Action line in scene two.",
+);
+
+describe("generation does not mutate the parsed hierarchy", () => {
+  it("ObjectExpression.GenerateIntoContainer is idempotent on `content`", () => {
+    const expr = new ObjectExpression([
+      new ObjectExpressionEntry("alpha", new NumberExpression(1, "int")),
+      new ObjectExpressionEntry("beta", new NumberExpression(2, "int")),
+      new ObjectExpressionEntry("gamma", new NumberExpression(3, "int")),
+    ]);
+    const initial = expr.content.length;
+
+    const emitted: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const container = new RuntimeContainer();
+      expr.GenerateIntoContainer(container);
+      emitted.push(container.content.length);
+      // The parsed node must look exactly as it did before generating.
+      expect(expr.content.length).toBe(initial);
+    }
+
+    // ...and every pass must still emit the same runtime shape, so the
+    // idempotency did not come at the cost of dropping the key expressions.
+    expect(new Set(emitted).size).toBe(1);
+    expect(emitted[0]).toBeGreaterThan(0);
+  });
+
+  it("repeated incremental compiles do not grow the parsed tree", () => {
+    const compiler = new SparkdownCompiler();
+    quiet(() => {
+      compiler.configure({
+        files: [
+          {
+            uri: URI,
+            type: "script",
+            name: "main",
+            ext: "sd",
+            text: SOURCE,
+            version: 1,
+            languageId: "sparkdown",
+          },
+        ],
+      } as never);
+      compiler.compile({ textDocument: { uri: URI } } as never);
+    });
+
+    let character = "  Action line in scene two.".length;
+    let version = 1;
+    const editAndCompile = () => {
+      version += 1;
+      quiet(() => {
+        compiler.updateDocument({
+          textDocument: { uri: URI, version },
+          contentChanges: [
+            {
+              range: {
+                start: { line: EDIT_LINE, character },
+                end: { line: EDIT_LINE, character },
+              },
+              text: "x",
+            },
+          ],
+        } as never);
+        character += 1;
+        compiler.compile({ textDocument: { uri: URI } } as never);
+      });
+    };
+
+    // Warm up so every one-time cache is populated before the baseline.
+    for (let i = 0; i < 3; i++) editAndCompile();
+    const baseline = objectExpressionContentTotal(compiler);
+    expect(baseline.nodes).toBeGreaterThan(0);
+    expect(baseline.content).toBeGreaterThan(0);
+
+    for (let i = 0; i < 8; i++) editAndCompile();
+    const after = objectExpressionContentTotal(compiler);
+
+    // Same nodes, same content: no generation was appended to the tree.
+    // Before the fix this grew by one key expression per static key per
+    // compile, without bound.
+    expect(after.nodes).toBe(baseline.nodes);
+    expect(after.content).toBe(baseline.content);
+  });
+});


### PR DESCRIPTION
Fixes #312.

## Root cause

`ObjectExpression.GenerateIntoContainer` mutated the parsed hierarchy while generating runtime objects. For every **static** key it built a fresh `StringExpression`/`Text` and `AddContent`-ed it to itself:

```ts
const keyExpr = new StringExpression([new Text(entry.key)]);
this.AddContent(keyExpr);        // permanent append, on every generation pass
keyExpr.GenerateIntoContainer(container);
```

The incremental pipeline carries parsed chunks forward across compiles *by identity* — that is the whole point of the design — so an unchanged `define` block or table literal keeps the same `ObjectExpression` node forever. Every compile therefore appended another full set of key expressions and never released the previous set.

The retained bytes came from what those accumulated nodes *pinned*, not from the nodes themselves: each `Text` caches its `_runtimeObject` (a `StringValue`) whose `.parent` points into that compile's runtime container tree, so one accumulated `Text` holds a whole superseded runtime container subtree alive. That is exactly the retaining path in the issue report:

```
Text._runtimeObject → StringValue → .parent → Container → _content[0] → ControlCommand
```

### How it was isolated

Attributing every object reachable from the compiler to its first-hop field showed **every** cache flat across iterations (`_prevCompilationIds`, `_locCache`, `_flowJsonCache`, `_prevFlowRuns`, `_reuseParentBackups`, `_lastCompileResult`, …) except the set of reused parsed flows. Narrowing to array growth then pinpointed it: a **fixed** population of 1,195 `ObjectExpression` nodes whose `content` arrays grew without bound (longest went 156 → 364 entries over 8 edits) while parsed `Knot` and `Weave` counts stayed exactly constant. So this was never whole-generation retention — it was content accumulating inside stable containers.

## The fix

Parent the key expression without adding it to `content`. The parent link is all generation needs (`debugMetadata` and `story` both walk it), and the key expression carries nothing for `ResolveReferences` to resolve — the base implementation only recurses into `content`, and `Text` has no resolve behaviour. Compiled output is unchanged, which the 86 `compileSnapshot` and 42 `expressionSnapshot` cases plus the incremental-vs-cold equivalence oracles confirm.

Keeping the node freshly built per generation pass (rather than memoising it) is deliberate: a memoised `Text` would share one `StringValue` across containers, and `Container.AddContent` re-parents, so a second generation pass would silently steal the first container's child.

## Measured (real R&B corpus: main.sd 8,309 lines / 208 KB + 10 includes)

Single-character incremental `updateDocument` + `compile` cycles, `global.gc()` forced twice before each sample:

| | before | after |
|---|---|---|
| retained per edit | **5.274 MB** | **0.006 MB** |
| heap after 30 edits | 116.3 → 274.6 MB | 98.5 → 98.7 MB |

Before, growth was dead linear with no plateau (~26.4 MB per 5 edits) — roughly 700 keystrokes to exhaust a 4 GB worker heap. After, the heap is flat.

## Tests

`packages/sparkdown/src/tests/compiler/generationTreeMutation.test.ts` pins the invariant structurally rather than by measuring heap bytes, so it is deterministic and fast:

1. `ObjectExpression.GenerateIntoContainer` is idempotent on `content` across 5 passes, and every pass still emits the same runtime shape (so idempotency did not come from dropping the key expressions).
2. Repeated incremental compiles do not grow the parsed tree — the total `content` length across all reachable `ObjectExpression`s is identical after 3 and after 11 compiles.

Both fail on `main` with the expected signature (`content` 3 → 6 after a single pass; 25 → 65 across 8 compiles) and pass with the fix.

## Verification

Full `packages/sparkdown` suite, run per-directory:

| suite | result |
|---|---|
| compiler | 539 passed (26 files) |
| incremental | 144 passed |
| runtime | 304 passed, 24 skipped |
| luau-conformance | 759 passed (70 files) |
| inkjs-utils | 37 passed |
| language-config | 11 passed |
| textmate-conformance | 2 passed |

## Adversarial review of this change

A multi-agent adversarial sweep (six lenses over the compiler/engine, each finding then put to a skeptic whose default answer is "refuted") found **no correctness regression in this change**. Two unrelated unbounded leaks it did surface are confirmed but out of scope here, and are filed separately:

- `profile()` writes `performance.mark`/`measure` entries that nothing ever clears. Measured 34 marks + 17 measures per edit, ~0.035 MB/edit. Live in the shipped web player and the VS Code extension, both of which pass a hardcoded `profilerId`.
- `FormattingAnnotator`'s zero-width `top_level_begin` mark is anchored at a top-level block's START, so it falls outside the incremental re-annotation delete-window and is re-added without being removed. Measured exactly 1 duplicate annotation per keystroke, unbounded, in the language-server / VS Code annotate set.

Neither is the OOM in #312, and neither is affected by this diff.

## A related site that is NOT a leak

`FunctionCall.GenerateIntoContainer` re-`AddContent`s the same `DivertTarget`/`VariableReference` arg on every generation pass (lines 127/132), which looks like the same defect. It is not. The add is paired with `this.content.splice(this.content.indexOf(this._proxyDivert), 1)` at line 265; after the first pass removes `_proxyDivert`, `indexOf` returns `-1` and `splice(-1, 1)` drops the LAST element — the arg just added. Net `content` length is stable, so nothing accumulates.

That pairing is accidental rather than designed. Guarding the add so the arg is only added once makes the splice eat real content instead, which is why `incrementalStaleTargetPaths` fails with 2 divergences if you try it. Worth cleaning up on its own, but it is not a memory issue and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
