### PR TITLE
feat(sparkdown): binary compiled-program format, opt-in (#314)

### DIFF
--- a/packages/spark-engine/src/game/core/classes/BinaryProgramTransport.test.ts
+++ b/packages/spark-engine/src/game/core/classes/BinaryProgramTransport.test.ts
@@ -1,0 +1,124 @@
+import { SparkdownCompiler } from "@impower/sparkdown/src/compiler/classes/SparkdownCompiler";
+import { describe, expect, it } from "vitest";
+import { Game } from "./Game";
+
+/**
+ * #314 phase 3: the compiled program travels to the runtime as binary buffer
+ * PIECES instead of a JS object graph.
+ *
+ * The hop that matters is the `compiler/compile` response from the compiler
+ * worker to its host, which is a structured clone over a MessagePort. So these
+ * tests clone the program before using it — a test that skipped the clone
+ * would pass even if the buffer were something structured clone cannot carry,
+ * which is the whole risk of changing what crosses that boundary.
+ */
+
+const SOURCE = [
+  "title: Transport",
+  "",
+  "define hero as character:",
+  `  name = "Hero"`,
+  "",
+  "const LIMIT = 3",
+  "store trust = 0",
+  "",
+  "First beat with {trust} and {LIMIT}.",
+  "",
+  "hero:",
+  "  A line of dialogue.",
+  "",
+  "Second beat.",
+  "",
+].join("\n");
+
+const compile = (source: string, binaryProgram: boolean) => {
+  const uri = "inmemory:///main.sd";
+  const compiler = new SparkdownCompiler();
+  compiler.configure({
+    binaryProgram,
+    files: [
+      {
+        uri,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text: source,
+        version: 1,
+        languageId: "sparkdown",
+      },
+    ],
+  } as never);
+  return compiler.compile({ textDocument: { uri } } as never).program;
+};
+
+/** Same system wiring the other engine suites use; Game requires it to run. */
+const makeGame = (program: unknown) =>
+  new Game({
+    program,
+    now: () => 0,
+    setTimeout: (handler: Function) => {
+      handler();
+      return 0;
+    },
+  } as never);
+
+describe("binary program transport (#314 phase 3)", () => {
+  it("survives the structured clone that crosses the worker boundary", () => {
+    const program = compile(SOURCE, true) as any;
+    expect(program.compiledBuffer, "binary path must be on").toBeTruthy();
+    expect(program.compiled).toBeUndefined();
+
+    const relayed = structuredClone(program);
+    // Typed arrays and the string table are exactly what makes this cheap:
+    // structured clone copies them as buffers rather than walking ~33k nodes.
+    expect(ArrayBuffer.isView(relayed.compiledBuffer.nodes)).toBe(true);
+    expect(relayed.compiledBuffer.nodes.length).toBe(
+      program.compiledBuffer.nodes.length,
+    );
+    expect(relayed.compiledBuffer.strings.length).toBe(
+      program.compiledBuffer.strings.length,
+    );
+    expect(ArrayBuffer.isView(relayed.compiledBuffer.numbers)).toBe(true);
+  });
+
+  it("builds a runnable Game from the relayed buffer alone", () => {
+    const relayed = structuredClone(compile(SOURCE, true)) as any;
+    const emitted: string[] = [];
+    const game = makeGame(relayed);
+    game.connection.outgoing.addListener("*", (message) => {
+      emitted.push((message as { method: string }).method);
+    });
+    expect(game.story).toBeTruthy();
+    // Not merely constructed: it has to actually run and emit flow events.
+    game.start();
+    expect(emitted).toContain("game/started");
+  });
+
+  it("produces the same story as the JSON path", () => {
+    // The gate. If the two paths ever diverge, the JSON fallback stops being a
+    // fallback and starts being a different program.
+    const viaJson = compile(SOURCE, false) as any;
+    const viaBinary = structuredClone(compile(SOURCE, true)) as any;
+
+    const jsonGame = makeGame(viaJson);
+    const binaryGame = makeGame(viaBinary);
+
+    const drain = (game: Game) => {
+      const out: string[] = [];
+      for (let i = 0; i < 20 && game.story.canContinue; i += 1) {
+        out.push(game.story.Continue() ?? "");
+      }
+      return out;
+    };
+    expect(drain(binaryGame)).toEqual(drain(jsonGame));
+  });
+
+  it("rejects a program with neither representation", () => {
+    // The readiness gates were `Boolean(program.compiled)` before #314; if any
+    // were missed, a binary program reads as "not compiled" — so the negative
+    // case has to stay a hard failure rather than silently degrade.
+    const program = compile(SOURCE, false) as any;
+    delete program.compiled;
+    expect(() => makeGame(program)).toThrow(/must be successfully compiled/);
+  });
+});

--- a/packages/spark-engine/src/game/core/classes/Game.ts
+++ b/packages/spark-engine/src/game/core/classes/Game.ts
@@ -3,6 +3,7 @@ import { NotificationMessage } from "@impower/jsonrpc/src/common/types/Notificat
 import { RequestMessage } from "@impower/jsonrpc/src/common/types/RequestMessage";
 import { ResponseError } from "@impower/jsonrpc/src/common/types/ResponseError";
 import { type SparkProgram } from "@impower/sparkdown/src/compiler/types/SparkProgram";
+import { resolveCompiledProgram } from "@impower/sparkdown/src/binary/programBinary";
 import {
   buildRouteSimulator,
   planRoute,
@@ -329,7 +330,10 @@ export class Game<T extends M = {}> {
 
   updateProgram(program: SparkProgram, story?: Story) {
     this._program = program;
-    if (!story && !this._program.compiled) {
+    // Resolved ONCE: with the binary path (#314) this materializes the buffer,
+    // so testing it repeatedly would re-walk the whole program.
+    const compiled = story ? undefined : resolveCompiledProgram(program);
+    if (!story && !compiled) {
       throw new Error(
         "Program must be successfully compiled before it can be run",
       );
@@ -341,8 +345,8 @@ export class Game<T extends M = {}> {
 
     if (story) {
       this._story = story;
-    } else if (program.compiled) {
-      this._story = new Story(program.compiled);
+    } else if (compiled) {
+      this._story = new Story(compiled);
     }
     this.setupStory(this._story);
     return this._program;

--- a/packages/spark-engine/src/worker/installGameWorker.ts
+++ b/packages/spark-engine/src/worker/installGameWorker.ts
@@ -1,3 +1,4 @@
+import { hasCompiledProgram } from "@impower/sparkdown/src/binary/programBinary";
 import { MessageConnection } from "@impower/jsonrpc/src/browser/classes/MessageConnection";
 import { Message } from "@impower/jsonrpc/src/common/types/Message";
 import { ResponseError } from "@impower/jsonrpc/src/common/types/ResponseError";
@@ -166,7 +167,7 @@ export function installGameWorker(connection: MessageConnection) {
           throw new NoGameError();
         }
         state.game.start();
-        return { success: Boolean(state.game.program.compiled) };
+        return { success: hasCompiledProgram(state.game.program) };
       });
       return;
     }

--- a/packages/spark-web-player/src/GamePlayerController.ts
+++ b/packages/spark-web-player/src/GamePlayerController.ts
@@ -1,3 +1,4 @@
+import { hasCompiledProgram } from "@impower/sparkdown/src/binary/programBinary";
 import {
   ProtocolObserver,
   sendProtocolMessage,
@@ -795,7 +796,7 @@ export class GamePlayerController {
       ? StartGameMessage.type.response(message.id, { success })
       : StartGameMessage.type.error(message.id, {
           code: 1,
-          message: !this._program?.compiled
+          message: !hasCompiledProgram(this._program)
             ? "The program contains errors that prevent it from being compiled"
             : `The game could not be started`,
         });
@@ -1011,7 +1012,7 @@ export class GamePlayerController {
 
   loadProgram = conflate(
     async (program: SparkProgram, checkpoint: string | undefined) => {
-      if (!program.compiled) {
+      if (!hasCompiledProgram(program)) {
         console.error("Program not compiled", program);
         return;
       }
@@ -1061,7 +1062,7 @@ export class GamePlayerController {
     this.simulate(this._game, this._options?.simulationOptions);
     this.listen(this._game);
     this._app = await this.buildApp(this._game);
-    const programCompiled = Boolean(this._program?.compiled);
+    const programCompiled = hasCompiledProgram(this._program);
     this._game?.start();
     if (programCompiled) {
       this._app?.start();

--- a/packages/sparkdown/src/binary/ProgramBinaryWriter.ts
+++ b/packages/sparkdown/src/binary/ProgramBinaryWriter.ts
@@ -1,0 +1,481 @@
+/**
+ * A `SimpleJson.Writer`-shaped writer that emits the binary program format
+ * directly (#314 phase 2).
+ *
+ * `Story.ToJson` drives a streaming, SAX-style writer: `WriteObjectStart`,
+ * `WritePropertyStart`, `Write`, `WriteArrayEnd` and friends. `SimpleJson.Writer`
+ * happens to answer those events by building a JS object tree, which is then
+ * stringified. Answering the SAME events by appending `[tag, value, end]`
+ * records skips the object tree entirely — so on the path where no flow memo is
+ * in play, this does strictly LESS work than the JSON path, not more.
+ *
+ * ## Why this exists rather than encoding the finished JSON
+ *
+ * Encoding `writer.toObject()` after the fact means building the tree AND
+ * walking it again; measured, that walk is ~9ms of a ~10.6ms encode on the
+ * raffles-and-bunny corpus. Consuming the write events removes the second walk
+ * and the tree.
+ *
+ * ## Per-flow chunk reuse
+ *
+ * `JsonSerialisation.WriteRuntimeContainer` consults a per-flow memo and splices
+ * the result via `WriteInjected`. That is the seam the incremental `ToJson`
+ * cache already uses. Here `WriteInjected` accepts either:
+ *
+ *  - a {@link ProgramChunk} — a previously serialized flow, spliced in as raw
+ *    records with its indices remapped, no re-serialization; or
+ *  - any plain JS value — encoded inline (the memo-miss path, where the engine
+ *    hands back a freshly built JS subtree).
+ *
+ * Chunks store LOCAL string/number tables and chunk-relative `end` offsets, so
+ * a chunk is portable across compiles even though the assembled program keeps
+ * one compact global table. Splicing remaps a chunk's indices into the global
+ * tables: that is O(chunk nodes) integer work (~0.1-0.3ms for the whole
+ * program), against ~9ms to re-walk the runtime tree and re-hash its strings.
+ */
+import {
+  NODE_WIDTH,
+  ProgramNodeTag,
+  type ProgramBuffer,
+} from "./programBinary";
+
+/**
+ * A serialized top-level flow, portable across compiles.
+ *
+ * Indices are LOCAL: `value` indexes this chunk's own tables and `end` is
+ * relative to the chunk's first record. That is what lets a chunk outlive the
+ * program it was produced for — the global tables it was originally interned
+ * against will have been rebuilt by the next compile.
+ */
+export interface ProgramChunk {
+  readonly nodes: Uint32Array;
+  readonly strings: readonly string[];
+  readonly numbers: Float64Array;
+}
+
+/** A chunk plus the fingerprint it was valid for. */
+export interface CachedFlowChunk {
+  readonly fp: string;
+  readonly chunk: ProgramChunk;
+}
+
+export class ProgramBinaryWriter {
+  private _nodes: number[] = [];
+  private _strings: string[] = [];
+  private _stringIds = new Map<string, number>();
+  private _numbers: number[] = [];
+  private _numberIds = new Map<number, number>();
+  /** Indices of records whose `end` is still unpatched, innermost last. */
+  private _open: number[] = [];
+  private _widest = 0;
+  private _currentString: string | null = null;
+  private _currentPropertyName: string | null = null;
+  /** Armed by `captureNextInjectedAs`; consumed by the next `WriteInjected`. */
+  private _pendingCapture: { name: string; fp: string } | null = null;
+  private _captured = new Map<string, CachedFlowChunk>();
+
+  // ---------------------------------------------------------------- interning
+
+  private _intern(text: string): number {
+    let id = this._stringIds.get(text);
+    if (id === undefined) {
+      id = this._strings.length;
+      this._strings.push(text);
+      this._stringIds.set(text, id);
+    }
+    return id;
+  }
+
+  private _internNumber(n: number): number {
+    let id = this._numberIds.get(n);
+    if (id === undefined) {
+      id = this._numbers.length;
+      this._numbers.push(n);
+      this._numberIds.set(n, id);
+    }
+    return id;
+  }
+
+  // ------------------------------------------------------------------ records
+
+  /** Append a record, returning its index in RECORDS (not slots). */
+  private _emit(tag: ProgramNodeTag, value: number): number {
+    const index = this._nodes.length / NODE_WIDTH;
+    this._nodes.push(tag, value, 0);
+    if (value > this._widest) {
+      this._widest = value;
+    }
+    return index;
+  }
+
+  /** Patch a record's `end` to the current write head. */
+  private _close(index: number): void {
+    const end = this._nodes.length / NODE_WIDTH;
+    this._nodes[index * NODE_WIDTH + 2] = end;
+    if (end > this._widest) {
+      this._widest = end;
+    }
+  }
+
+  /** A leaf: opens and closes in one step. */
+  private _leaf(tag: ProgramNodeTag, value: number): void {
+    this._close(this._emit(tag, value));
+  }
+
+  // ------------------------------------------------- SimpleJson.Writer surface
+
+  WriteObjectStart(): void {
+    this._open.push(this._emit(ProgramNodeTag.Object, 0));
+  }
+
+  WriteObjectEnd(): void {
+    this._close(this._open.pop()!);
+  }
+
+  WriteArrayStart(): void {
+    this._open.push(this._emit(ProgramNodeTag.Array, 0));
+  }
+
+  WriteArrayEnd(): void {
+    this._close(this._open.pop()!);
+  }
+
+  WriteObject(inner: (w: ProgramBinaryWriter) => void): void {
+    this.WriteObjectStart();
+    inner(this);
+    this.WriteObjectEnd();
+  }
+
+  WritePropertyStart(name: string): void {
+    this._open.push(this._emit(ProgramNodeTag.Member, this._intern(String(name))));
+  }
+
+  WritePropertyEnd(): void {
+    const index = this._open.pop()!;
+    // A Member must have exactly one child. `WriteInt`/`WriteFloat`/`WriteBool`
+    // write NOTHING when handed null (mirroring SimpleJson), which would
+    // otherwise leave a childless Member and a structurally invalid buffer.
+    if (this._nodes.length / NODE_WIDTH === index + 1) {
+      this._leaf(ProgramNodeTag.Null, 0);
+    }
+    this._close(index);
+  }
+
+  WriteProperty(
+    name: string,
+    innerOrContent: ((w: ProgramBinaryWriter) => void) | string | boolean | null,
+  ): void {
+    this.WritePropertyStart(name);
+    if (typeof innerOrContent === "function") {
+      innerOrContent(this);
+    } else {
+      this.Write(innerOrContent);
+    }
+    this.WritePropertyEnd();
+  }
+
+  WriteIntProperty(name: string, content: number): void {
+    this.WritePropertyStart(name);
+    this.WriteInt(content);
+    this.WritePropertyEnd();
+  }
+
+  WriteFloatProperty(name: string, content: number): void {
+    this.WritePropertyStart(name);
+    this.WriteFloat(content);
+    this.WritePropertyEnd();
+  }
+
+  WritePropertyNameStart(): void {
+    this._currentPropertyName = "";
+  }
+
+  WritePropertyNameInner(str: string): void {
+    this._currentPropertyName += str;
+  }
+
+  WritePropertyNameEnd(): void {
+    this._open.push(
+      this._emit(ProgramNodeTag.Member, this._intern(this._currentPropertyName!)),
+    );
+    this._currentPropertyName = null;
+  }
+
+  Write(value: number | string | boolean | null): void {
+    if (value === null || value === undefined) {
+      this._leaf(ProgramNodeTag.Null, 0);
+    } else if (typeof value === "string") {
+      this._leaf(ProgramNodeTag.String, this._intern(value));
+    } else if (typeof value === "boolean") {
+      this._leaf(value ? ProgramNodeTag.True : ProgramNodeTag.False, 0);
+    } else {
+      this._leaf(ProgramNodeTag.Number, this._internNumber(value));
+    }
+  }
+
+  WriteBool(value: boolean | null): void {
+    if (value === null) {
+      return; // SimpleJson writes nothing for null; see WritePropertyEnd.
+    }
+    this._leaf(value ? ProgramNodeTag.True : ProgramNodeTag.False, 0);
+  }
+
+  WriteInt(value: number | null): void {
+    if (value === null) {
+      return;
+    }
+    // Math.floor mirrors SimpleJson exactly: it guarantees savegame
+    // compatibility with the reference implementation, so the binary path must
+    // not quietly preserve a fractional part the JSON path would drop.
+    this._leaf(ProgramNodeTag.Number, this._internNumber(Math.floor(value)));
+  }
+
+  WriteFloat(value: number | null): void {
+    if (value === null) {
+      return;
+    }
+    // These string markers are load-bearing, not cosmetic: JSON cannot carry
+    // Infinity/NaN, and a whole-number float has to survive as `"3.0f"` or the
+    // loader recovers it as an IntValue and `7 / 3.0` degrades to integer
+    // division. Kept byte-for-byte identical to SimpleJson.Writer.WriteFloat.
+    if (value === Number.POSITIVE_INFINITY) {
+      this._leaf(ProgramNodeTag.String, this._intern("inff"));
+    } else if (value === Number.NEGATIVE_INFINITY) {
+      this._leaf(ProgramNodeTag.String, this._intern("-inff"));
+    } else if (isNaN(value)) {
+      this._leaf(ProgramNodeTag.String, this._intern("nanf"));
+    } else if (Number.isInteger(value)) {
+      const repr = value.toString();
+      this._leaf(
+        ProgramNodeTag.String,
+        this._intern(repr.includes("e") ? `${repr}f` : `${repr}.0f`),
+      );
+    } else {
+      this._leaf(ProgramNodeTag.Number, this._internNumber(value));
+    }
+  }
+
+  WriteNull(): void {
+    this._leaf(ProgramNodeTag.Null, 0);
+  }
+
+  WriteStringStart(): void {
+    this._currentString = "";
+  }
+
+  WriteStringInner(str: string | null): void {
+    if (str === null) {
+      return;
+    }
+    this._currentString += str;
+  }
+
+  WriteStringEnd(): void {
+    this._leaf(ProgramNodeTag.String, this._intern(this._currentString!));
+    this._currentString = null;
+  }
+
+  /**
+   * Inject a pre-built value as a property of the CURRENT object.
+   *
+   * `SimpleJson.Writer.InjectObject` assigns into the root object rather than
+   * the current collection. `Story.ToJson` only calls it while the root object
+   * is the current collection (for `constants` and `structDefs`), so writing a
+   * property here is equivalent — and preserves the same key order, which the
+   * byte-identity test depends on.
+   */
+  InjectObject(name: string, obj: unknown): void {
+    this.WritePropertyStart(name);
+    this._writeValue(obj);
+    this.WritePropertyEnd();
+  }
+
+  /**
+   * Splice a cached flow chunk, or encode a plain JS value inline.
+   *
+   * The chunk path is the point of phase 2: an unchanged flow costs a remap of
+   * its records rather than a re-walk of the runtime tree.
+   */
+  WriteInjected(value: unknown): void {
+    const pending = this._pendingCapture;
+    const start = pending ? this.mark() : 0;
+    if (isProgramChunk(value)) {
+      this._spliceChunk(value);
+    } else {
+      this._writeValue(value);
+    }
+    if (pending) {
+      this._pendingCapture = null;
+      this._captured.set(pending.name, {
+        fp: pending.fp,
+        chunk: this.captureChunk(start),
+      });
+    }
+  }
+
+  /**
+   * Capture the next injected value as flow `name`'s chunk.
+   *
+   * The flow memo's `resolve` runs BEFORE the caller injects what it returned,
+   * so a memo cannot capture the resulting record range itself. It arms the
+   * capture here instead, and collects the results afterwards via
+   * {@link takeCapturedChunks}.
+   */
+  captureNextInjectedAs(name: string, fp: string): void {
+    this._pendingCapture = { name, fp };
+  }
+
+  /** Chunks captured during this serialization, keyed by flow name. */
+  takeCapturedChunks(): Map<string, CachedFlowChunk> {
+    const captured = this._captured;
+    this._captured = new Map();
+    return captured;
+  }
+
+  // ------------------------------------------------------- inline JS encoding
+
+  /** Encode a plain JS value as a subtree (the memo-miss path). */
+  private _writeValue(value: unknown): void {
+    if (value === null || value === undefined) {
+      this._leaf(ProgramNodeTag.Null, 0);
+    } else if (value === true) {
+      this._leaf(ProgramNodeTag.True, 0);
+    } else if (value === false) {
+      this._leaf(ProgramNodeTag.False, 0);
+    } else if (typeof value === "number") {
+      this._leaf(ProgramNodeTag.Number, this._internNumber(value));
+    } else if (typeof value === "string") {
+      this._leaf(ProgramNodeTag.String, this._intern(value));
+    } else if (Array.isArray(value)) {
+      const index = this._emit(ProgramNodeTag.Array, 0);
+      for (const item of value) {
+        this._writeValue(item);
+      }
+      this._close(index);
+    } else {
+      const record = value as Record<string, unknown>;
+      const keys = Object.keys(record);
+      const index = this._emit(ProgramNodeTag.Object, 0);
+      for (let i = 0; i < keys.length; i += 1) {
+        const key = keys[i]!;
+        const member = this._emit(ProgramNodeTag.Member, this._intern(key));
+        this._writeValue(record[key]);
+        this._close(member);
+      }
+      this._close(index);
+    }
+  }
+
+  // ------------------------------------------------------------------- chunks
+
+  /** Node index the next written value will start at. */
+  mark(): number {
+    return this._nodes.length / NODE_WIDTH;
+  }
+
+  /**
+   * Capture the records written since `start` as a portable chunk.
+   *
+   * Rewrites into LOCAL tables and chunk-relative `end` offsets, so the chunk
+   * survives into a later compile whose global tables are interned differently.
+   */
+  captureChunk(start: number): ProgramChunk {
+    const end = this._nodes.length / NODE_WIDTH;
+    const count = end - start;
+    const nodes = new Uint32Array(count * NODE_WIDTH);
+    const strings: string[] = [];
+    const stringRemap = new Map<number, number>();
+    const numbers: number[] = [];
+    const numberRemap = new Map<number, number>();
+
+    for (let i = 0; i < count; i += 1) {
+      const src = (start + i) * NODE_WIDTH;
+      const dst = i * NODE_WIDTH;
+      const tag = this._nodes[src]! as ProgramNodeTag;
+      const value = this._nodes[src + 1]!;
+      nodes[dst] = tag;
+      if (tag === ProgramNodeTag.String || tag === ProgramNodeTag.Member) {
+        let local = stringRemap.get(value);
+        if (local === undefined) {
+          local = strings.length;
+          strings.push(this._strings[value]!);
+          stringRemap.set(value, local);
+        }
+        nodes[dst + 1] = local;
+      } else if (tag === ProgramNodeTag.Number) {
+        let local = numberRemap.get(value);
+        if (local === undefined) {
+          local = numbers.length;
+          numbers.push(this._numbers[value]!);
+          numberRemap.set(value, local);
+        }
+        nodes[dst + 1] = local;
+      } else {
+        nodes[dst + 1] = value;
+      }
+      nodes[dst + 2] = this._nodes[src + 2]! - start;
+    }
+
+    return { nodes, strings, numbers: Float64Array.from(numbers) };
+  }
+
+  /** Append a chunk's records, remapping its local indices into ours. */
+  private _spliceChunk(chunk: ProgramChunk): void {
+    const base = this._nodes.length / NODE_WIDTH;
+    const stringBase: number[] = new Array(chunk.strings.length);
+    for (let i = 0; i < chunk.strings.length; i += 1) {
+      stringBase[i] = this._intern(chunk.strings[i]!);
+    }
+    const numberBase: number[] = new Array(chunk.numbers.length);
+    for (let i = 0; i < chunk.numbers.length; i += 1) {
+      numberBase[i] = this._internNumber(chunk.numbers[i]!);
+    }
+    const src = chunk.nodes;
+    const count = src.length / NODE_WIDTH;
+    for (let i = 0; i < count; i += 1) {
+      const o = i * NODE_WIDTH;
+      const tag = src[o]! as ProgramNodeTag;
+      const value = src[o + 1]!;
+      const mapped =
+        tag === ProgramNodeTag.String || tag === ProgramNodeTag.Member
+          ? stringBase[value]!
+          : tag === ProgramNodeTag.Number
+            ? numberBase[value]!
+            : value;
+      const end = src[o + 2]! + base;
+      this._nodes.push(tag, mapped, end);
+      if (mapped > this._widest) {
+        this._widest = mapped;
+      }
+      if (end > this._widest) {
+        this._widest = end;
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------- output
+
+  /** The assembled buffer. */
+  toBuffer(): ProgramBuffer {
+    return {
+      nodes:
+        this._widest <= 0xffff
+          ? Uint16Array.from(this._nodes)
+          : Uint32Array.from(this._nodes),
+      strings: this._strings,
+      numbers: Float64Array.from(this._numbers),
+    };
+  }
+}
+
+/**
+ * Structural test rather than an instanceof/brand check, because a chunk may
+ * arrive from a previous compile (and, later, across a worker boundary) where
+ * class identity does not survive.
+ */
+export const isProgramChunk = (value: unknown): value is ProgramChunk =>
+  !!value &&
+  typeof value === "object" &&
+  (value as ProgramChunk).nodes instanceof Uint32Array &&
+  Array.isArray((value as ProgramChunk).strings) &&
+  (value as ProgramChunk).numbers instanceof Float64Array;

--- a/packages/sparkdown/src/binary/ProgramBinaryWriter.ts
+++ b/packages/sparkdown/src/binary/ProgramBinaryWriter.ts
@@ -346,7 +346,18 @@ export class ProgramBinaryWriter {
   WriteInjected(value: unknown): void {
     const pending = this._pendingCapture;
     const start = pending ? this.mark() : 0;
-    if (this._isUsableChunk(value)) {
+    if (isProgramChunk(value)) {
+      if (value.generation !== this._table.generation) {
+        // There is no correct recovery here: the caller returned this chunk
+        // INSTEAD of calling serialize(), so the real content is no longer
+        // reachable. Encoding it as a plain value would silently write
+        // `{nodes, generation}` into the program as data — which is precisely
+        // the corruption `generation` exists to prevent. Callers must check
+        // the generation before handing a chunk over.
+        throw new Error(
+          `Stale program chunk: minted for table generation ${value.generation}, writer is on ${this._table.generation}.`,
+        );
+      }
       this._spliceChunk(value);
     } else {
       this._writeValue(value);
@@ -379,11 +390,9 @@ export class ProgramBinaryWriter {
     return captured;
   }
 
-  /** True if `value` is a chunk minted against THIS table's generation. */
-  private _isUsableChunk(value: unknown): value is ProgramChunk {
-    return (
-      isProgramChunk(value) && value.generation === this._table.generation
-    );
+  /** The table generation a chunk must carry to be splice-able here. */
+  get generation(): number {
+    return this._table.generation;
   }
 
   // ------------------------------------------------------- inline JS encoding

--- a/packages/sparkdown/src/binary/ProgramBinaryWriter.ts
+++ b/packages/sparkdown/src/binary/ProgramBinaryWriter.ts
@@ -80,6 +80,14 @@ export const reseedProgramTable = (table: ProgramTable): void => {
  */
 export interface ProgramChunk {
   readonly nodes: Uint32Array;
+  /**
+   * Largest payload/size slot in this chunk, recorded at capture.
+   *
+   * Splicing needs it to keep the buffer's slot-width decision correct, and
+   * caching it here is what keeps splice a pure memcpy rather than a memcpy
+   * plus a rescan of every record.
+   */
+  readonly widest: number;
   readonly generation: number;
 }
 
@@ -90,7 +98,9 @@ export interface CachedFlowChunk {
 }
 
 export class ProgramBinaryWriter {
-  private _nodes: number[] = [];
+  private _nodes: Uint32Array;
+  /** Slots written so far (NOT records, and not the array's capacity). */
+  private _length = 0;
   private _table: ProgramTable;
   /** Indices of records whose `size` is still unpatched, innermost last. */
   private _open: number[] = [];
@@ -101,14 +111,29 @@ export class ProgramBinaryWriter {
   private _pendingCapture: { name: string; fp: string } | null = null;
   private _captured = new Map<string, CachedFlowChunk>();
 
-  constructor(table: ProgramTable = createProgramTable()) {
+  constructor(table: ProgramTable = createProgramTable(), hint = 0) {
     this._table = table;
     // Ids already in the table stay valid, so the widest existing pointer is a
     // lower bound on the slot width this buffer needs.
-    this._widest = Math.max(
-      table.strings.length,
-      table.numbers.length,
-    );
+    this._widest = Math.max(table.strings.length, table.numbers.length);
+    // Sizing from the previous compile avoids most regrowth: the program is
+    // nearly the same size every keystroke.
+    this._nodes = new Uint32Array(Math.max(hint, 1024));
+  }
+
+  /** Ensure room for `slots` more, growing geometrically. */
+  private _ensure(slots: number): void {
+    const needed = this._length + slots;
+    if (needed <= this._nodes.length) {
+      return;
+    }
+    let capacity = this._nodes.length * 2;
+    while (capacity < needed) {
+      capacity *= 2;
+    }
+    const grown = new Uint32Array(capacity);
+    grown.set(this._nodes.subarray(0, this._length));
+    this._nodes = grown;
   }
 
   // ---------------------------------------------------------------- interning
@@ -145,14 +170,19 @@ export class ProgramBinaryWriter {
 
   /** Append a record, returning its index in RECORDS (not slots). */
   private _emit(tag: ProgramNodeTag, value: number): number {
-    const index = this._nodes.length / NODE_WIDTH;
-    this._nodes.push(tag, value, 0);
-    return index;
+    this._ensure(NODE_WIDTH);
+    const at = this._length;
+    const nodes = this._nodes;
+    nodes[at] = tag;
+    nodes[at + 1] = value;
+    nodes[at + 2] = 0;
+    this._length = at + NODE_WIDTH;
+    return at / NODE_WIDTH;
   }
 
   /** Patch a record's subtree SIZE, in records, including itself. */
   private _close(index: number): void {
-    const size = this._nodes.length / NODE_WIDTH - index;
+    const size = this._length / NODE_WIDTH - index;
     this._nodes[index * NODE_WIDTH + 2] = size;
     if (size > this._widest) {
       this._widest = size;
@@ -161,7 +191,13 @@ export class ProgramBinaryWriter {
 
   /** A leaf: opens and closes in one step. */
   private _leaf(tag: ProgramNodeTag, value: number): void {
-    this._nodes.push(tag, value, 1);
+    this._ensure(NODE_WIDTH);
+    const at = this._length;
+    const nodes = this._nodes;
+    nodes[at] = tag;
+    nodes[at + 1] = value;
+    nodes[at + 2] = 1;
+    this._length = at + NODE_WIDTH;
   }
 
   // ------------------------------------------------- SimpleJson.Writer surface
@@ -199,7 +235,7 @@ export class ProgramBinaryWriter {
     // A Member must have exactly one child. `WriteInt`/`WriteFloat`/`WriteBool`
     // write NOTHING when handed null (mirroring SimpleJson), which would
     // otherwise leave a childless Member and a structurally invalid buffer.
-    if (this._nodes.length / NODE_WIDTH === index + 1) {
+    if (this._length / NODE_WIDTH === index + 1) {
       this._leaf(ProgramNodeTag.Null, 0);
     }
     this._close(index);
@@ -433,7 +469,7 @@ export class ProgramBinaryWriter {
 
   /** Node index the next written value will start at. */
   mark(): number {
-    return this._nodes.length / NODE_WIDTH;
+    return this._length / NODE_WIDTH;
   }
 
   /**
@@ -443,32 +479,35 @@ export class ProgramBinaryWriter {
    * for as long as the shared table keeps this generation.
    */
   captureChunk(start: number): ProgramChunk {
-    const from = start * NODE_WIDTH;
-    const nodes = new Uint32Array(this._nodes.length - from);
-    for (let i = 0; i < nodes.length; i += 1) {
-      nodes[i] = this._nodes[from + i]!;
+    // A typed-array slice: one bulk copy, not a per-element loop.
+    const nodes = this._nodes.slice(start * NODE_WIDTH, this._length);
+    let widest = 0;
+    for (let i = 0; i < nodes.length; i += NODE_WIDTH) {
+      const payload = nodes[i + 1]!;
+      const size = nodes[i + 2]!;
+      if (payload > widest) {
+        widest = payload;
+      }
+      if (size > widest) {
+        widest = size;
+      }
     }
-    return { nodes, generation: this._table.generation };
+    // Recorded at capture so splicing does not have to rescan the chunk; the
+    // values are position-independent, so this stays valid for its lifetime.
+    return { nodes, widest, generation: this._table.generation };
   }
 
   /** Append a chunk's records verbatim. */
   private _spliceChunk(chunk: ProgramChunk): void {
     const src = chunk.nodes;
-    for (let i = 0; i < src.length; i += 1) {
-      this._nodes.push(src[i]!);
-    }
-    // Sizes are relative and pointers are table-global, so nothing inside the
-    // chunk needs rewriting. Only the width tracker has to notice the chunk's
-    // largest slot; the tags themselves are always < 8.
-    for (let i = 0; i < src.length; i += NODE_WIDTH) {
-      const payload = src[i + 1]!;
-      const size = src[i + 2]!;
-      if (payload > this._widest) {
-        this._widest = payload;
-      }
-      if (size > this._widest) {
-        this._widest = size;
-      }
+    this._ensure(src.length);
+    // The whole point of relocatable records: sizes are relative and payload
+    // pointers are table-global, so an unchanged flow is a bulk memcpy with no
+    // per-node rewriting and no rescan.
+    this._nodes.set(src, this._length);
+    this._length += src.length;
+    if (chunk.widest > this._widest) {
+      this._widest = chunk.widest;
     }
   }
 
@@ -477,10 +516,12 @@ export class ProgramBinaryWriter {
   /** The assembled buffer. */
   toBuffer(): ProgramBuffer {
     return {
+      // subarray, not the whole capacity: the array is grown geometrically so
+      // its tail is unwritten slack.
       nodes:
         this._widest <= 0xffff
-          ? Uint16Array.from(this._nodes)
-          : Uint32Array.from(this._nodes),
+          ? Uint16Array.from(this._nodes.subarray(0, this._length))
+          : this._nodes.slice(0, this._length),
       strings: this._table.strings,
       numbers: Float64Array.from(this._table.numbers),
     };
@@ -495,4 +536,5 @@ export const isProgramChunk = (value: unknown): value is ProgramChunk =>
   !!value &&
   typeof value === "object" &&
   (value as ProgramChunk).nodes instanceof Uint32Array &&
+  typeof (value as ProgramChunk).widest === "number" &&
   typeof (value as ProgramChunk).generation === "number";

--- a/packages/sparkdown/src/binary/ProgramBinaryWriter.ts
+++ b/packages/sparkdown/src/binary/ProgramBinaryWriter.ts
@@ -5,33 +5,28 @@
  * `Story.ToJson` drives a streaming, SAX-style writer: `WriteObjectStart`,
  * `WritePropertyStart`, `Write`, `WriteArrayEnd` and friends. `SimpleJson.Writer`
  * happens to answer those events by building a JS object tree, which is then
- * stringified. Answering the SAME events by appending `[tag, value, end]`
- * records skips the object tree entirely — so on the path where no flow memo is
- * in play, this does strictly LESS work than the JSON path, not more.
+ * stringified. Answering the SAME events by appending `[tag, payload, size]`
+ * records skips the object tree entirely.
  *
- * ## Why this exists rather than encoding the finished JSON
+ * ## Why a cached flow is a plain record copy
  *
- * Encoding `writer.toObject()` after the fact means building the tree AND
- * walking it again; measured, that walk is ~9ms of a ~10.6ms encode on the
- * raffles-and-bunny corpus. Consuming the write events removes the second walk
- * and the tree.
+ * Both of a record's non-tag slots are deliberately position-INDEPENDENT, which
+ * is what lezer does and what makes its subtrees relocatable:
  *
- * ## Per-flow chunk reuse
+ *  - `size` is lezer's fourth value — the records this node and its descendants
+ *    occupy. Intrinsic to the node, unlike an end index, so moving a subtree
+ *    rewrites nothing inside it.
+ *  - `payload` points into a string/number table that PERSISTS across compiles
+ *    (see {@link ProgramTable}), the analogue of lezer's grammar-fixed
+ *    `NodeSet`. A table rebuilt per compile would make every pointer stale and
+ *    force a remap pass over every reused record.
  *
- * `JsonSerialisation.WriteRuntimeContainer` consults a per-flow memo and splices
- * the result via `WriteInjected`. That is the seam the incremental `ToJson`
- * cache already uses. Here `WriteInjected` accepts either:
- *
- *  - a {@link ProgramChunk} — a previously serialized flow, spliced in as raw
- *    records with its indices remapped, no re-serialization; or
- *  - any plain JS value — encoded inline (the memo-miss path, where the engine
- *    hands back a freshly built JS subtree).
- *
- * Chunks store LOCAL string/number tables and chunk-relative `end` offsets, so
- * a chunk is portable across compiles even though the assembled program keeps
- * one compact global table. Splicing remaps a chunk's indices into the global
- * tables: that is O(chunk nodes) integer work (~0.1-0.3ms for the whole
- * program), against ~9ms to re-walk the runtime tree and re-hash its strings.
+ * With both, splicing an unchanged flow is a bulk copy of its records rather
+ * than a per-node rewrite. An earlier revision of this format stored an
+ * absolute end index and per-compile tables; that cost 13.0 ms/compile in
+ * remapping on the raffles-and-bunny corpus, which is the entire reason a
+ * binary path looked like it could not compete with the by-pointer reuse the
+ * JSON writer gets for free.
  */
 import {
   NODE_WIDTH,
@@ -40,17 +35,52 @@ import {
 } from "./programBinary";
 
 /**
- * A serialized top-level flow, portable across compiles.
+ * String and number tables shared across compiles.
  *
- * Indices are LOCAL: `value` indexes this chunk's own tables and `end` is
- * relative to the chunk's first record. That is what lets a chunk outlive the
- * program it was produced for — the global tables it was originally interned
- * against will have been rebuilt by the next compile.
+ * Append-only by construction: an id, once handed out, must stay valid for as
+ * long as any cached chunk references it. `generation` is bumped when the
+ * table is reseeded, which invalidates every chunk minted against the old one.
+ */
+export interface ProgramTable {
+  strings: string[];
+  stringIds: Map<string, number>;
+  numbers: number[];
+  numberIds: Map<number, number>;
+  generation: number;
+}
+
+export const createProgramTable = (): ProgramTable => ({
+  strings: [],
+  stringIds: new Map(),
+  numbers: [],
+  numberIds: new Map(),
+  generation: 0,
+});
+
+/**
+ * Reseed a table, dropping entries no longer referenced.
+ *
+ * The table only grows while a session runs, so strings from deleted content
+ * accumulate. Callers reseed when the waste is worth the cost: every cached
+ * chunk becomes invalid, because its pointers referred to the old numbering.
+ */
+export const reseedProgramTable = (table: ProgramTable): void => {
+  table.strings = [];
+  table.stringIds = new Map();
+  table.numbers = [];
+  table.numberIds = new Map();
+  table.generation += 1;
+};
+
+/**
+ * A serialized top-level flow: just its records.
+ *
+ * No local tables and no rebasing — the payload pointers are valid against the
+ * shared table of the same `generation`, and `size` is already relative.
  */
 export interface ProgramChunk {
   readonly nodes: Uint32Array;
-  readonly strings: readonly string[];
-  readonly numbers: Float64Array;
+  readonly generation: number;
 }
 
 /** A chunk plus the fingerprint it was valid for. */
@@ -61,11 +91,8 @@ export interface CachedFlowChunk {
 
 export class ProgramBinaryWriter {
   private _nodes: number[] = [];
-  private _strings: string[] = [];
-  private _stringIds = new Map<string, number>();
-  private _numbers: number[] = [];
-  private _numberIds = new Map<number, number>();
-  /** Indices of records whose `end` is still unpatched, innermost last. */
+  private _table: ProgramTable;
+  /** Indices of records whose `size` is still unpatched, innermost last. */
   private _open: number[] = [];
   private _widest = 0;
   private _currentString: string | null = null;
@@ -74,24 +101,42 @@ export class ProgramBinaryWriter {
   private _pendingCapture: { name: string; fp: string } | null = null;
   private _captured = new Map<string, CachedFlowChunk>();
 
+  constructor(table: ProgramTable = createProgramTable()) {
+    this._table = table;
+    // Ids already in the table stay valid, so the widest existing pointer is a
+    // lower bound on the slot width this buffer needs.
+    this._widest = Math.max(
+      table.strings.length,
+      table.numbers.length,
+    );
+  }
+
   // ---------------------------------------------------------------- interning
 
   private _intern(text: string): number {
-    let id = this._stringIds.get(text);
+    const table = this._table;
+    let id = table.stringIds.get(text);
     if (id === undefined) {
-      id = this._strings.length;
-      this._strings.push(text);
-      this._stringIds.set(text, id);
+      id = table.strings.length;
+      table.strings.push(text);
+      table.stringIds.set(text, id);
+      if (id > this._widest) {
+        this._widest = id;
+      }
     }
     return id;
   }
 
   private _internNumber(n: number): number {
-    let id = this._numberIds.get(n);
+    const table = this._table;
+    let id = table.numberIds.get(n);
     if (id === undefined) {
-      id = this._numbers.length;
-      this._numbers.push(n);
-      this._numberIds.set(n, id);
+      id = table.numbers.length;
+      table.numbers.push(n);
+      table.numberIds.set(n, id);
+      if (id > this._widest) {
+        this._widest = id;
+      }
     }
     return id;
   }
@@ -102,24 +147,21 @@ export class ProgramBinaryWriter {
   private _emit(tag: ProgramNodeTag, value: number): number {
     const index = this._nodes.length / NODE_WIDTH;
     this._nodes.push(tag, value, 0);
-    if (value > this._widest) {
-      this._widest = value;
-    }
     return index;
   }
 
-  /** Patch a record's `end` to the current write head. */
+  /** Patch a record's subtree SIZE, in records, including itself. */
   private _close(index: number): void {
-    const end = this._nodes.length / NODE_WIDTH;
-    this._nodes[index * NODE_WIDTH + 2] = end;
-    if (end > this._widest) {
-      this._widest = end;
+    const size = this._nodes.length / NODE_WIDTH - index;
+    this._nodes[index * NODE_WIDTH + 2] = size;
+    if (size > this._widest) {
+      this._widest = size;
     }
   }
 
   /** A leaf: opens and closes in one step. */
   private _leaf(tag: ProgramNodeTag, value: number): void {
-    this._close(this._emit(tag, value));
+    this._nodes.push(tag, value, 1);
   }
 
   // ------------------------------------------------- SimpleJson.Writer surface
@@ -147,7 +189,9 @@ export class ProgramBinaryWriter {
   }
 
   WritePropertyStart(name: string): void {
-    this._open.push(this._emit(ProgramNodeTag.Member, this._intern(String(name))));
+    this._open.push(
+      this._emit(ProgramNodeTag.Member, this._intern(String(name))),
+    );
   }
 
   WritePropertyEnd(): void {
@@ -196,7 +240,10 @@ export class ProgramBinaryWriter {
 
   WritePropertyNameEnd(): void {
     this._open.push(
-      this._emit(ProgramNodeTag.Member, this._intern(this._currentPropertyName!)),
+      this._emit(
+        ProgramNodeTag.Member,
+        this._intern(this._currentPropertyName!),
+      ),
     );
     this._currentPropertyName = null;
   }
@@ -293,13 +340,13 @@ export class ProgramBinaryWriter {
   /**
    * Splice a cached flow chunk, or encode a plain JS value inline.
    *
-   * The chunk path is the point of phase 2: an unchanged flow costs a remap of
-   * its records rather than a re-walk of the runtime tree.
+   * The chunk path is the point of phase 2: an unchanged flow costs a bulk
+   * record copy rather than a re-walk of the runtime tree.
    */
   WriteInjected(value: unknown): void {
     const pending = this._pendingCapture;
     const start = pending ? this.mark() : 0;
-    if (isProgramChunk(value)) {
+    if (this._isUsableChunk(value)) {
       this._spliceChunk(value);
     } else {
       this._writeValue(value);
@@ -330,6 +377,13 @@ export class ProgramBinaryWriter {
     const captured = this._captured;
     this._captured = new Map();
     return captured;
+  }
+
+  /** True if `value` is a chunk minted against THIS table's generation. */
+  private _isUsableChunk(value: unknown): value is ProgramChunk {
+    return (
+      isProgramChunk(value) && value.generation === this._table.generation
+    );
   }
 
   // ------------------------------------------------------- inline JS encoding
@@ -374,81 +428,37 @@ export class ProgramBinaryWriter {
   }
 
   /**
-   * Capture the records written since `start` as a portable chunk.
+   * Capture the records written since `start`.
    *
-   * Rewrites into LOCAL tables and chunk-relative `end` offsets, so the chunk
-   * survives into a later compile whose global tables are interned differently.
+   * A straight copy: `size` is already relative and payload pointers are valid
+   * for as long as the shared table keeps this generation.
    */
   captureChunk(start: number): ProgramChunk {
-    const end = this._nodes.length / NODE_WIDTH;
-    const count = end - start;
-    const nodes = new Uint32Array(count * NODE_WIDTH);
-    const strings: string[] = [];
-    const stringRemap = new Map<number, number>();
-    const numbers: number[] = [];
-    const numberRemap = new Map<number, number>();
-
-    for (let i = 0; i < count; i += 1) {
-      const src = (start + i) * NODE_WIDTH;
-      const dst = i * NODE_WIDTH;
-      const tag = this._nodes[src]! as ProgramNodeTag;
-      const value = this._nodes[src + 1]!;
-      nodes[dst] = tag;
-      if (tag === ProgramNodeTag.String || tag === ProgramNodeTag.Member) {
-        let local = stringRemap.get(value);
-        if (local === undefined) {
-          local = strings.length;
-          strings.push(this._strings[value]!);
-          stringRemap.set(value, local);
-        }
-        nodes[dst + 1] = local;
-      } else if (tag === ProgramNodeTag.Number) {
-        let local = numberRemap.get(value);
-        if (local === undefined) {
-          local = numbers.length;
-          numbers.push(this._numbers[value]!);
-          numberRemap.set(value, local);
-        }
-        nodes[dst + 1] = local;
-      } else {
-        nodes[dst + 1] = value;
-      }
-      nodes[dst + 2] = this._nodes[src + 2]! - start;
+    const from = start * NODE_WIDTH;
+    const nodes = new Uint32Array(this._nodes.length - from);
+    for (let i = 0; i < nodes.length; i += 1) {
+      nodes[i] = this._nodes[from + i]!;
     }
-
-    return { nodes, strings, numbers: Float64Array.from(numbers) };
+    return { nodes, generation: this._table.generation };
   }
 
-  /** Append a chunk's records, remapping its local indices into ours. */
+  /** Append a chunk's records verbatim. */
   private _spliceChunk(chunk: ProgramChunk): void {
-    const base = this._nodes.length / NODE_WIDTH;
-    const stringBase: number[] = new Array(chunk.strings.length);
-    for (let i = 0; i < chunk.strings.length; i += 1) {
-      stringBase[i] = this._intern(chunk.strings[i]!);
-    }
-    const numberBase: number[] = new Array(chunk.numbers.length);
-    for (let i = 0; i < chunk.numbers.length; i += 1) {
-      numberBase[i] = this._internNumber(chunk.numbers[i]!);
-    }
     const src = chunk.nodes;
-    const count = src.length / NODE_WIDTH;
-    for (let i = 0; i < count; i += 1) {
-      const o = i * NODE_WIDTH;
-      const tag = src[o]! as ProgramNodeTag;
-      const value = src[o + 1]!;
-      const mapped =
-        tag === ProgramNodeTag.String || tag === ProgramNodeTag.Member
-          ? stringBase[value]!
-          : tag === ProgramNodeTag.Number
-            ? numberBase[value]!
-            : value;
-      const end = src[o + 2]! + base;
-      this._nodes.push(tag, mapped, end);
-      if (mapped > this._widest) {
-        this._widest = mapped;
+    for (let i = 0; i < src.length; i += 1) {
+      this._nodes.push(src[i]!);
+    }
+    // Sizes are relative and pointers are table-global, so nothing inside the
+    // chunk needs rewriting. Only the width tracker has to notice the chunk's
+    // largest slot; the tags themselves are always < 8.
+    for (let i = 0; i < src.length; i += NODE_WIDTH) {
+      const payload = src[i + 1]!;
+      const size = src[i + 2]!;
+      if (payload > this._widest) {
+        this._widest = payload;
       }
-      if (end > this._widest) {
-        this._widest = end;
+      if (size > this._widest) {
+        this._widest = size;
       }
     }
   }
@@ -462,20 +472,18 @@ export class ProgramBinaryWriter {
         this._widest <= 0xffff
           ? Uint16Array.from(this._nodes)
           : Uint32Array.from(this._nodes),
-      strings: this._strings,
-      numbers: Float64Array.from(this._numbers),
+      strings: this._table.strings,
+      numbers: Float64Array.from(this._table.numbers),
     };
   }
 }
 
 /**
  * Structural test rather than an instanceof/brand check, because a chunk may
- * arrive from a previous compile (and, later, across a worker boundary) where
- * class identity does not survive.
+ * arrive from a previous compile where class identity does not survive.
  */
 export const isProgramChunk = (value: unknown): value is ProgramChunk =>
   !!value &&
   typeof value === "object" &&
   (value as ProgramChunk).nodes instanceof Uint32Array &&
-  Array.isArray((value as ProgramChunk).strings) &&
-  (value as ProgramChunk).numbers instanceof Float64Array;
+  typeof (value as ProgramChunk).generation === "number";

--- a/packages/sparkdown/src/binary/programBinary.ts
+++ b/packages/sparkdown/src/binary/programBinary.ts
@@ -432,3 +432,53 @@ export const readProgramBuffer = (input: Uint8Array): ProgramBuffer => {
 /** Decode bytes produced by {@link encodeProgram} back to a JSON value. */
 export const decodeProgram = <T = unknown>(bytes: Uint8Array): T =>
   materializeNode(readProgramBuffer(bytes)) as T;
+
+/**
+ * A program carrying bytecode in EITHER representation.
+ *
+ * Typed structurally rather than as `SparkProgram`, because `SparkProgram`
+ * imports `ProgramBuffer` from this module and the reverse import would be a
+ * cycle.
+ */
+export interface CompiledProgramLike {
+  compiled?: Record<string, any>;
+  compiledBuffer?: ProgramBuffer;
+}
+
+/**
+ * True if the program has runnable bytecode, whichever form it arrived in.
+ *
+ * Call sites used to test `program.compiled` for truthiness as a readiness
+ * gate; with the binary path those gates must accept the buffer too, or a
+ * perfectly good program reads as "not compiled yet".
+ */
+export const hasCompiledProgram = (
+  program: CompiledProgramLike | undefined | null,
+): boolean => Boolean(program && (program.compiled || program.compiledBuffer));
+
+/**
+ * The program's bytecode as a JS object tree, materializing the binary form.
+ *
+ * `new Story(...)` walks a plain object tree, so the binary form has to be
+ * materialized at that boundary. Materializing is still cheaper than what it
+ * replaces: the object graph no longer crosses the worker hop as a structured
+ * clone, only the typed arrays and the string table do.
+ *
+ * Not memoized — callers materialize once and keep the result (see
+ * `Game.updateProgram`), because caching onto the program would mutate an
+ * object the compiler retains for its no-change short-circuit.
+ */
+export const resolveCompiledProgram = (
+  program: CompiledProgramLike | undefined | null,
+): Record<string, any> | undefined => {
+  if (!program) {
+    return undefined;
+  }
+  if (program.compiled) {
+    return program.compiled;
+  }
+  if (program.compiledBuffer) {
+    return materializeNode(program.compiledBuffer) as Record<string, any>;
+  }
+  return undefined;
+};

--- a/packages/sparkdown/src/binary/programBinary.ts
+++ b/packages/sparkdown/src/binary/programBinary.ts
@@ -302,8 +302,18 @@ const encodeStringTable = (
 };
 
 /** Serialize a compiled program (or any JSON value) to one buffer. */
-export const encodeProgram = (value: unknown): Uint8Array => {
-  const { nodes, strings, numbers } = buildProgramBuffer(value);
+export const encodeProgram = (value: unknown): Uint8Array =>
+  encodeProgramBuffer(buildProgramBuffer(value));
+
+/**
+ * Serialize an already-built buffer.
+ *
+ * Split out from {@link encodeProgram} so a writer that produced its records
+ * directly (`ProgramBinaryWriter`) does not have to build a JS value first,
+ * only to have it walked a second time.
+ */
+export const encodeProgramBuffer = (buffer: ProgramBuffer): Uint8Array => {
+  const { nodes, strings, numbers } = buffer;
   const slotBytes = nodes.BYTES_PER_ELEMENT;
   const { data: stringData, lengths: stringLengths } =
     encodeStringTable(strings);

--- a/packages/sparkdown/src/binary/programBinary.ts
+++ b/packages/sparkdown/src/binary/programBinary.ts
@@ -52,11 +52,19 @@
 export const PROGRAM_BINARY_MAGIC = new Uint8Array([0x53, 0x44, 0x42, 0x03]);
 
 /**
- * Slots per node record: tag, value, end.
+ * Slots per node record: `[tag, payload, size]`.
  *
- * Deliberately no child count — `end` already bounds the subtree, and a
- * consumer that wants the children walks them by hopping each child's `end`.
- * Storing it too cost 66KB on the R&B corpus for a number nothing read.
+ * `size` is lezer's fourth value — "the amount of space taken up in the array
+ * by this node and its children", counted in RECORDS including the node
+ * itself. It is deliberately a SIZE and not an end index, because a size is
+ * intrinsic to the node while an end index is a statement about where the node
+ * sits. That single difference is what makes a subtree relocatable: skipping
+ * one is `i += size` instead of `i = end`, and splicing a cached subtree needs
+ * no structural rewrite at all.
+ *
+ * lezer carries `from`/`to` document offsets in its other two slots; we have no
+ * use for those, so the record stays three wide — the payload slot is a
+ * pointer into the string or number table, never an inline value.
  */
 export const NODE_WIDTH = 3;
 
@@ -131,7 +139,7 @@ export const buildProgramBuffer = (value: unknown): ProgramBuffer => {
   };
 
   // Tracked as we go rather than by re-scanning every slot afterwards; only
-  // payload indices and end offsets can be large, tags are always < 8.
+  // payload pointers and sizes can be large, tags are always < 8.
   let widest = 0;
 
   /** Emit a record, returning its index in RECORDS (not ints). */
@@ -144,12 +152,12 @@ export const buildProgramBuffer = (value: unknown): ProgramBuffer => {
     return index;
   };
 
-  /** Patch the end offset once the whole subtree has been written. */
+  /** Patch the subtree SIZE once the whole subtree has been written. */
   const close = (index: number) => {
-    const end = nodes.length / NODE_WIDTH;
-    nodes[index * NODE_WIDTH + 2] = end;
-    if (end > widest) {
-      widest = end;
+    const size = nodes.length / NODE_WIDTH - index;
+    nodes[index * NODE_WIDTH + 2] = size;
+    if (size > widest) {
+      widest = size;
     }
   };
 
@@ -224,25 +232,25 @@ export const materializeNode = (
       return strings[value]!;
     case ProgramNodeTag.Array: {
       const items: unknown[] = [];
-      // Children are laid out consecutively; each one's `end` is where the
-      // next begins, so this walks siblings without recursing to find them.
+      // Children are laid out consecutively; hopping a child's SIZE lands on
+      // the next sibling, so this walks siblings without recursing into them.
       let child = index + 1;
-      const end = nodes[base + 2]!;
+      const end = index + nodes[base + 2]!;
       while (child < end) {
         items.push(materializeNode(buffer, child));
-        child = nodes[child * NODE_WIDTH + 2]!;
+        child += nodes[child * NODE_WIDTH + 2]!;
       }
       return items;
     }
     case ProgramNodeTag.Object: {
       const result: Record<string, unknown> = {};
       let child = index + 1;
-      const end = nodes[base + 2]!;
+      const end = index + nodes[base + 2]!;
       while (child < end) {
         // Every child of an Object is a Member: key in `value`, one child.
         const key = strings[nodes[child * NODE_WIDTH + 1]!]!;
         result[key] = materializeNode(buffer, child + 1);
-        child = nodes[child * NODE_WIDTH + 2]!;
+        child += nodes[child * NODE_WIDTH + 2]!;
       }
       return result;
     }

--- a/packages/sparkdown/src/binary/programBinary.ts
+++ b/packages/sparkdown/src/binary/programBinary.ts
@@ -1,0 +1,416 @@
+/**
+ * Binary encoding for the compiled program (#314, phase 1).
+ *
+ * The compiled program travels as ink JSON: the compiler stringifies it, the
+ * host structured-clones it, and the player parses it back. On the
+ * raffles-and-bunny corpus that is ~417KB of bytecode inside a ~1.5MB program
+ * (`JSON.stringify` of the whole program costs ~21ms; of the bytecode slice
+ * alone, ~5.4ms to write and ~5.7ms to parse back).
+ *
+ * ## Shape: a flat node buffer, not a nested encoding
+ *
+ * Modelled on lezer's `TreeBuffer` (the same structure this repo's
+ * `textmate-grammar-tree` builds parse trees with): every node is a
+ * fixed-width record in one contiguous typed array, and a subtree is a
+ * CONTIGUOUS RANGE of that array. A recursive tagged encoding would have been
+ * simpler, but it forces the decoder to materialize a JS object tree — which
+ * merely replaces `JSON.parse` with a bespoke parse and keeps the allocation
+ * cost. This layout is what makes the rest of the ticket work:
+ *
+ *  - **Iterable in place.** A consumer walks it with an integer cursor and
+ *    allocates nothing, so a `SharedArrayBuffer` genuinely removes the
+ *    transfer cost instead of relocating it (ticket phase 4).
+ *  - **Subtrees are spans.** `end` is the index one past a node's last
+ *    descendant, so skipping a subtree is one assignment, and a top-level
+ *    flow's serialized form is a slice — which is what phase 2 needs to keep
+ *    the incremental `ToJson` flow memo alive.
+ *  - **Repetition collapses.** Ink bytecode is overwhelmingly repeated short
+ *    strings (`ev`, `/ev`, `^`, `done`, `#`, `/#`, and every `{"VAR?":…}`
+ *    key); they are interned once and referenced by index.
+ *
+ * Key ORDER is preserved, so a decoded program re-stringifies byte-identically
+ * to the original — that equality is the round-trip test.
+ *
+ * ## Layout
+ *
+ * ```
+ * header   magic "SDB\x03" | nodeCount | stringCount | doubleCount | slotBytes
+ * nodes    NODE_WIDTH slots per node: [tag, value, end]
+ * numbers  Float64Array (every numeric payload, deduped, by index)
+ * strings  length table (Int32) + UTF-8 blob (interned, referenced by index)
+ * ```
+ *
+ * Sections are padded so each starts at a multiple of its own element size,
+ * which is what lets them be read back as views instead of copies.
+ *
+ * `value` is always an INDEX, never a payload: into `numbers` for Number,
+ * into `strings` for String and for a Member's key. `end` indexes the node
+ * array, in RECORDS, one past the last descendant.
+ */
+
+/** `SDB` + format version. Bump the last byte on any incompatible change. */
+export const PROGRAM_BINARY_MAGIC = new Uint8Array([0x53, 0x44, 0x42, 0x03]);
+
+/**
+ * Slots per node record: tag, value, end.
+ *
+ * Deliberately no child count — `end` already bounds the subtree, and a
+ * consumer that wants the children walks them by hopping each child's `end`.
+ * Storing it too cost 66KB on the R&B corpus for a number nothing read.
+ */
+export const NODE_WIDTH = 3;
+
+export const enum ProgramNodeTag {
+  Null = 0,
+  False = 1,
+  True = 2,
+  /** `value` indexes the numbers table. */
+  Number = 3,
+  /** `value` indexes the strings table. */
+  String = 4,
+  Array = 5,
+  Object = 6,
+  /**
+   * One object entry. `value` is the key's string index and it has exactly one
+   * child (the entry's value). Modelling members as nodes keeps every record
+   * fixed-width, so the buffer stays a flat array a cursor can scan.
+   */
+  Member = 7,
+}
+
+export interface ProgramBuffer {
+  /**
+   * `NODE_WIDTH` slots per node; a subtree is the range `[i, node.end)`.
+   *
+   * 16-bit when every slot fits, 32-bit otherwise — measured on the R&B
+   * corpus, ink bytecode is ~33k nodes whose largest slot is well under
+   * 65,535, and halving the record is the difference between this format
+   * being larger than the JSON it replaces and being smaller. The width is
+   * recorded in the header, so a story big enough to overflow simply widens
+   * rather than failing.
+   */
+  readonly nodes: Uint16Array | Uint32Array;
+  readonly strings: readonly string[];
+  /**
+   * Every numeric payload, deduplicated. Numbers live here rather than inline
+   * so a node slot only ever holds a tag, a table index, or a node index —
+   * all bounded by STRUCTURE size. Inline values would let one large integer
+   * force the whole node array from 16 to 32 bits.
+   */
+  readonly numbers: Float64Array;
+}
+
+/** Build the flat node buffer for a JSON value. */
+export const buildProgramBuffer = (value: unknown): ProgramBuffer => {
+  const nodes: number[] = [];
+  const strings: string[] = [];
+  const stringIds = new Map<string, number>();
+  const numbers: number[] = [];
+  const numberIds = new Map<number, number>();
+
+  const intern = (text: string): number => {
+    let id = stringIds.get(text);
+    if (id === undefined) {
+      id = strings.length;
+      strings.push(text);
+      stringIds.set(text, id);
+    }
+    return id;
+  };
+
+  const internNumber = (n: number): number => {
+    // `0`, `1`, `2` and friends recur constantly in bytecode, so dedupe.
+    // Keyed on the value; -0 and 0 collide harmlessly (JSON has no -0).
+    let id = numberIds.get(n);
+    if (id === undefined) {
+      id = numbers.length;
+      numbers.push(n);
+      numberIds.set(n, id);
+    }
+    return id;
+  };
+
+  // Tracked as we go rather than by re-scanning every slot afterwards; only
+  // payload indices and end offsets can be large, tags are always < 8.
+  let widest = 0;
+
+  /** Emit a record, returning its index in RECORDS (not ints). */
+  const emit = (tag: ProgramNodeTag, nodeValue: number): number => {
+    const index = nodes.length / NODE_WIDTH;
+    nodes.push(tag, nodeValue, 0);
+    if (nodeValue > widest) {
+      widest = nodeValue;
+    }
+    return index;
+  };
+
+  /** Patch the end offset once the whole subtree has been written. */
+  const close = (index: number) => {
+    const end = nodes.length / NODE_WIDTH;
+    nodes[index * NODE_WIDTH + 2] = end;
+    if (end > widest) {
+      widest = end;
+    }
+  };
+
+  const write = (node: unknown): void => {
+    if (node === null || node === undefined) {
+      close(emit(ProgramNodeTag.Null, 0));
+    } else if (node === true) {
+      close(emit(ProgramNodeTag.True, 0));
+    } else if (node === false) {
+      close(emit(ProgramNodeTag.False, 0));
+    } else if (typeof node === "number") {
+      close(emit(ProgramNodeTag.Number, internNumber(node)));
+    } else if (typeof node === "string") {
+      close(emit(ProgramNodeTag.String, intern(node)));
+    } else if (Array.isArray(node)) {
+      const index = emit(ProgramNodeTag.Array, 0);
+      for (const item of node) {
+        write(item);
+      }
+      close(index);
+    } else {
+      const record = node as Record<string, unknown>;
+      // Object.keys, not Object.entries: entries allocates a [key, value] pair
+      // array per object on top of the key array, and the program is mostly
+      // small objects. Own enumerable keys, matching JSON.stringify's set.
+      const keys = Object.keys(record);
+      const index = emit(ProgramNodeTag.Object, 0);
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i]!;
+        const memberIndex = emit(ProgramNodeTag.Member, intern(key));
+        write(record[key]);
+        close(memberIndex);
+      }
+      close(index);
+    }
+  };
+  write(value);
+
+  return {
+    nodes:
+      widest <= 0xffff ? Uint16Array.from(nodes) : Uint32Array.from(nodes),
+    strings,
+    numbers: Float64Array.from(numbers),
+  };
+};
+
+/**
+ * Materialize a node (and its subtree) back into a plain JSON value.
+ *
+ * The fallback/equivalence path. Consumers that care about speed should walk
+ * the buffer directly rather than calling this — not allocating this tree is
+ * the entire point of the layout.
+ */
+export const materializeNode = (
+  buffer: ProgramBuffer,
+  index = 0,
+): unknown => {
+  const { nodes, strings, numbers } = buffer;
+  const base = index * NODE_WIDTH;
+  const tag = nodes[base] as ProgramNodeTag;
+  const value = nodes[base + 1]!;
+  switch (tag) {
+    case ProgramNodeTag.Null:
+      return null;
+    case ProgramNodeTag.True:
+      return true;
+    case ProgramNodeTag.False:
+      return false;
+    case ProgramNodeTag.Number:
+      return numbers[value]!;
+    case ProgramNodeTag.String:
+      return strings[value]!;
+    case ProgramNodeTag.Array: {
+      const items: unknown[] = [];
+      // Children are laid out consecutively; each one's `end` is where the
+      // next begins, so this walks siblings without recursing to find them.
+      let child = index + 1;
+      const end = nodes[base + 2]!;
+      while (child < end) {
+        items.push(materializeNode(buffer, child));
+        child = nodes[child * NODE_WIDTH + 2]!;
+      }
+      return items;
+    }
+    case ProgramNodeTag.Object: {
+      const result: Record<string, unknown> = {};
+      let child = index + 1;
+      const end = nodes[base + 2]!;
+      while (child < end) {
+        // Every child of an Object is a Member: key in `value`, one child.
+        const key = strings[nodes[child * NODE_WIDTH + 1]!]!;
+        result[key] = materializeNode(buffer, child + 1);
+        child = nodes[child * NODE_WIDTH + 2]!;
+      }
+      return result;
+    }
+    case ProgramNodeTag.Member:
+      // A Member is only reachable through its Object parent above.
+      return materializeNode(buffer, index + 1);
+    default:
+      throw new Error(`Unknown tag ${tag} in sparkdown binary program`);
+  }
+};
+
+const HEADER_INTS = 4; // nodeCount, stringCount, doubleCount, slotBytes
+
+/**
+ * Encode the string table into one contiguous blob plus a length table.
+ *
+ * A `TextEncoder.encode()` per string allocates a `Uint8Array` per string, and
+ * with a few thousand short bytecode tokens those allocations — not the
+ * encoding — dominate: measured 7.9ms per-string vs 1.8ms into a single
+ * buffer for the same strings. Nearly every ink token is ASCII, so that path
+ * skips the encoder entirely and just widens the code units.
+ */
+const encodeStringTable = (
+  strings: readonly string[]
+): { data: Uint8Array; lengths: Int32Array } => {
+  const lengths = new Int32Array(strings.length);
+  // UTF-8 never exceeds 3 bytes per UTF-16 code unit (a surrogate pair is two
+  // units and four bytes, so it stays under the bound), which lets us write
+  // into one scratch buffer before we know the exact size.
+  let bound = 0;
+  for (const s of strings) {
+    bound += s.length * 3;
+  }
+  const data = new Uint8Array(bound);
+  const encoder = new TextEncoder();
+  let cursor = 0;
+  for (let i = 0; i < strings.length; i++) {
+    const s = strings[i]!;
+    const start = cursor;
+    let ascii = true;
+    for (let c = 0; c < s.length; c++) {
+      const code = s.charCodeAt(c);
+      if (code > 0x7f) {
+        ascii = false;
+        break;
+      }
+      data[start + c] = code;
+    }
+    // On the fallback the partial ASCII bytes above are simply overwritten,
+    // since encodeInto starts at the same offset.
+    cursor = ascii
+      ? start + s.length
+      : start + encoder.encodeInto(s, data.subarray(start)).written;
+    lengths[i] = cursor - start;
+  }
+  return { data: data.subarray(0, cursor), lengths };
+};
+
+/** Serialize a compiled program (or any JSON value) to one buffer. */
+export const encodeProgram = (value: unknown): Uint8Array => {
+  const { nodes, strings, numbers } = buildProgramBuffer(value);
+  const slotBytes = nodes.BYTES_PER_ELEMENT;
+  const { data: stringData, lengths: stringLengths } =
+    encodeStringTable(strings);
+  const stringBytes = stringData.length;
+
+  const magic = PROGRAM_BINARY_MAGIC.length;
+  // Keep every typed-array section aligned to its own element size, so a
+  // consumer can subarray them out of a SharedArrayBuffer without copying.
+  const headerBytes = magic + HEADER_INTS * 4;
+  const nodeBytes = nodes.length * slotBytes;
+  const numberOffset = align(headerBytes + nodeBytes, 8);
+  const stringLenOffset = numberOffset + numbers.length * 8;
+  const stringDataOffset = stringLenOffset + strings.length * 4;
+  const total = stringDataOffset + stringBytes;
+
+  const out = new Uint8Array(total);
+  const view = new DataView(out.buffer);
+  out.set(PROGRAM_BINARY_MAGIC, 0);
+  view.setInt32(magic, nodes.length / NODE_WIDTH, true);
+  view.setInt32(magic + 4, strings.length, true);
+  view.setInt32(magic + 8, numbers.length, true);
+  view.setInt32(magic + 12, slotBytes, true);
+  if (slotBytes === 2) {
+    new Uint16Array(out.buffer, headerBytes, nodes.length).set(nodes);
+  } else {
+    new Uint32Array(out.buffer, headerBytes, nodes.length).set(nodes);
+  }
+  new Float64Array(out.buffer, numberOffset, numbers.length).set(numbers);
+  new Int32Array(out.buffer, stringLenOffset, strings.length).set(stringLengths);
+  out.set(stringData, stringDataOffset);
+  return out;
+};
+
+const align = (offset: number, to: number) =>
+  offset % to === 0 ? offset : offset + (to - (offset % to));
+
+/** True if `bytes` carries this format's magic. */
+export const isProgramBinary = (bytes: Uint8Array): boolean =>
+  bytes.length >= PROGRAM_BINARY_MAGIC.length &&
+  PROGRAM_BINARY_MAGIC.every((byte, i) => bytes[i] === byte);
+
+/**
+ * Read the sections back out. The node and double arrays are VIEWS onto the
+ * caller's bytes — no copy — which is what a shared buffer needs.
+ */
+export const readProgramBuffer = (input: Uint8Array): ProgramBuffer => {
+  if (!isProgramBinary(input)) {
+    throw new Error(
+      "Not a sparkdown binary program (bad magic). Callers are responsible for choosing the JSON path when this format isn't in use.",
+    );
+  }
+  // Every section is laid out aligned relative to the START of the message, so
+  // a message sitting at an unaligned offset inside a larger buffer (a framed
+  // or sliced payload) would make the Float64Array/Uint16Array constructors
+  // throw a bare RangeError. A transferred buffer is always offset 0, so this
+  // copies only in the case that would otherwise crash.
+  const bytes =
+    input.byteOffset % 8 === 0 ? input : new Uint8Array(input.slice());
+  const magic = PROGRAM_BINARY_MAGIC.length;
+  const base = bytes.byteOffset;
+  const view = new DataView(bytes.buffer, base, bytes.byteLength);
+  const nodeCount = view.getInt32(magic, true);
+  const stringCount = view.getInt32(magic + 4, true);
+  const numberCount = view.getInt32(magic + 8, true);
+  const slotBytes = view.getInt32(magic + 12, true);
+
+  const headerBytes = magic + HEADER_INTS * 4;
+  const nodeBytes = nodeCount * NODE_WIDTH * slotBytes;
+  const numberOffset = align(headerBytes + nodeBytes, 8);
+  const stringLenOffset = numberOffset + numberCount * 8;
+  const stringDataOffset = stringLenOffset + stringCount * 4;
+
+  const nodes =
+    slotBytes === 2
+      ? new Uint16Array(
+          bytes.buffer,
+          base + headerBytes,
+          nodeCount * NODE_WIDTH,
+        )
+      : new Uint32Array(
+          bytes.buffer,
+          base + headerBytes,
+          nodeCount * NODE_WIDTH,
+        );
+  const numbers = new Float64Array(
+    bytes.buffer,
+    base + numberOffset,
+    numberCount,
+  );
+  const lengths = new Int32Array(
+    bytes.buffer,
+    base + stringLenOffset,
+    stringCount,
+  );
+  const decoder = new TextDecoder();
+  const strings: string[] = new Array(stringCount);
+  let cursor = base + stringDataOffset;
+  for (let i = 0; i < stringCount; i += 1) {
+    const length = lengths[i]!;
+    strings[i] = decoder.decode(
+      new Uint8Array(bytes.buffer, cursor, length),
+    );
+    cursor += length;
+  }
+  return { nodes, strings, numbers };
+};
+
+/** Decode bytes produced by {@link encodeProgram} back to a JSON value. */
+export const decodeProgram = <T = unknown>(bytes: Uint8Array): T =>
+  materializeNode(readProgramBuffer(bytes)) as T;

--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -231,6 +231,10 @@ export class SparkdownCompiler {
   // compile"; see `maybeReseedBinaryTable`.
   protected _binaryTableBaseline = 0;
 
+  // Previous compile's buffer size, so the writer allocates once instead of
+  // regrowing geometrically. The program is nearly the same size every edit.
+  protected _binarySlotHint = 0;
+
   // ---- Incremental ExportRuntime: constructed-flow reuse ------------------
   // A top-level flow (knot/scene/function, plus its stitches) is assembled
   // from a RUN of chunks: the declaration chunk plus every body chunk that
@@ -938,7 +942,7 @@ export class SparkdownCompiler {
         // object tree — so on the no-memo path it does strictly less work.
         const binary = this._config.binaryProgram === true;
         const writer = binary
-          ? new ProgramBinaryWriter(this._binaryTable)
+          ? new ProgramBinaryWriter(this._binaryTable, this._binarySlotHint)
           : new SimpleJson.Writer();
         // Incremental ToJson: reuse the serialized subtree of each top-level flow
         // whose source content is unchanged AND whose cross-flow fingerprint
@@ -1059,7 +1063,9 @@ export class SparkdownCompiler {
           // transfer in O(1) across a worker boundary, and packing them into
           // one self-describing byte blob costs ~10ms/compile (it re-encodes
           // the whole string table to UTF-8) for no benefit on that hop.
-          program.compiledBuffer = (writer as ProgramBinaryWriter).toBuffer();
+          const buffer = (writer as ProgramBinaryWriter).toBuffer();
+          program.compiledBuffer = buffer;
+          this._binarySlotHint = buffer.nodes.length;
           // Safe to run AFTER emitting: reseeding installs fresh arrays on the
           // table rather than clearing them in place, so the buffer just
           // emitted keeps its own (correct) string array alive.

--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -43,6 +43,11 @@ import { LowerContext } from "../lower/context";
 import { InkObject } from "../../inkjs/engine/Object";
 import { SimpleJson } from "../../inkjs/engine/SimpleJson";
 import { JsonSerialisation } from "../../inkjs/engine/JsonSerialisation";
+import { encodeProgramBuffer } from "../../binary/programBinary";
+import {
+  ProgramBinaryWriter,
+  type CachedFlowChunk,
+} from "../../binary/ProgramBinaryWriter";
 import { Story as RuntimeStory } from "../../inkjs/engine/Story";
 import { asINamedContentOrNull, asOrNull } from "../../inkjs/engine/TypeAssertion";
 import { Container } from "../../inkjs/engine/Container";
@@ -196,6 +201,15 @@ export class SparkdownCompiler {
   // cross-flow fingerprint matches AND no header/global chunk changed (const
   // inlining / global decl) — see the `flowMemo` in `compile`.
   protected _flowJsonCache?: Map<string, { fp: string; value: any }>;
+
+  // The binary-format twin of `_flowJsonCache` (#314 phase 2), used when
+  // `config.binaryProgram` is set. Same key (top-level flow name) and same
+  // validity check (cross-flow fingerprint + the reuse guards below), but the
+  // cached value is a portable record range rather than a JS subtree. Chunks
+  // store LOCAL string/number tables and chunk-relative `end` offsets, because
+  // both are program-global in an assembled buffer and would otherwise decode
+  // against the wrong tables on the next compile.
+  protected _flowChunkCache?: Map<string, CachedFlowChunk>;
 
   // ---- Incremental ExportRuntime: constructed-flow reuse ------------------
   // A top-level flow (knot/scene/function, plus its stitches) is assembled
@@ -432,6 +446,16 @@ export class SparkdownCompiler {
       config.stripImageData !== this._config.stripImageData
     ) {
       this._config.stripImageData = config.stripImageData;
+    }
+    if (
+      config.binaryProgram !== undefined &&
+      config.binaryProgram !== this._config.binaryProgram
+    ) {
+      this._config.binaryProgram = config.binaryProgram;
+      // The two paths keep separate per-flow caches; a cache built for the
+      // other format must never be consulted after a switch.
+      this._flowJsonCache = undefined;
+      this._flowChunkCache = undefined;
     }
     if (
       config.workspace !== undefined &&
@@ -889,7 +913,13 @@ export class SparkdownCompiler {
       }
       if (story) {
         profile("start", this._profilerId, "ink/json", uri);
-        const writer = new SimpleJson.Writer();
+        // #314: the binary writer answers the SAME streaming write events as
+        // SimpleJson.Writer, but appends records instead of building a JS
+        // object tree — so on the no-memo path it does strictly less work.
+        const binary = this._config.binaryProgram === true;
+        const writer = binary
+          ? new ProgramBinaryWriter()
+          : new SimpleJson.Writer();
         // Incremental ToJson: reuse the serialized subtree of each top-level flow
         // whose source content is unchanged AND whose cross-flow fingerprint
         // (#f flags + resolved divert/reference paths) is unchanged. Content is
@@ -911,8 +941,51 @@ export class SparkdownCompiler {
           // compile. Take the exact baseline path — no fingerprinting, which
           // would otherwise be pure overhead — and let the cache lapse so the
           // next reuse-eligible edit reseeds from a fresh serialization.
-          story.ToJson(writer);
+          story.ToJson(writer as never);
           this._flowJsonCache = undefined;
+          this._flowChunkCache = undefined;
+        } else if (binary) {
+          // Binary twin of the JSON memo below. The reuse GUARDS are shared —
+          // `reusableFlows` and the `_renamedFlowNames` subtraction are
+          // computed once above — so the two paths can never disagree about
+          // which flows are eligible, only about what a cached value is.
+          const binaryWriter = writer as ProgramBinaryWriter;
+          const prevChunkCache = this._flowChunkCache;
+          const nextChunkCache = new Map<string, CachedFlowChunk>();
+          const flowMemo = {
+            resolve: (
+              name: string,
+              container: Container,
+              serialize: () => any,
+            ) => {
+              // Same two exclusions as the JSON path, for the same reasons:
+              // `global decl` is non-contiguous and cheap, and canonical
+              // synthetic names are POSITIONAL, so a name can rebind to a
+              // different flow that the fingerprint cannot distinguish.
+              if (name === "global decl" || CANONICAL_SYNTH_NAME.test(name)) {
+                return serialize();
+              }
+              const fp = JsonSerialisation.FingerprintCrossFlow(container);
+              if (reusableFlows.has(name) && prevChunkCache) {
+                const cached = prevChunkCache.get(name);
+                if (cached && cached.fp === fp) {
+                  nextChunkCache.set(name, cached);
+                  // `WriteInjected` splices the records; the flow is never
+                  // re-walked and its strings are never re-hashed.
+                  return cached.chunk;
+                }
+              }
+              // Miss: arm the writer to capture whatever gets injected next,
+              // because `resolve` returns BEFORE the caller injects it.
+              binaryWriter.captureNextInjectedAs(name, fp);
+              return serialize();
+            },
+          };
+          story.ToJson(binaryWriter as never, flowMemo);
+          for (const [name, entry] of binaryWriter.takeCapturedChunks()) {
+            nextChunkCache.set(name, entry);
+          }
+          this._flowChunkCache = nextChunkCache;
         } else {
           const prevFlowCache = this._flowJsonCache;
           const nextFlowCache = new Map<string, { fp: string; value: any }>();
@@ -952,9 +1025,15 @@ export class SparkdownCompiler {
           story.ToJson(writer, flowMemo);
           this._flowJsonCache = nextFlowCache;
         }
-        const json = writer.toObject();
-        if (json) {
-          program.compiled = json;
+        if (binary) {
+          program.compiledBinary = encodeProgramBuffer(
+            (writer as ProgramBinaryWriter).toBuffer(),
+          );
+        } else {
+          const json = (writer as SimpleJson.Writer).toObject();
+          if (json) {
+            program.compiled = json;
+          }
         }
         state.story = story;
         profile("end", this._profilerId, "ink/json", uri);

--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -46,6 +46,7 @@ import { JsonSerialisation } from "../../inkjs/engine/JsonSerialisation";
 import {
   ProgramBinaryWriter,
   createProgramTable,
+  reseedProgramTable,
   type CachedFlowChunk,
   type ProgramTable,
 } from "../../binary/ProgramBinaryWriter";
@@ -96,6 +97,13 @@ import { SparkdownFileRegistry } from "./SparkdownFileRegistry";
 // name can refer to a different flow after an edit — name-keyed caches must
 // never reuse entries for flows matching this.
 const CANONICAL_SYNTH_NAME = /^__synth_\d+$/;
+
+// Reseed the binary string table once it is half again its live size, provided
+// the absolute slack is worth a full re-serialization. A ratio rather than a
+// fixed cap, because a large project legitimately holds more live strings than
+// a small one. See `maybeReseedBinaryTable`.
+const BINARY_TABLE_RESEED_RATIO = 1.5;
+const BINARY_TABLE_RESEED_MIN_SLACK = 512;
 
 const LANGUAGE_NAME = GRAMMAR_DEFINITION.name.toLowerCase();
 const FILE_TYPES = GRAMMAR_DEFINITION.fileTypes;
@@ -217,6 +225,11 @@ export class SparkdownCompiler {
   // grammar-fixed NodeSet, and it is what lets a cached chunk be copied in
   // verbatim instead of remapped record by record.
   protected _binaryTable: ProgramTable = createProgramTable();
+
+  // Table size once a freshly seeded table has settled, i.e. the LIVE string
+  // count for the current document. Zero means "recalibrate on the next
+  // compile"; see `maybeReseedBinaryTable`.
+  protected _binaryTableBaseline = 0;
 
   // ---- Incremental ExportRuntime: constructed-flow reuse ------------------
   // A top-level flow (knot/scene/function, plus its stitches) is assembled
@@ -975,7 +988,16 @@ export class SparkdownCompiler {
               const fp = JsonSerialisation.FingerprintCrossFlow(container);
               if (reusableFlows.has(name) && prevChunkCache) {
                 const cached = prevChunkCache.get(name);
-                if (cached && cached.fp === fp) {
+                // The generation check is what keeps a reseed sound. Returning
+                // a chunk here means NOT calling serialize(), so a chunk from
+                // an older numbering could not be recovered from downstream —
+                // the writer throws rather than guess, so the decision has to
+                // be made here.
+                if (
+                  cached &&
+                  cached.fp === fp &&
+                  cached.chunk.generation === binaryWriter.generation
+                ) {
                   nextChunkCache.set(name, cached);
                   // `WriteInjected` splices the records; the flow is never
                   // re-walked and its strings are never re-hashed.
@@ -1038,6 +1060,10 @@ export class SparkdownCompiler {
           // one self-describing byte blob costs ~10ms/compile (it re-encodes
           // the whole string table to UTF-8) for no benefit on that hop.
           program.compiledBuffer = (writer as ProgramBinaryWriter).toBuffer();
+          // Safe to run AFTER emitting: reseeding installs fresh arrays on the
+          // table rather than clearing them in place, so the buffer just
+          // emitted keeps its own (correct) string array alive.
+          this.maybeReseedBinaryTable();
         } else {
           const json = (writer as SimpleJson.Writer).toObject();
           if (json) {
@@ -2554,6 +2580,41 @@ export class SparkdownCompiler {
   // that sit before the first named flow. So if any changed chunk lies before the
   // first flow's span, a referenced const may have changed and every flow must be
   // re-serialized; otherwise per-flow content+fingerprint reuse is sound.
+  /**
+   * Bound the append-only binary string table.
+   *
+   * Every edited flow interns strings for its changed lines, and those are
+   * dead the moment the next keystroke lands — measured at ~1 per keystroke on
+   * raffles-and-bunny. The table is not merely a compiler-side cache: it ships
+   * inside `program.compiledBuffer`, so unchecked growth costs payload size and
+   * per-hop clone time as well as memory.
+   *
+   * Reseeding is cheap in the amortized sense but not free: every cached chunk
+   * was minted against the old numbering, so the next compile re-serializes
+   * every flow. With the thresholds below that happens once per few thousand
+   * edits, which is why it is a ratio and not a fixed cap — a large project
+   * legitimately holds more live strings than a small one.
+   */
+  protected maybeReseedBinaryTable(): void {
+    const size = this._binaryTable.strings.length;
+    if (this._binaryTableBaseline === 0) {
+      // First compile after a (re)seed: whatever is interned now is live.
+      this._binaryTableBaseline = size;
+      return;
+    }
+    const grown = size - this._binaryTableBaseline;
+    if (
+      size > this._binaryTableBaseline * BINARY_TABLE_RESEED_RATIO &&
+      grown > BINARY_TABLE_RESEED_MIN_SLACK
+    ) {
+      reseedProgramTable(this._binaryTable);
+      // Not strictly required — `generation` already makes stale chunks
+      // unusable — but holding them would pin memory for nothing.
+      this._flowChunkCache = undefined;
+      this._binaryTableBaseline = 0;
+    }
+  }
+
   protected computeFlowReuse(story: RuntimeStory): {
     reusable: Set<string>;
     ok: boolean;

--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -43,10 +43,11 @@ import { LowerContext } from "../lower/context";
 import { InkObject } from "../../inkjs/engine/Object";
 import { SimpleJson } from "../../inkjs/engine/SimpleJson";
 import { JsonSerialisation } from "../../inkjs/engine/JsonSerialisation";
-import { encodeProgramBuffer } from "../../binary/programBinary";
 import {
   ProgramBinaryWriter,
+  createProgramTable,
   type CachedFlowChunk,
+  type ProgramTable,
 } from "../../binary/ProgramBinaryWriter";
 import { Story as RuntimeStory } from "../../inkjs/engine/Story";
 import { asINamedContentOrNull, asOrNull } from "../../inkjs/engine/TypeAssertion";
@@ -210,6 +211,12 @@ export class SparkdownCompiler {
   // both are program-global in an assembled buffer and would otherwise decode
   // against the wrong tables on the next compile.
   protected _flowChunkCache?: Map<string, CachedFlowChunk>;
+
+  // The string/number table the binary chunks' payload pointers refer to.
+  // Persisted across compiles on purpose: it is the analogue of lezer's
+  // grammar-fixed NodeSet, and it is what lets a cached chunk be copied in
+  // verbatim instead of remapped record by record.
+  protected _binaryTable: ProgramTable = createProgramTable();
 
   // ---- Incremental ExportRuntime: constructed-flow reuse ------------------
   // A top-level flow (knot/scene/function, plus its stitches) is assembled
@@ -918,7 +925,7 @@ export class SparkdownCompiler {
         // object tree — so on the no-memo path it does strictly less work.
         const binary = this._config.binaryProgram === true;
         const writer = binary
-          ? new ProgramBinaryWriter()
+          ? new ProgramBinaryWriter(this._binaryTable)
           : new SimpleJson.Writer();
         // Incremental ToJson: reuse the serialized subtree of each top-level flow
         // whose source content is unchanged AND whose cross-flow fingerprint
@@ -1026,9 +1033,11 @@ export class SparkdownCompiler {
           this._flowJsonCache = nextFlowCache;
         }
         if (binary) {
-          program.compiledBinary = encodeProgramBuffer(
-            (writer as ProgramBinaryWriter).toBuffer(),
-          );
+          // Pieces, not a packed blob: `nodes`/`numbers` are typed arrays that
+          // transfer in O(1) across a worker boundary, and packing them into
+          // one self-describing byte blob costs ~10ms/compile (it re-encodes
+          // the whole string table to UTF-8) for no benefit on that hop.
+          program.compiledBuffer = (writer as ProgramBinaryWriter).toBuffer();
         } else {
           const json = (writer as SimpleJson.Writer).toObject();
           if (json) {

--- a/packages/sparkdown/src/compiler/types/SparkProgram.ts
+++ b/packages/sparkdown/src/compiler/types/SparkProgram.ts
@@ -1,3 +1,4 @@
+import type { ProgramBuffer } from "../../binary/programBinary";
 import { SparkleNode } from "@impower/sparkle-screen-renderer/src/parser/parser";
 import { type File } from "./File";
 import { Range, type SparkDiagnostic } from "./SparkDiagnostic";
@@ -16,12 +17,17 @@ export interface SparkProgram {
   files: Record<string, Omit<File, "src" | "text" | "data">>;
   compiled?: Record<string, any>;
   /**
-   * The compiled program in the binary format (#314), set INSTEAD of
-   * `compiled` when `SparkdownCompilerConfig.binaryProgram` is on. Its
-   * `ArrayBuffer` is transferable, so a host that opts in moves it across a
-   * worker boundary rather than structured-cloning an object graph.
+   * The compiled program as binary buffer PIECES (#314), set INSTEAD of
+   * `compiled` when `SparkdownCompilerConfig.binaryProgram` is on.
+   *
+   * Deliberately not packed into one self-describing blob. Packing costs ~10ms
+   * per compile (it re-encodes the whole string table to UTF-8) and buys
+   * nothing for a worker hop: `nodes` and `numbers` are typed arrays that
+   * TRANSFER in O(1), and only `strings` is structured-cloned. Packing is for
+   * persistence and `SharedArrayBuffer` — use `encodeProgramBuffer` when a
+   * single self-describing blob is actually what is needed.
    */
-  compiledBinary?: Uint8Array;
+  compiledBuffer?: ProgramBuffer;
   workspace?: string;
   startFrom?: { file: string; line: number };
   simulationOptions?: Record<

--- a/packages/sparkdown/src/compiler/types/SparkProgram.ts
+++ b/packages/sparkdown/src/compiler/types/SparkProgram.ts
@@ -15,6 +15,13 @@ export interface SparkProgram {
   scripts: Record<string, number>;
   files: Record<string, Omit<File, "src" | "text" | "data">>;
   compiled?: Record<string, any>;
+  /**
+   * The compiled program in the binary format (#314), set INSTEAD of
+   * `compiled` when `SparkdownCompilerConfig.binaryProgram` is on. Its
+   * `ArrayBuffer` is transferable, so a host that opts in moves it across a
+   * worker boundary rather than structured-cloning an object graph.
+   */
+  compiledBinary?: Uint8Array;
   workspace?: string;
   startFrom?: { file: string; line: number };
   simulationOptions?: Record<

--- a/packages/sparkdown/src/compiler/types/SparkdownCompilerConfig.ts
+++ b/packages/sparkdown/src/compiler/types/SparkdownCompilerConfig.ts
@@ -15,6 +15,17 @@ export interface SparkdownCompilerConfig {
    * filtering depends on the inlined source.
    */
   stripImageData?: boolean;
+  /**
+   * Serialize the compiled program to the binary format (#314) instead of a
+   * JSON object tree, exposing it as `program.compiledBinary`.
+   *
+   * Off by default: the JSON path stays the default and the fallback, so a
+   * regression in the binary path can be bisected without a revert. Hosts opt
+   * in when they can carry an `ArrayBuffer` across their worker boundary,
+   * where the win is — the encoder itself is not faster than
+   * `JSON.stringify`; skipping the structured clone and the re-parse is.
+   */
+  binaryProgram?: boolean;
   workspace?: string;
   startFrom?: { file: string; line: number };
   simulationOptions?: Record<

--- a/packages/sparkdown/src/inkjs/engine/JsonSerialisation.ts
+++ b/packages/sparkdown/src/inkjs/engine/JsonSerialisation.ts
@@ -644,9 +644,16 @@ export class JsonSerialisation {
   // pre-order stream is anchored: a remote edit that moves a non-zero `#f` from
   // one container to another must change the string, which requires every
   // container to contribute a token.
+  //
+  // Dispatch is written as direct `instanceof` rather than `asOrNull`, and the
+  // contributing types are tested before the fall-through. The walk visits
+  // EVERY object in every flow on every compile, and the common case — string
+  // and control content, which contributes nothing — has to fail every test,
+  // so the per-object constant is the whole cost. `asOrNull` adds two calls per
+  // test on top of the same `instanceof`.
   private static fingerprintCrossFlowInto(obj: InkObject, out: string[]): void {
-    const container = asOrNull(obj, Container);
-    if (container) {
+    if (obj instanceof Container) {
+      const container = obj;
       out.push("f" + container.countFlags);
       const content = container.content;
       for (let i = 0; i < content.length; i++) {
@@ -660,8 +667,8 @@ export class JsonSerialisation {
       }
       return;
     }
-    const divert = asOrNull(obj, Divert);
-    if (divert) {
+    if (obj instanceof Divert) {
+      const divert = obj;
       const target = divert.hasVariableTarget
         ? divert.variableDivertName
         : divert.targetPathString;
@@ -674,8 +681,8 @@ export class JsonSerialisation {
     // read-count depends on whether the named flow exists — a CROSS-FLOW fact: a
     // remote edit that adds/removes/renames a scene flips this reference's form
     // even though the referencing flow's own source is unchanged.
-    const varRef = asOrNull(obj, VariableReference);
-    if (varRef) {
+    if (obj instanceof VariableReference) {
+      const varRef = obj;
       const cnt = varRef.pathStringForCount;
       if (cnt != null) {
         out.push("rC" + cnt.length + ":" + cnt);
@@ -687,22 +694,20 @@ export class JsonSerialisation {
     }
     // Resolved divert-target value (`{^->: path}`) and choice target path are
     // also resolved cross-flow.
-    const divTargetVal = asOrNull(obj, DivertTargetValue);
-    if (divTargetVal) {
-      const p = divTargetVal.value?.componentsString ?? "";
+    if (obj instanceof DivertTargetValue) {
+      const p = obj.value?.componentsString ?? "";
       out.push("T" + p.length + ":" + p);
       return;
     }
-    const choicePoint = asOrNull(obj, ChoicePoint);
-    if (choicePoint) {
+    if (obj instanceof ChoicePoint) {
+      const choicePoint = obj;
       const p = choicePoint.pathStringOnChoice ?? "";
       out.push("P" + p.length + ":" + p + ":" + choicePoint.flags);
       return;
     }
-    const varPtrVal = asOrNull(obj, VariablePointerValue);
-    if (varPtrVal) {
-      const p = varPtrVal.value ?? "";
-      out.push("p" + p.length + ":" + p + ":" + varPtrVal.contextIndex);
+    if (obj instanceof VariablePointerValue) {
+      const p = obj.value ?? "";
+      out.push("p" + p.length + ":" + p + ":" + obj.contextIndex);
       return;
     }
     // Pure-content object (string/value/control/glue/...): part of the flow's OWN

--- a/packages/sparkdown/src/tests/compiler/binaryProgramIncremental.test.ts
+++ b/packages/sparkdown/src/tests/compiler/binaryProgramIncremental.test.ts
@@ -1,0 +1,187 @@
+// Compiler-level binary path equivalence, INCLUDING across edits (#314 phase 2).
+//
+// Phase 2's whole risk is the per-flow chunk cache: a chunk carried across a
+// compile could decode against the wrong string table, be rebased wrongly, or
+// be served for a flow that actually changed. So the gate is not "the binary
+// path works once" — it is that after a SEQUENCE of edits the binary program
+// still equals what a cold JSON compile of the same text produces.
+import "../../inkjs/engine/Container";
+import { describe, expect, it } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+import { decodeProgram } from "../../binary/programBinary";
+
+const URI = "inmemory:///main.sd";
+
+function makeCompiler(text: string, binaryProgram: boolean) {
+  const c = new SparkdownCompiler();
+  c.configure({
+    binaryProgram,
+    files: [
+      {
+        uri: URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text,
+        version: 1,
+        languageId: "sparkdown",
+      },
+    ],
+  } as never);
+  return c;
+}
+
+function quiet<T>(fn: () => T): T {
+  const realWarn = console.warn;
+  const realError = console.error;
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    return fn();
+  } finally {
+    console.warn = realWarn;
+    console.error = realError;
+  }
+}
+
+/** Compile once from scratch, JSON path. */
+function coldJson(text: string): string {
+  return quiet(() => {
+    const c = makeCompiler(text, false);
+    const program = (c.compile({ textDocument: { uri: URI } } as never) as any)
+      .program;
+    return JSON.stringify(program.compiled);
+  });
+}
+
+function corpus(sceneCount: number, tag: string): string {
+  const L: string[] = [];
+  L.push("title: Incremental Binary");
+  L.push("");
+  L.push("define hero as character:");
+  L.push(`  name = "Hero"`);
+  L.push("");
+  L.push("const LIMIT = 3");
+  L.push("store trust = 0");
+  L.push("");
+  L.push("function bonus(x):");
+  L.push("  return x * 2 + 1");
+  L.push("");
+  for (let s = 0; s < sceneCount; s++) {
+    L.push(`scene scene_${s}`);
+    L.push(`= INT. ROOM ${s} - DAY`);
+    L.push(":");
+    L.push(`  Action ${s} ${tag} with {trust} and {LIMIT}.`);
+    L.push("hero:");
+    L.push(`  Line ${s} for ${tag}.`);
+    L.push("& trust = bonus(trust)");
+    L.push(`-> scene_${(s + 1) % sceneCount}`);
+    L.push("end");
+    L.push("");
+  }
+  return L.join("\n");
+}
+
+describe("binary program path (#314 phase 2)", () => {
+  it("populates compiledBinary instead of compiled", () => {
+    const program = quiet(() => {
+      const c = makeCompiler(corpus(4, "a"), true);
+      return (c.compile({ textDocument: { uri: URI } } as never) as any).program;
+    });
+    expect(program.compiledBinary).toBeInstanceOf(Uint8Array);
+    expect(program.compiled).toBeUndefined();
+  });
+
+  it("cold binary compile equals cold JSON compile", () => {
+    const text = corpus(4, "a");
+    const program = quiet(() => {
+      const c = makeCompiler(text, true);
+      return (c.compile({ textDocument: { uri: URI } } as never) as any).program;
+    });
+    expect(JSON.stringify(decodeProgram(program.compiledBinary))).toBe(
+      coldJson(text),
+    );
+  });
+
+  it("stays identical to a cold compile across a sequence of edits", () => {
+    // The chunk cache only engages on the SECOND and later compiles, so a
+    // single-compile test would not exercise splice at all.
+    const text = corpus(5, "a");
+    const c = quiet(() => makeCompiler(text, true));
+    quiet(() => c.compile({ textDocument: { uri: URI } } as never));
+
+    // Edit inside one scene body, repeatedly. Every other flow should be
+    // served from its cached chunk while this one is re-serialized.
+    const NL = String.fromCharCode(10);
+    let current = text;
+    for (let i = 0; i < 4; i += 1) {
+      // Anchor on text the edit does NOT consume, so it still resolves after
+      // each insertion (appending right after it leaves it intact).
+      const anchor = "Line 2 for a";
+      const at = current.indexOf(anchor);
+      expect(at, "edit anchor must exist").toBeGreaterThan(-1);
+      const off = at + anchor.length;
+      const before = current.slice(0, off);
+      const line = before.split(NL).length - 1;
+      const character = off - (before.lastIndexOf(NL) + 1);
+      current = current.slice(0, off) + "!" + current.slice(off);
+
+      quiet(() =>
+        c.updateDocument({
+          textDocument: { uri: URI, version: i + 2 },
+          contentChanges: [
+            {
+              range: {
+                start: { line, character },
+                end: { line, character },
+              },
+              text: "!",
+            },
+          ],
+        } as never),
+      );
+      const program = quiet(
+        () => (c.compile({ textDocument: { uri: URI } } as never) as any).program,
+      );
+      expect(
+        JSON.stringify(decodeProgram(program.compiledBinary)),
+        `after edit ${i + 1}`,
+      ).toBe(coldJson(current));
+    }
+  });
+
+  it("stays identical when an edit adds a whole new flow", () => {
+    // Adding a flow shifts every later flow's position and can rebind
+    // positional synthetic names — the case the JSON memo excludes by name.
+    const text = corpus(3, "a");
+    const c = quiet(() => makeCompiler(text, true));
+    quiet(() => c.compile({ textDocument: { uri: URI } } as never));
+
+    const addition = ["", "scene extra_scene", ":", "  Brand new content.", "end", ""].join(
+      String.fromCharCode(10),
+    );
+    const NL = String.fromCharCode(10);
+    const lineCount = text.split(NL).length;
+    const updated = text + addition;
+    quiet(() =>
+      c.updateDocument({
+        textDocument: { uri: URI, version: 2 },
+        contentChanges: [
+          {
+            range: {
+              start: { line: lineCount - 1, character: 0 },
+              end: { line: lineCount - 1, character: 0 },
+            },
+            text: addition,
+          },
+        ],
+      } as never),
+    );
+    const program = quiet(
+      () => (c.compile({ textDocument: { uri: URI } } as never) as any).program,
+    );
+    expect(JSON.stringify(decodeProgram(program.compiledBinary))).toBe(
+      coldJson(updated),
+    );
+  });
+});

--- a/packages/sparkdown/src/tests/compiler/binaryProgramIncremental.test.ts
+++ b/packages/sparkdown/src/tests/compiler/binaryProgramIncremental.test.ts
@@ -8,7 +8,7 @@
 import "../../inkjs/engine/Container";
 import { describe, expect, it } from "vitest";
 import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
-import { decodeProgram } from "../../binary/programBinary";
+import { materializeNode } from "../../binary/programBinary";
 
 const URI = "inmemory:///main.sd";
 
@@ -83,12 +83,14 @@ function corpus(sceneCount: number, tag: string): string {
 }
 
 describe("binary program path (#314 phase 2)", () => {
-  it("populates compiledBinary instead of compiled", () => {
+  it("populates compiledBuffer instead of compiled", () => {
     const program = quiet(() => {
       const c = makeCompiler(corpus(4, "a"), true);
       return (c.compile({ textDocument: { uri: URI } } as never) as any).program;
     });
-    expect(program.compiledBinary).toBeInstanceOf(Uint8Array);
+    expect(program.compiledBuffer).toBeTruthy();
+    expect(ArrayBuffer.isView(program.compiledBuffer.nodes)).toBe(true);
+    expect(Array.isArray(program.compiledBuffer.strings)).toBe(true);
     expect(program.compiled).toBeUndefined();
   });
 
@@ -98,7 +100,7 @@ describe("binary program path (#314 phase 2)", () => {
       const c = makeCompiler(text, true);
       return (c.compile({ textDocument: { uri: URI } } as never) as any).program;
     });
-    expect(JSON.stringify(decodeProgram(program.compiledBinary))).toBe(
+    expect(JSON.stringify(materializeNode(program.compiledBuffer))).toBe(
       coldJson(text),
     );
   });
@@ -144,7 +146,7 @@ describe("binary program path (#314 phase 2)", () => {
         () => (c.compile({ textDocument: { uri: URI } } as never) as any).program,
       );
       expect(
-        JSON.stringify(decodeProgram(program.compiledBinary)),
+        JSON.stringify(materializeNode(program.compiledBuffer)),
         `after edit ${i + 1}`,
       ).toBe(coldJson(current));
     }
@@ -180,7 +182,7 @@ describe("binary program path (#314 phase 2)", () => {
     const program = quiet(
       () => (c.compile({ textDocument: { uri: URI } } as never) as any).program,
     );
-    expect(JSON.stringify(decodeProgram(program.compiledBinary))).toBe(
+    expect(JSON.stringify(materializeNode(program.compiledBuffer))).toBe(
       coldJson(updated),
     );
   });

--- a/packages/sparkdown/src/tests/compiler/binaryTableReseed.test.ts
+++ b/packages/sparkdown/src/tests/compiler/binaryTableReseed.test.ts
@@ -1,0 +1,210 @@
+// Binary string-table reseeding (#314).
+//
+// The table is append-only so cached chunks' payload pointers stay valid, which
+// means it grows: every edited flow interns strings for its changed lines, and
+// those are dead immediately (measured ~1 per keystroke on raffles-and-bunny).
+// The table SHIPS inside program.compiledBuffer, so unchecked growth costs
+// payload and per-hop clone time, not just memory.
+//
+// Reseeding is therefore required — and it is the one operation that can
+// silently corrupt output, because every cached chunk was minted against the
+// old numbering. `generation` exists to refuse those chunks; these tests are
+// what prove it actually does.
+import "../../inkjs/engine/Container";
+import { describe, expect, it } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+import { materializeNode } from "../../binary/programBinary";
+import {
+  ProgramBinaryWriter,
+  createProgramTable,
+  reseedProgramTable,
+} from "../../binary/ProgramBinaryWriter";
+
+const URI = "inmemory:///main.sd";
+
+function quiet<T>(fn: () => T): T {
+  const realWarn = console.warn;
+  const realError = console.error;
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    return fn();
+  } finally {
+    console.warn = realWarn;
+    console.error = realError;
+  }
+}
+
+function makeCompiler(text: string, binaryProgram: boolean) {
+  const c = new SparkdownCompiler();
+  c.configure({
+    binaryProgram,
+    files: [
+      {
+        uri: URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text,
+        version: 1,
+        languageId: "sparkdown",
+      },
+    ],
+  } as never);
+  return c;
+}
+
+function coldJson(text: string): string {
+  return quiet(() => {
+    const c = makeCompiler(text, false);
+    return JSON.stringify(
+      (c.compile({ textDocument: { uri: URI } } as never) as any).program
+        .compiled,
+    );
+  });
+}
+
+function corpus(tag: string): string {
+  const L: string[] = [];
+  L.push("title: Reseed");
+  L.push("");
+  L.push("store trust = 0");
+  L.push("");
+  for (let s = 0; s < 4; s++) {
+    L.push(`scene scene_${s}`);
+    L.push(":");
+    L.push(`  Action ${s} ${tag} with {trust}.`);
+    L.push(`-> scene_${(s + 1) % 4}`);
+    L.push("end");
+    L.push("");
+  }
+  return L.join("\n");
+}
+
+describe("binary string-table reseeding", () => {
+  it("refuses chunks minted against an older table generation", () => {
+    // Without this guard a stale chunk would be spliced verbatim and its
+    // payload pointers would resolve against a table that no longer numbers
+    // those strings the same way — silent corruption, not a crash.
+    const table = createProgramTable();
+    const source = new ProgramBinaryWriter(table);
+    source.WriteArrayStart();
+    const mark = source.mark();
+    source.WriteArrayStart();
+    source.Write("ev");
+    source.Write("^some text");
+    source.WriteArrayEnd();
+    const chunk = source.captureChunk(mark);
+    source.WriteArrayEnd();
+    expect(chunk.generation).toBe(0);
+
+    reseedProgramTable(table);
+    expect(table.generation).toBe(1);
+
+    // A stale chunk must FAIL LOUDLY. There is no correct recovery inside the
+    // writer: whoever returned the chunk did so instead of calling
+    // serialize(), so the real content is gone. Encoding it as a plain value
+    // would write `{nodes, generation}` into the program as data — which is
+    // exactly the silent corruption this test was written to catch.
+    const fresh = new ProgramBinaryWriter(table);
+    fresh.WriteArrayStart();
+    expect(() => fresh.WriteInjected(chunk)).toThrow(/Stale program chunk/);
+
+    // A non-chunk value still injects normally.
+    const ok = new ProgramBinaryWriter(table);
+    ok.WriteArrayStart();
+    ok.WriteInjected({ rebuilt: true });
+    ok.WriteArrayEnd();
+    expect(materializeNode(ok.toBuffer())).toEqual([{ rebuilt: true }]);
+  });
+
+  it("still produces a correct program after the table is reseeded", () => {
+    const text = corpus("a");
+    const c = quiet(() => makeCompiler(text, true));
+    quiet(() => c.compile({ textDocument: { uri: URI } } as never));
+
+    // Force the condition the size policy would eventually reach, rather than
+    // typing thousands of characters to trigger it naturally.
+    reseedProgramTable((c as never as { _binaryTable: never })._binaryTable);
+    (c as never as { _binaryTableBaseline: number })._binaryTableBaseline = 0;
+
+    // Now edit and recompile: every cached chunk is stale, so the compile must
+    // fall back to re-serializing and still match a cold JSON compile.
+    const NL = String.fromCharCode(10);
+    const anchor = "Action 2 a";
+    const at = text.indexOf(anchor);
+    expect(at).toBeGreaterThan(-1);
+    const off = at + anchor.length;
+    const before = text.slice(0, off);
+    const line = before.split(NL).length - 1;
+    const character = off - (before.lastIndexOf(NL) + 1);
+    const updated = text.slice(0, off) + "!" + text.slice(off);
+
+    quiet(() =>
+      c.updateDocument({
+        textDocument: { uri: URI, version: 2 },
+        contentChanges: [
+          {
+            range: { start: { line, character }, end: { line, character } },
+            text: "!",
+          },
+        ],
+      } as never),
+    );
+    const program = quiet(
+      () => (c.compile({ textDocument: { uri: URI } } as never) as any).program,
+    );
+    expect(JSON.stringify(materializeNode(program.compiledBuffer))).toBe(
+      coldJson(updated),
+    );
+  });
+
+  it("keeps the table bounded instead of growing per keystroke", () => {
+    // The leak this policy exists for: each edit interns strings for the line
+    // it changed, and they are dead on the next keystroke.
+    const text = corpus("a");
+    const c = quiet(() => makeCompiler(text, true));
+    quiet(() => c.compile({ textDocument: { uri: URI } } as never));
+    const table = (c as never as { _binaryTable: { strings: string[] } })
+      ._binaryTable;
+    const baseline = table.strings.length;
+
+    const NL = String.fromCharCode(10);
+    let current = text;
+    const EDITS = 900; // enough to exceed the minimum slack and trip the ratio
+    for (let i = 0; i < EDITS; i += 1) {
+      const anchor = "Action 2 a";
+      const at = current.indexOf(anchor);
+      const off = at + anchor.length;
+      const before = current.slice(0, off);
+      const line = before.split(NL).length - 1;
+      const character = off - (before.lastIndexOf(NL) + 1);
+      current = current.slice(0, off) + "z" + current.slice(off);
+      quiet(() =>
+        c.updateDocument({
+          textDocument: { uri: URI, version: i + 2 },
+          contentChanges: [
+            {
+              range: { start: { line, character }, end: { line, character } },
+              text: "z",
+            },
+          ],
+        } as never),
+      );
+      quiet(() => c.compile({ textDocument: { uri: URI } } as never));
+    }
+
+    // Unbounded growth would be baseline + EDITS. The policy must hold it well
+    // under that; the exact figure depends on where the ratio last tripped.
+    expect(table.strings.length).toBeLessThan(baseline + EDITS);
+    expect(table.strings.length).toBeLessThan(baseline * 2 + 600);
+
+    // And the program is still correct after however many reseeds happened.
+    const program = quiet(
+      () => (c.compile({ textDocument: { uri: URI } } as never) as any).program,
+    );
+    expect(JSON.stringify(materializeNode(program.compiledBuffer))).toBe(
+      coldJson(current),
+    );
+  });
+});

--- a/packages/sparkdown/src/tests/compiler/programBinaryRoundTrip.test.ts
+++ b/packages/sparkdown/src/tests/compiler/programBinaryRoundTrip.test.ts
@@ -138,23 +138,29 @@ describe("binary program format round-trip", () => {
     expect(buffer.strings).toEqual(["a", "ev"]);
   });
 
-  it("lays subtrees out as contiguous spans", () => {
-    // What phases 2-4 rely on: a node's `end` bounds its whole subtree, so a
-    // consumer can skip or slice it by index without walking into it.
+  it("stores a relocatable subtree SIZE, not an end index", () => {
+    // The property phase 2 depends on, and lezer's reason for storing a size:
+    // it is intrinsic to the node, so a subtree can be copied to a different
+    // position without rewriting anything inside it. An end index would encode
+    // where the node happens to sit.
     const buffer = buildProgramBuffer({ first: [1, 2, 3], second: 9 });
     const { nodes } = buffer;
     expect(nodes[0]).toBe(ProgramNodeTag.Object);
-    const rootEnd = nodes[2]!;
-    expect(rootEnd).toBe(nodes.length / NODE_WIDTH);
+    // Root spans the whole buffer, expressed as a count of records.
+    expect(nodes[2]).toBe(nodes.length / NODE_WIDTH);
 
-    // Root's first child is the `first` Member; its end must skip the array.
     const firstMember = 1;
     expect(nodes[firstMember * NODE_WIDTH]).toBe(ProgramNodeTag.Member);
-    const secondMember = nodes[firstMember * NODE_WIDTH + 2]!;
+    // Member + Array + 3 numbers = 5 records.
+    expect(nodes[firstMember * NODE_WIDTH + 2]).toBe(5);
+
+    // Hopping a node's size lands on the next sibling.
+    const secondMember = firstMember + nodes[firstMember * NODE_WIDTH + 2]!;
     expect(nodes[secondMember * NODE_WIDTH]).toBe(ProgramNodeTag.Member);
-    // Skipping the first member lands exactly on the second, having stepped
-    // over the array and its three elements.
     expect(secondMember).toBe(firstMember + 1 + 1 + 3);
+
+    // A leaf occupies exactly one record.
+    expect(nodes[(secondMember + 1) * NODE_WIDTH + 2]).toBe(1);
   });
 
   it("exposes node and double sections as views, not copies", () => {

--- a/packages/sparkdown/src/tests/compiler/programBinaryRoundTrip.test.ts
+++ b/packages/sparkdown/src/tests/compiler/programBinaryRoundTrip.test.ts
@@ -1,0 +1,194 @@
+// Binary compiled-program format: round-trip equivalence (#314).
+//
+// The format must be a LOSSLESS carrier for the compiled program. The gate is
+// not "the decoder returns something reasonable" — it is that a story built
+// from the decoded program re-serializes byte-identically to the JSON the
+// compiler produced. Anything less and the two paths can drift, which is the
+// whole risk of keeping JSON as the fallback.
+import "../../inkjs/engine/Container";
+import { describe, expect, it } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+import { Story as RuntimeStory } from "../../inkjs/engine/Story";
+import { SimpleJson } from "../../inkjs/engine/SimpleJson";
+import {
+  NODE_WIDTH,
+  ProgramNodeTag,
+  buildProgramBuffer,
+  decodeProgram,
+  encodeProgram,
+  isProgramBinary,
+  readProgramBuffer,
+} from "../../binary/programBinary";
+
+const URI = "inmemory:///main.sd";
+
+function compileToJson(text: string) {
+  const realWarn = console.warn;
+  const realError = console.error;
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    const c = new SparkdownCompiler();
+    c.configure({
+      files: [
+        {
+          uri: URI,
+          type: "script",
+          name: "main",
+          ext: "sd",
+          text,
+          version: 1,
+          languageId: "sparkdown",
+        },
+      ],
+    } as never);
+    return (c.compile({ textDocument: { uri: URI } } as never) as any).program
+      .compiled;
+  } finally {
+    console.warn = realWarn;
+    console.error = realError;
+  }
+}
+
+/** Re-serialize a compiled program through the runtime, as the player would. */
+function storyToJson(compiled: unknown): string {
+  const story = new RuntimeStory(compiled as never);
+  const writer = new SimpleJson.Writer();
+  story.ToJson(writer);
+  return JSON.stringify(writer.toObject());
+}
+
+/** Exercises constants, defines, diverts, choices, functions and interpolation. */
+function corpus(): string {
+  const L: string[] = [];
+  L.push("title: Binary Round Trip");
+  L.push("author: Anonymous");
+  L.push("");
+  L.push("define hero as character:");
+  L.push(`  name = "Hero"`);
+  L.push(`  color = "#3366cc"`);
+  L.push("");
+  L.push("const LIMIT = 3");
+  L.push("const LABEL = \"chapter\"");
+  L.push("store trust = 0");
+  L.push("store ratio = 0.5");
+  L.push("");
+  L.push("function bonus(x):");
+  L.push("  return x * 2 + 1");
+  L.push("");
+  for (let s = 0; s < 6; s++) {
+    L.push(`scene scene_${s}`);
+    L.push(`= INT. ROOM ${s} - DAY`);
+    L.push(":");
+    L.push(`  Action in room ${s} with {trust} and {LIMIT}.`);
+    L.push("hero:");
+    L.push(`  Dialogue line for ${s} — {LABEL}.`);
+    L.push("if trust > 2 then");
+    L.push(`  hero: Trusted in ${s}.`);
+    L.push("else");
+    L.push(`  hero: Not yet in ${s}.`);
+    L.push("end");
+    L.push("& trust = bonus(trust)");
+    L.push(`-> scene_${(s + 1) % 6}`);
+    L.push("end");
+    L.push("");
+  }
+  return L.join("\n");
+}
+
+describe("binary program format round-trip", () => {
+  it("decodes back to a byte-identical program", () => {
+    const compiled = compileToJson(corpus());
+    expect(compiled, "corpus must compile").toBeTruthy();
+    const bytes = encodeProgram(compiled);
+    expect(isProgramBinary(bytes)).toBe(true);
+    const decoded = decodeProgram(bytes);
+    // Key ORDER matters: the program is compared as serialized text elsewhere
+    // in the pipeline, so an order-insensitive match would hide real drift.
+    expect(JSON.stringify(decoded)).toBe(JSON.stringify(compiled));
+  });
+
+  it("produces a runtime story that re-serializes identically", () => {
+    const compiled = compileToJson(corpus());
+    const decoded = decodeProgram(encodeProgram(compiled));
+    expect(storyToJson(decoded)).toBe(storyToJson(compiled));
+  });
+
+  it("round-trips the JSON value types the format has to carry", () => {
+    const value = {
+      nested: { deep: [1, -1, 0, 2.5, -0.125, true, false, null, ""] },
+      "": "empty key",
+      unicode: "héllo ✨ 𝄞",
+      big: 1234567,
+      float: 1e-7,
+      emptyArray: [],
+      emptyObject: {},
+      repeated: ["ev", "ev", "ev", "/ev", "/ev"],
+    };
+    expect(JSON.stringify(decodeProgram(encodeProgram(value)))).toBe(
+      JSON.stringify(value),
+    );
+  });
+
+  it("interns repeated strings instead of storing them per occurrence", () => {
+    // The size win comes from ink bytecode being mostly repeated short
+    // tokens; if this regresses, the format is not paying for itself.
+    const repeated = { a: Array.from({ length: 500 }, () => "ev") };
+    const buffer = buildProgramBuffer(repeated);
+    expect(buffer.strings).toEqual(["a", "ev"]);
+  });
+
+  it("lays subtrees out as contiguous spans", () => {
+    // What phases 2-4 rely on: a node's `end` bounds its whole subtree, so a
+    // consumer can skip or slice it by index without walking into it.
+    const buffer = buildProgramBuffer({ first: [1, 2, 3], second: 9 });
+    const { nodes } = buffer;
+    expect(nodes[0]).toBe(ProgramNodeTag.Object);
+    const rootEnd = nodes[2]!;
+    expect(rootEnd).toBe(nodes.length / NODE_WIDTH);
+
+    // Root's first child is the `first` Member; its end must skip the array.
+    const firstMember = 1;
+    expect(nodes[firstMember * NODE_WIDTH]).toBe(ProgramNodeTag.Member);
+    const secondMember = nodes[firstMember * NODE_WIDTH + 2]!;
+    expect(nodes[secondMember * NODE_WIDTH]).toBe(ProgramNodeTag.Member);
+    // Skipping the first member lands exactly on the second, having stepped
+    // over the array and its three elements.
+    expect(secondMember).toBe(firstMember + 1 + 1 + 3);
+  });
+
+  it("exposes node and double sections as views, not copies", () => {
+    // Zero-copy is the reason for the layout; if these ever became copies the
+    // SharedArrayBuffer phase would silently gain a full deserialization.
+    const bytes = encodeProgram({ n: 1.5, s: "x" });
+    const buffer = readProgramBuffer(bytes);
+    expect(buffer.nodes.buffer).toBe(bytes.buffer);
+    expect(buffer.numbers.buffer).toBe(bytes.buffer);
+  });
+
+  it("reads a message sitting at an unaligned offset in a larger buffer", () => {
+    // Sections are aligned relative to the START of the message, so a framed
+    // or sliced payload lands the Float64Array/Uint16Array views on odd byte
+    // offsets and their constructors throw a bare RangeError. A transferred
+    // buffer is offset 0, so this is the case that would crash rather than
+    // the case that is common.
+    const value = { a: [1.5, "x"], b: 2 };
+    const bytes = encodeProgram(value);
+    for (const offset of [1, 2, 3, 4, 5, 6, 7]) {
+      const framed = new Uint8Array(offset + bytes.length);
+      framed.set(bytes, offset);
+      const view = framed.subarray(offset);
+      expect(view.byteOffset, "test must actually be unaligned").toBe(offset);
+      expect(JSON.stringify(decodeProgram(view)), `offset ${offset}`).toBe(
+        JSON.stringify(value),
+      );
+    }
+  });
+
+  it("rejects bytes that are not this format", () => {
+    expect(() => decodeProgram(new Uint8Array([1, 2, 3, 4]))).toThrow(
+      /Not a sparkdown binary program/,
+    );
+    expect(isProgramBinary(new Uint8Array([1, 2, 3, 4]))).toBe(false);
+  });
+});

--- a/packages/sparkdown/src/tests/compiler/programBinaryWriter.test.ts
+++ b/packages/sparkdown/src/tests/compiler/programBinaryWriter.test.ts
@@ -1,0 +1,224 @@
+// Binary writer equivalence (#314 phase 2).
+//
+// The gate: driving `Story.ToJson` with ProgramBinaryWriter must produce the
+// same program as driving it with SimpleJson.Writer. Anything less and the
+// binary path silently diverges from the JSON path it is meant to replace —
+// which is exactly the failure the JSON fallback exists to bisect.
+import "../../inkjs/engine/Container";
+import { describe, expect, it } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+import { Story as RuntimeStory } from "../../inkjs/engine/Story";
+import { SimpleJson } from "../../inkjs/engine/SimpleJson";
+import { materializeNode } from "../../binary/programBinary";
+import { ProgramBinaryWriter } from "../../binary/ProgramBinaryWriter";
+
+const URI = "inmemory:///main.sd";
+
+function compileToJson(text: string) {
+  const realWarn = console.warn;
+  const realError = console.error;
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    const c = new SparkdownCompiler();
+    c.configure({
+      files: [
+        {
+          uri: URI,
+          type: "script",
+          name: "main",
+          ext: "sd",
+          text,
+          version: 1,
+          languageId: "sparkdown",
+        },
+      ],
+    } as never);
+    return (c.compile({ textDocument: { uri: URI } } as never) as any).program
+      .compiled;
+  } finally {
+    console.warn = realWarn;
+    console.error = realError;
+  }
+}
+
+/** Exercises the shapes the writer has to get exactly right. */
+function corpus(): string {
+  const L: string[] = [];
+  L.push("title: Writer Equivalence");
+  L.push("");
+  L.push("define hero as character:");
+  L.push(`  name = "Hero"`);
+  L.push("");
+  L.push("const LIMIT = 3");
+  L.push("store trust = 0");
+  L.push("store ratio = 0.5");
+  L.push("store whole = 2.0");
+  L.push("list mood = (calm), tense");
+  L.push("");
+  L.push("function bonus(x):");
+  L.push("  return x * 2 + 1");
+  L.push("");
+  for (let s = 0; s < 5; s++) {
+    L.push(`scene scene_${s}`);
+    L.push(`= INT. ROOM ${s} - DAY`);
+    L.push(":");
+    L.push(`  Action ${s} with {trust} and {LIMIT}.`);
+    L.push("hero:");
+    L.push(`  Line ${s} — dash and {ratio}.`);
+    L.push("if trust > 2 then");
+    L.push(`  hero: Trusted ${s}.`);
+    L.push("else");
+    L.push(`  hero: Not yet ${s}.`);
+    L.push("end");
+    L.push("& trust = bonus(trust)");
+    L.push(`-> scene_${(s + 1) % 5}`);
+    L.push("end");
+    L.push("");
+  }
+  return L.join("\n");
+}
+
+/** What SimpleJson.Writer produces for the same story. */
+function viaJsonWriter(story: RuntimeStory): unknown {
+  const writer = new SimpleJson.Writer();
+  story.ToJson(writer);
+  return writer.toObject();
+}
+
+/** What ProgramBinaryWriter produces, materialized back for comparison. */
+function viaBinaryWriter(story: RuntimeStory): unknown {
+  const writer = new ProgramBinaryWriter();
+  story.ToJson(writer as never);
+  return materializeNode(writer.toBuffer());
+}
+
+describe("ProgramBinaryWriter", () => {
+  it("emits the same program as SimpleJson.Writer", () => {
+    const compiled = compileToJson(corpus());
+    expect(compiled, "corpus must compile").toBeTruthy();
+    const story = new RuntimeStory(compiled);
+    // Key ORDER is compared, not just structure: the program is compared as
+    // serialized text elsewhere in the pipeline, so an order-insensitive match
+    // would hide real drift.
+    expect(JSON.stringify(viaBinaryWriter(story))).toBe(
+      JSON.stringify(viaJsonWriter(story)),
+    );
+  });
+
+  it("produces a story that itself re-serializes identically", () => {
+    const compiled = compileToJson(corpus());
+    const story = new RuntimeStory(compiled);
+    const rebuilt = new RuntimeStory(viaBinaryWriter(story) as never);
+    expect(JSON.stringify(viaJsonWriter(rebuilt))).toBe(
+      JSON.stringify(viaJsonWriter(story)),
+    );
+  });
+
+  it("preserves the float markers the loader depends on", () => {
+    // "3.0f" / "inff" / "nanf" are load-bearing: without them a whole-number
+    // float reloads as an IntValue and `7 / 3.0` degrades to integer division.
+    const w = new ProgramBinaryWriter();
+    w.WriteArrayStart();
+    w.WriteFloat(3.0);
+    w.WriteFloat(0.5);
+    w.WriteFloat(Number.POSITIVE_INFINITY);
+    w.WriteFloat(Number.NEGATIVE_INFINITY);
+    w.WriteFloat(NaN);
+    w.WriteInt(7.9);
+    w.WriteBool(true);
+    w.WriteNull();
+    w.WriteArrayEnd();
+    expect(materializeNode(w.toBuffer())).toEqual([
+      "3.0f",
+      0.5,
+      "inff",
+      "-inff",
+      "nanf",
+      7, // WriteInt floors, matching SimpleJson
+      true,
+      null,
+    ]);
+  });
+
+  it("writes nothing for a null number, exactly like SimpleJson", () => {
+    // SimpleJson's WriteInt/WriteFloat/WriteBool return early on null, leaving
+    // the property with no value. The binary buffer has no way to express a
+    // childless Member, so it must fill one in rather than emit a corrupt
+    // record whose `end` implies a child that is not there.
+    const w = new ProgramBinaryWriter();
+    w.WriteObjectStart();
+    w.WriteIntProperty("missing", null as never);
+    w.WriteIntProperty("present", 4);
+    w.WriteObjectEnd();
+    expect(materializeNode(w.toBuffer())).toEqual({
+      missing: null,
+      present: 4,
+    });
+  });
+
+  it("round-trips a captured chunk through splice", () => {
+    // The phase 2 mechanism: capture a subtree as a portable chunk, then
+    // splice it into a DIFFERENT writer whose tables are interned differently,
+    // and get the same value back.
+    const source = new ProgramBinaryWriter();
+    source.WriteObjectStart();
+    source.WritePropertyStart("flow");
+    const mark = source.mark();
+    source.WriteArrayStart();
+    source.Write("ev");
+    source.Write(42);
+    source.WriteObjectStart();
+    source.WriteProperty("->", "target.path");
+    source.WriteObjectEnd();
+    source.Write("/ev");
+    source.WriteArrayEnd();
+    const chunk = source.captureChunk(mark);
+    source.WritePropertyEnd();
+    source.WriteObjectEnd();
+
+    // A fresh writer whose tables are populated in a different order, so a
+    // chunk that leaked absolute indices would decode to the wrong strings.
+    const target = new ProgramBinaryWriter();
+    target.WriteObjectStart();
+    target.WriteProperty("decoy", "unrelated");
+    target.WriteIntProperty("another", 999);
+    target.WritePropertyStart("flow");
+    target.WriteInjected(chunk);
+    target.WritePropertyEnd();
+    target.WriteObjectEnd();
+
+    expect(materializeNode(target.toBuffer())).toEqual({
+      decoy: "unrelated",
+      another: 999,
+      flow: ["ev", 42, { "->": "target.path" }, "/ev"],
+    });
+  });
+
+  it("captures a chunk from a real story flow and splices it back", () => {
+    const compiled = compileToJson(corpus());
+    const story = new RuntimeStory(compiled);
+    const expected = JSON.stringify(viaJsonWriter(story));
+
+    // Serialize once, arming a capture for every top-level flow...
+    const first = new ProgramBinaryWriter();
+    story.ToJson(first as never, {
+      resolve: (name: string, _container: unknown, serialize: () => unknown) => {
+        first.captureNextInjectedAs(name, "fp");
+        return serialize();
+      },
+    } as never);
+    const chunks = first.takeCapturedChunks();
+    expect(chunks.size, "corpus must have top-level flows").toBeGreaterThan(0);
+    expect(JSON.stringify(materializeNode(first.toBuffer()))).toBe(expected);
+
+    // ...then serialize again reusing every chunk, and expect the same program.
+    // This is the phase 2 claim: a flow that did not change is spliced from
+    // records instead of re-walked, with no observable difference.
+    const second = new ProgramBinaryWriter();
+    story.ToJson(second as never, {
+      resolve: (name: string) => chunks.get(name)!.chunk,
+    } as never);
+    expect(JSON.stringify(materializeNode(second.toBuffer()))).toBe(expected);
+  });
+});

--- a/packages/sparkdown/src/tests/compiler/programBinaryWriter.test.ts
+++ b/packages/sparkdown/src/tests/compiler/programBinaryWriter.test.ts
@@ -10,7 +10,10 @@ import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
 import { Story as RuntimeStory } from "../../inkjs/engine/Story";
 import { SimpleJson } from "../../inkjs/engine/SimpleJson";
 import { materializeNode } from "../../binary/programBinary";
-import { ProgramBinaryWriter } from "../../binary/ProgramBinaryWriter";
+import {
+  ProgramBinaryWriter,
+  createProgramTable,
+} from "../../binary/ProgramBinaryWriter";
 
 const URI = "inmemory:///main.sd";
 
@@ -158,10 +161,12 @@ describe("ProgramBinaryWriter", () => {
   });
 
   it("round-trips a captured chunk through splice", () => {
-    // The phase 2 mechanism: capture a subtree as a portable chunk, then
-    // splice it into a DIFFERENT writer whose tables are interned differently,
-    // and get the same value back.
-    const source = new ProgramBinaryWriter();
+    // The phase 2 mechanism: capture a subtree, then splice it into a DIFFERENT
+    // writer and get the same value back. Both writers SHARE the table, which
+    // is what makes the chunk a plain record copy — that sharing is the
+    // invariant, so the test exercises it rather than working around it.
+    const table = createProgramTable();
+    const source = new ProgramBinaryWriter(table);
     source.WriteObjectStart();
     source.WritePropertyStart("flow");
     const mark = source.mark();
@@ -177,9 +182,10 @@ describe("ProgramBinaryWriter", () => {
     source.WritePropertyEnd();
     source.WriteObjectEnd();
 
-    // A fresh writer whose tables are populated in a different order, so a
-    // chunk that leaked absolute indices would decode to the wrong strings.
-    const target = new ProgramBinaryWriter();
+    // A second writer that writes DIFFERENT content before the splice, so a
+    // chunk holding absolute end indices would land its subtree bounds in the
+    // wrong place. Sizes are relative, so it survives.
+    const target = new ProgramBinaryWriter(table);
     target.WriteObjectStart();
     target.WriteProperty("decoy", "unrelated");
     target.WriteIntProperty("another", 999);
@@ -201,7 +207,8 @@ describe("ProgramBinaryWriter", () => {
     const expected = JSON.stringify(viaJsonWriter(story));
 
     // Serialize once, arming a capture for every top-level flow...
-    const first = new ProgramBinaryWriter();
+    const table = createProgramTable();
+    const first = new ProgramBinaryWriter(table);
     story.ToJson(first as never, {
       resolve: (name: string, _container: unknown, serialize: () => unknown) => {
         first.captureNextInjectedAs(name, "fp");
@@ -215,7 +222,7 @@ describe("ProgramBinaryWriter", () => {
     // ...then serialize again reusing every chunk, and expect the same program.
     // This is the phase 2 claim: a flow that did not change is spliced from
     // records instead of re-walked, with no observable difference.
-    const second = new ProgramBinaryWriter();
+    const second = new ProgramBinaryWriter(table);
     story.ToJson(second as never, {
       resolve: (name: string) => chunks.get(name)!.chunk,
     } as never);


### PR DESCRIPTION
A binary compiled-program format for #314, shipped as an **opt-in option that is not the default**.

**Read the numbers before the code: binary is a wash on speed and ~10% on size.** It is here because a binary program format is worth having for its own sake — see "Why keep it" — not because it made compiles faster. The performance work that *did* pay off was not binary-specific and is split out into #348.

## Measured, current code, R&B, one candidate per process

| | serialize | hop | consumer | TOTAL | payload |
| --- | --- | --- | --- | --- | --- |
| JSON | 31.9 / 26.1 | 7.8 / 8.9 | 0 | **39.7 / 34.9 ms** | 417 KB |
| binary | 35.5 / 38.4 | 1.3 / 1.3 | 2.1 / 1.6 | **38.8 / 41.3 ms** | 377 KB |

The hop is a genuine ~6x win — cloning typed arrays is a memcpy, cloning a 33k-node object graph is not — but binary gives it back on serialization and materialization. End to end it is noise.

**Correction on size.** Earlier notes on this branch claimed binary roughly halved the payload. That was wrong: it counted the node array (195 KB) and silently omitted the string table. Counting both, it is 377 KB vs 417 KB — about 10%.

## Why keep it at all

A binary program format is a recurring request for reasons that have nothing to do with compile speed — inkle/ink#710 (faster reads, "slight code obfuscation" of narrative content, streaming) and inkle/ink#51 (small file size, fast loading, no third-party dependencies). Shipping a story as JSON means shipping the script in plain text.

Two artifacts exist for two different jobs:

- `encodeProgram()` / `decodeProgram()` — one self-contained blob with a magic + version byte. This is the one for **shipping or persisting** a story: not plain-readable, no dependencies.
- `program.compiledBuffer` — the loose pieces (`nodes`, `strings`, `numbers`). This is the one for the **worker hop**, where typed arrays clone as a memcpy and packing to bytes would cost ~10 ms for nothing.

Default stays JSON. `SparkdownCompilerConfig.binaryProgram` opts in.

## What is in here

**The format.** Modelled on lezer's `TreeBuffer`: fixed-width `[tag, payload, size]` records in one contiguous typed array; a subtree is a contiguous range. Both non-tag slots are deliberately position-INDEPENDENT — `size` is intrinsic (lezer's fourth value, not an end index), and `payload` points into a string/number table that persists across compiles (the analogue of lezer's grammar-fixed `NodeSet`). That is what makes splicing a cached flow a bulk memcpy rather than a per-node rewrite; an earlier revision used absolute indices and per-compile tables, which cost **13.0 ms/compile** in remapping.

**Per-flow reuse.** `ProgramBinaryWriter` answers the same streaming events as `SimpleJson.Writer`, so `Story.ToJson` drives it **unmodified** — no engine change was needed, because `WriteRuntimeContainer` already splices memo results through `WriteInjected`. Reuse guards are shared with the JSON path rather than reimplemented, so the two can never disagree about which flows are eligible.

**Table bounding.** The table is append-only so cached pointers stay valid, which means it grows — measured at exactly 1 dead string per keystroke. It reseeds at 1.5x live size, and stale chunks are refused with a throw rather than silently written into the program as data (a real bug the reseed tests caught).

**Transport.** `Game.updateProgram` resolves either representation once; the four `Boolean(program.compiled)` readiness gates now go through `hasCompiledProgram`, or a perfectly good binary program reads as "not compiled".

## Phase 4 (SharedArrayBuffer): dropped

Not on the blockers — on the payoff. Phase 3 left the hop at 1.79 ms, so SAB has ~**0.24 ms** to save. A SAB holds only bytes, so the string table cannot go in one without packing (2.11 ms) + decoding (2.07 ms) to save 1.10 ms of cloning: a net regression. Details and the COOP/COEP blocker list are on #314.

## Verification

- 21 binary tests + 4 transport tests. The gates that matter: driving `Story.ToJson` with the binary writer produces a program **identical to `SimpleJson.Writer`**; a compiler on the binary path stays identical to a **cold JSON compile across a sequence of edits** and when an edit **adds a whole new flow**; a Game builds **and runs** from a structured-cloned buffer; float markers (`"3.0f"`/`"inff"`/`"nanf"`) survive, without which `7 / 3.0` degrades to integer division.
- Full sparkdown suite green: **152 files / 1,787 tests**, zero failures (run in halves, capped forks). spark-engine green: 11 files / 229 tests.
- Live, **both paths**, in the running editor with the game preview rendering its title card:
  - default JSON path — unchanged, which is what matters since the four readiness gates moved to `hasCompiledProgram`;
  - binary path — confirmed *actually active*, not merely rendering the same. Identical rendering proves nothing on its own (it is equally consistent with the flag never taking effect), and a console marker does not survive the worker boundary. So the check reads an observable global from the **player frame's** main thread: `{ hasCompiled: false, hasBuffer: true, nodes: 285, strings: 44, ctor: "Uint16Array" }` with the game mounted.

## Related

- #348 — the fingerprint dispatch fix, split out: not binary-specific, 3-5x, helps the default path today.
- #345 — the LSP instance serializes ~25-30 ms of bytecode per keystroke that nobody reads.
- #346 — the player rebuilds the whole runtime hierarchy (~55 ms) on every recompile. The dominant per-edit cost, and 30x larger than anything in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
