### PR TITLE
fix(compiler): make filtered layered images actually render (#302)

### DIFF
--- a/packages/spark-engine/src/game/modules/ui/classes/FilteredLayeredImage.test.ts
+++ b/packages/spark-engine/src/game/modules/ui/classes/FilteredLayeredImage.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { UIModule } from "./UIModule";
+
+/**
+ * #302: a `filtered_image` whose root is a `layered_image` resolves to the
+ * SUBSET of layers the filter leaves behind, not to a single flattened src.
+ *
+ * `getImageSrcsByName` used to check only `filtered_src` -- which the layered
+ * branch of `filterImage` never sets -- then fall through to lookups keyed by
+ * the FILTERED name, miss both, and return null. So a filtered layered image
+ * drew nothing at all, and the layer set the compiler computed had no reader
+ * on this path.
+ */
+
+/** Exposes the resolution path under test without booting a Game. */
+class ProbeUIModule extends UIModule {
+  constructor(context: any) {
+    super({} as any);
+    (this as any)._context = context;
+    Object.defineProperty(this, "context", {
+      get: () => context,
+      configurable: true,
+    });
+  }
+}
+
+const image = (name: string) => ({
+  $type: "image",
+  $name: name,
+  src: `/file:/local/assets/${name}.png?v=1`,
+});
+
+/** The shape the compiler emits: bare references carry `$type: ""`. */
+const ref = (name: string) => ({ $type: "", $name: name });
+
+const context = {
+  filter: {
+    hat_filter: { $type: "filter", $name: "hat_filter", includes: [""], excludes: ["hat"] },
+  },
+  image: {
+    portrait__hat: image("portrait__hat"),
+    portrait__body: image("portrait__body"),
+  },
+  layered_image: {
+    portrait: {
+      $type: "layered_image",
+      $name: "portrait",
+      assets: {
+        "filter hat": ref("portrait__hat"),
+        "filter default body": ref("portrait__body"),
+      },
+    },
+  },
+  filtered_image: {
+    p: {
+      $type: "filtered_image",
+      $name: "p",
+      image: ref("portrait"),
+      filters: [ref("hat_filter")],
+    },
+  },
+};
+
+describe("filtered image over a layered root", () => {
+  it("resolves to the surviving layers instead of nothing", () => {
+    const ui = new ProbeUIModule(structuredClone(context));
+    expect(ui.getImageSrcsByName("p")).toEqual([
+      "/file:/local/assets/portrait__body.png?v=1",
+    ]);
+  });
+
+  it("still resolves a plain layered image unfiltered", () => {
+    const ui = new ProbeUIModule(structuredClone(context));
+    expect(ui.getImageSrcsByName("portrait")).toEqual([
+      "/file:/local/assets/portrait__hat.png?v=1",
+      "/file:/local/assets/portrait__body.png?v=1",
+    ]);
+  });
+
+  it("terminates when a layer points back at the filtered image", () => {
+    // `portrait` lists `p` as a layer, and `p` filters `portrait` -- authorable,
+    // and the untyped fan-out re-enters getImageAssets, so an unguarded
+    // recursion blows the stack instead of rendering a missing image.
+    const cyclic = structuredClone(context) as any;
+    cyclic.layered_image.portrait.assets = { 0: ref("p") };
+    const ui = new ProbeUIModule(cyclic);
+    expect(() => ui.getImageSrcsByName("p")).not.toThrow();
+  });
+
+  it("keeps a surviving layer that is itself a group", () => {
+    // Layers are bare references carrying an empty `$type`, and one can name a
+    // layered_image rather than an image -- resolving them with a direct
+    // `context.image` lookup drops the whole group.
+    const nested = structuredClone(context) as any;
+    nested.image.eyes__open = image("eyes__open");
+    nested.image.eyes__brow = image("eyes__brow");
+    nested.layered_image.eyes = {
+      $type: "layered_image",
+      $name: "eyes",
+      assets: { 0: ref("eyes__open"), 1: ref("eyes__brow") },
+    };
+    nested.layered_image.portrait.assets["filter default eyes"] = ref("eyes");
+
+    expect(nested.filtered_image.p).toBeDefined();
+    expect(new ProbeUIModule(nested).getImageSrcsByName("p")).toEqual([
+      "/file:/local/assets/portrait__body.png?v=1",
+      "/file:/local/assets/eyes__open.png?v=1",
+      "/file:/local/assets/eyes__brow.png?v=1",
+    ]);
+  });
+});

--- a/packages/spark-engine/src/game/modules/ui/classes/UIModule.ts
+++ b/packages/spark-engine/src/game/modules/ui/classes/UIModule.ts
@@ -303,12 +303,20 @@ export class UIModule extends Module<UIState, UIMessageMap, UIBuiltins> {
     return `${ease.function}(${ease.parameters.join(",")})`;
   }
 
-  getImageAssets(type: string, name: string) {
+  getImageAssets(type: string, name: string, visited = new Set<string>()) {
+    // `a` -> filtered `a` -> `a` is authorable, and the untyped fan-out below
+    // re-enters this method, so without a guard a cycle recurses until the
+    // stack blows rather than rendering a missing image.
+    const visitKey = `${type}:${name}`;
+    if (visited.has(visitKey)) {
+      return [];
+    }
+    visited.add(visitKey);
     if (!type) {
       const images: Image[] = [];
-      images.push(...this.getImageAssets("filtered_image", name));
-      images.push(...this.getImageAssets("layered_image", name));
-      images.push(...this.getImageAssets("image", name));
+      images.push(...this.getImageAssets("filtered_image", name, visited));
+      images.push(...this.getImageAssets("layered_image", name, visited));
+      images.push(...this.getImageAssets("image", name, visited));
       return images;
     }
     if (type === "image") {
@@ -326,7 +334,12 @@ export class UIModule extends Module<UIState, UIMessageMap, UIBuiltins> {
         // `Object.values(undefined)` and abort the whole UI restore.
         for (const image of Object.values(layeredImage.assets ?? {})) {
           if (image && typeof image === "object") {
-            images.push(...this.getImageAssets(image.$type, image.$name));
+            // Branch the guard per layer: it exists to stop cycles along one
+            // path, and sharing it would drop a layer that legitimately
+            // reuses an asset an earlier layer already used.
+            images.push(
+              ...this.getImageAssets(image.$type, image.$name, new Set(visited)),
+            );
           }
         }
         return images;
@@ -345,9 +358,18 @@ export class UIModule extends Module<UIState, UIMessageMap, UIBuiltins> {
         }
         if (filteredImage.filtered_layers) {
           for (const layer of filteredImage.filtered_layers) {
-            const image = this.context?.image?.[layer?.$name];
-            if (image) {
-              images.push(image);
+            if (layer && typeof layer === "object") {
+              // Resolve each surviving layer the same way the layered_image
+              // branch does: a layer can itself be a group, and the compiler
+              // emits bare references with an empty `$type`, so a direct
+              // `context.image` lookup would silently drop it.
+              images.push(
+                ...this.getImageAssets(
+                  layer.$type,
+                  layer.$name,
+                  new Set(visited),
+                ),
+              );
             }
           }
         }
@@ -360,9 +382,23 @@ export class UIModule extends Module<UIState, UIMessageMap, UIBuiltins> {
   getImageSrcsByName(name: string) {
     const imageName = name.includes("~") ? sortFilteredName(name) : name;
     if (this.context?.filtered_image?.[imageName]) {
-      filterImage(this.context, this.context?.filtered_image?.[imageName]);
-      if (this.context?.filtered_image?.[imageName].filtered_src) {
-        return [this.context?.filtered_image?.[imageName].filtered_src];
+      const filteredImage = this.context.filtered_image[imageName];
+      filterImage(this.context, filteredImage);
+      if (filteredImage.filtered_src) {
+        return [filteredImage.filtered_src];
+      }
+      // A layered root yields no single flattened src — it filters down to the
+      // subset of layers that survived, which still has to be composited.
+      // Only claim the lookup when something survived: an empty array would
+      // join into a trailing empty `background-image` component, which
+      // invalidates the whole declaration and blanks sibling images too.
+      if (filteredImage.filtered_layers?.length) {
+        const srcs = this.getImageAssets("filtered_image", imageName).map(
+          (asset) => asset.src,
+        );
+        if (srcs.length > 0) {
+          return srcs;
+        }
       }
     }
     if (this.context?.layered_image?.[imageName]) {

--- a/packages/sparkdown/src/compiler/utils/filterImage.ts
+++ b/packages/sparkdown/src/compiler/utils/filterImage.ts
@@ -84,6 +84,13 @@ export const filterImage = (
           imageToFilter.$type === "image" &&
           !imageToFilter.$name.startsWith("$")
         ) {
+          // Structs are carried across incremental compiles by identity, so a
+          // root that flipped from layered_image to image would otherwise keep
+          // the layer set derived when it was still layered, and consumers
+          // would draw it alongside the fresh `filtered_src`. (The reverse
+          // flip stays stale: `filtered_src` is already set by then, so the
+          // early-out above means this never re-runs.)
+          filteredImage.filtered_layers = undefined;
           if (imageToFilter.data) {
             filteredImage.filtered_src = filterSVG(
               imageToFilter.data,
@@ -105,8 +112,13 @@ export const filterImage = (
           imageToFilter.$type === "layered_image" &&
           !imageToFilter.$name.startsWith("$")
         ) {
-          // One array across every layer: the result is the SET of layers
-          // matching the filter, so it must outlive a single iteration.
+          // `filtered_layers` is the set of layers to DRAW, so it accumulates
+          // the layers the filter does NOT match: `filterMatchesName` selects
+          // what gets filtered OUT (`filterSVG` deletes the nodes it matches).
+          // Layers that aren't filterable, and `default` ones, never match and
+          // so always survive — which is what makes a filter-less
+          // `filtered_image` show exactly the default layers.
+          // One array across every layer, so it outlives a single iteration.
           const filteredLayers: {
             $type: "image";
             $name: string;
@@ -118,14 +130,11 @@ export const filterImage = (
             imageToFilter.assets ?? {},
           )) {
             const keyIsArrayIndex = !Number.isNaN(Number(key));
-            if (keyIsArrayIndex) {
-              if (filterMatchesName(layerImage.$name, combinedFilter)) {
-                filteredLayers.push(layerImage);
-              }
-            } else {
-              if (filterMatchesName(key, combinedFilter)) {
-                filteredLayers.push(layerImage);
-              }
+            // Positional entries carry no key to match on, so the layer's own
+            // name is the subject; a keyed table names each layer by its key.
+            const layerName = keyIsArrayIndex ? layerImage.$name : key;
+            if (!filterMatchesName(layerName, combinedFilter)) {
+              filteredLayers.push(layerImage);
             }
           }
           filteredImage.filtered_layers = filteredLayers;

--- a/packages/sparkdown/src/compiler/utils/filterImage.ts
+++ b/packages/sparkdown/src/compiler/utils/filterImage.ts
@@ -105,13 +105,18 @@ export const filterImage = (
           imageToFilter.$type === "layered_image" &&
           !imageToFilter.$name.startsWith("$")
         ) {
+          // One array across every layer: the result is the SET of layers
+          // matching the filter, so it must outlive a single iteration.
+          const filteredLayers: {
+            $type: "image";
+            $name: string;
+          }[] = [];
+          // `assets` is absent on a malformed or still-being-typed
+          // layered_image, and this runs on every hover and preview — guard so
+          // one incomplete struct doesn't throw out of the whole compile.
           for (const [key, layerImage] of Object.entries(
-            imageToFilter.assets,
+            imageToFilter.assets ?? {},
           )) {
-            const filteredLayers: {
-              $type: "image";
-              $name: string;
-            }[] = [];
             const keyIsArrayIndex = !Number.isNaN(Number(key));
             if (keyIsArrayIndex) {
               if (filterMatchesName(layerImage.$name, combinedFilter)) {
@@ -122,8 +127,8 @@ export const filterImage = (
                 filteredLayers.push(layerImage);
               }
             }
-            filteredImage.filtered_layers = filteredLayers;
           }
+          filteredImage.filtered_layers = filteredLayers;
         }
       }
     }

--- a/packages/sparkdown/src/compiler/utils/getImagePreviewSrc.ts
+++ b/packages/sparkdown/src/compiler/utils/getImagePreviewSrc.ts
@@ -44,7 +44,25 @@ export const getImagePreviewSrc = (
     if (struct["filtered_src"]) {
       return struct["filtered_src"];
     }
-    // Raster or layered root: nothing to filter, so preview the root itself.
+    const filteredLayers = struct["filtered_layers"];
+    if (filteredLayers?.length) {
+      // A layered root filters down to the layers that survived. Previewing
+      // the root instead would show a layer the filter removes -- which is
+      // what happens whenever exactly one layer survives, since the compositor
+      // skips anything with fewer than two.
+      for (const layer of filteredLayers) {
+        const src = getImagePreviewSrc(
+          context,
+          resolveImageReference(context, layer),
+          visited,
+        );
+        if (src) {
+          return src;
+        }
+      }
+      return undefined;
+    }
+    // Raster root, or nothing survived: preview the root itself.
     return getImagePreviewSrc(
       context,
       resolveImageReference(context, struct["image"]),

--- a/packages/sparkdown/src/compiler/utils/resolveImageLayers.ts
+++ b/packages/sparkdown/src/compiler/utils/resolveImageLayers.ts
@@ -55,6 +55,19 @@ export const resolveImageLayers = (
       // context — there is no file to read behind it.
       return [{ src: struct["filtered_src"] }];
     }
+    const filteredLayers = struct["filtered_layers"];
+    if (filteredLayers) {
+      // A layered root filters down to a subset of its layers. Descending into
+      // the unfiltered root instead would show the author a preview carrying
+      // layers the running game drops.
+      return filteredLayers.flatMap((layer: unknown) =>
+        resolveImageLayers(
+          context,
+          resolveImageReference(context, layer),
+          new Set(visited),
+        ),
+      );
+    }
     return resolveImageLayers(
       context,
       resolveImageReference(context, struct["image"]),

--- a/packages/sparkdown/src/tests/compiler/FilterImageLayers.test.ts
+++ b/packages/sparkdown/src/tests/compiler/FilterImageLayers.test.ts
@@ -1,26 +1,29 @@
 // #302: filtering a `layered_image` root must consider EVERY layer. The result
 // was built inside the per-asset loop, so each iteration discarded the previous
-// one and `filtered_layers` ended up holding at most the last selected layer —
-// or nothing at all, when the final layer wasn't selected even though earlier
-// ones were.
+// one and `filtered_layers` ended up holding at most one layer — or none at
+// all, when the final layer didn't decide it.
 //
-// These compile real `.sd` source rather than hand-building a context: the
+// `filtered_layers` is the set of layers to DRAW (`UIModule.getImageAssets`
+// renders it), and `filterMatchesName` selects what gets filtered OUT — the
+// same predicate `filterSVG` uses to delete nodes. So a layer survives when the
+// predicate says false. Verified through both tables:
+//   excludes ["hat"]        -> "filter hat" true,       "filter default body" false
+//   includes ["look_left"]  -> "filter look_right" true, "filter look_left"   false
+// i.e. true marks the layer the author is filtering away, in both directions.
+//
+// These compile real `.sd` source rather than hand-building a context, so the
 // selection runs against the reference shapes the compiler actually emits
-// (bare references carry `$type: ""`, and `assets` keys survive verbatim), so
-// the test can't drift from the real struct layout.
-//
-// `filterMatchesName` needs the standalone word `filter` in the name it tests,
-// and never selects a name tagged `default`. Positional `assets` entries are
-// matched on the layer's `$name`, which is a sparkdown identifier and so can
-// never contain a standalone `filter`; the keyed form below is the shape that
-// actually reaches the selection. Whether the selected set denotes the layers
-// to draw or the layers to drop is a separate question this test takes no
-// position on — it pins accumulation only.
+// (bare references carry `$type: ""`, and `assets` keys survive verbatim).
+// Positional entries are matched on the layer's `$name`, which is a sparkdown
+// identifier and so can never contain a standalone `filter`; the keyed form is
+// the shape that reaches the selection.
 
 import { describe, expect, it } from "vitest";
 import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
 import { File } from "../../compiler/types/File";
 import { filterImage } from "../../compiler/utils/filterImage";
+import { getImagePreviewSrc } from "../../compiler/utils/getImagePreviewSrc";
+import { resolveImageLayers } from "../../compiler/utils/resolveImageLayers";
 
 const MAIN_URI = "file://proj/main.sd";
 
@@ -74,7 +77,7 @@ define p as filtered_image with
 end
 `;
 
-const selectedLayers = (program: any) => {
+const drawnLayers = (program: any) => {
   const filteredImage = program.context?.filtered_image?.p;
   filterImage(program.context, filteredImage);
   return (filteredImage.filtered_layers ?? []).map(
@@ -83,27 +86,33 @@ const selectedLayers = (program: any) => {
 };
 
 describe("filterImage over a layered_image root", () => {
-  it("accumulates every selected layer, not just the last one", () => {
+  it("keeps every layer the filter does not remove, not just one", () => {
     const program = compile(
       source(
         {
           "filter hat": "portrait__hat",
           "filter default body": "portrait__body",
           "filter scarf": "portrait__scarf",
+          "filter default shoes": "portrait__shoes",
         },
         ["hat", "scarf"],
       ),
-      ["portrait__hat", "portrait__body", "portrait__scarf"],
+      [
+        "portrait__hat",
+        "portrait__body",
+        "portrait__scarf",
+        "portrait__shoes",
+      ],
     );
-    expect(selectedLayers(program)).toEqual([
-      "portrait__hat",
-      "portrait__scarf",
+    // Two survivors, non-adjacent, spanning the first and last iterations —
+    // the shape the per-iteration overwrite could not produce.
+    expect(drawnLayers(program)).toEqual([
+      "portrait__body",
+      "portrait__shoes",
     ]);
   });
 
-  it("keeps an earlier selection when the final layer is not selected", () => {
-    // The overwrite's worst shape: the last iteration replaced a real result
-    // with an empty array, reporting that nothing was selected at all.
+  it("removes only what the filter names", () => {
     const program = compile(
       source(
         {
@@ -114,7 +123,68 @@ describe("filterImage over a layered_image root", () => {
       ),
       ["portrait__hat", "portrait__body"],
     );
-    expect(selectedLayers(program)).toEqual(["portrait__hat"]);
+    expect(drawnLayers(program)).toEqual(["portrait__body"]);
+  });
+
+  it("draws every default layer when the filter removes nothing", () => {
+    // A filter-less filtered_image shows exactly the default layers.
+    const program = compile(
+      `define portrait as layered_image with
+  assets = {
+    ["filter hat"] = portrait__hat,
+    ["filter default body"] = portrait__body,
+  }
+end
+
+define p as filtered_image with
+  image = portrait
+end
+`,
+      ["portrait__hat", "portrait__body"],
+    );
+    expect(drawnLayers(program)).toEqual(["portrait__body"]);
+  });
+
+  it("previews the same layers the game draws", () => {
+    // resolveImageLayers feeds hover previews and thumbnails. Descending into
+    // the unfiltered root would show the author layers the game drops.
+    const program = compile(
+      source(
+        {
+          "filter hat": "portrait__hat",
+          "filter default body": "portrait__body",
+        },
+        ["hat"],
+      ),
+      ["portrait__hat", "portrait__body"],
+    );
+    expect(
+      resolveImageLayers(
+        program.context,
+        program.context?.filtered_image?.p,
+      ).map((l) => l.src),
+    ).toEqual(["/file:/local/assets/portrait__body.png?v=1"]);
+  });
+
+  it("hovers the surviving layer, not the one the filter removed", () => {
+    // getImagePreviewSrc is what hover falls back to whenever fewer than two
+    // layers survive -- i.e. the usual case, since a filter normally leaves
+    // one variant. Descending into the root would preview the removed layer.
+    const program = compile(
+      source(
+        {
+          "filter hat": "portrait__hat",
+          "filter default body": "portrait__body",
+        },
+        ["hat"],
+      ),
+      ["portrait__hat", "portrait__body"],
+    );
+    const filteredImage = program.context?.filtered_image?.p;
+    filterImage(program.context, filteredImage);
+    expect(getImagePreviewSrc(program.context, filteredImage)).toBe(
+      "/file:/local/assets/portrait__body.png?v=1",
+    );
   });
 
   it("survives a layered_image that has no assets yet", () => {
@@ -131,8 +201,8 @@ end
 `,
       [],
     );
-    expect(() => selectedLayers(program)).not.toThrow();
-    expect(selectedLayers(program)).toEqual([]);
+    expect(() => drawnLayers(program)).not.toThrow();
+    expect(drawnLayers(program)).toEqual([]);
   });
 
   it("re-derives the same set when called again on the same struct", () => {
@@ -143,19 +213,13 @@ end
       source(
         {
           "filter hat": "portrait__hat",
-          "filter scarf": "portrait__scarf",
+          "filter default body": "portrait__body",
         },
-        ["hat", "scarf"],
+        ["hat"],
       ),
-      ["portrait__hat", "portrait__scarf"],
+      ["portrait__hat", "portrait__body"],
     );
-    expect(selectedLayers(program)).toEqual([
-      "portrait__hat",
-      "portrait__scarf",
-    ]);
-    expect(selectedLayers(program)).toEqual([
-      "portrait__hat",
-      "portrait__scarf",
-    ]);
+    expect(drawnLayers(program)).toEqual(["portrait__body"]);
+    expect(drawnLayers(program)).toEqual(["portrait__body"]);
   });
 });

--- a/packages/sparkdown/src/tests/compiler/FilterImageLayers.test.ts
+++ b/packages/sparkdown/src/tests/compiler/FilterImageLayers.test.ts
@@ -1,0 +1,161 @@
+// #302: filtering a `layered_image` root must consider EVERY layer. The result
+// was built inside the per-asset loop, so each iteration discarded the previous
+// one and `filtered_layers` ended up holding at most the last selected layer —
+// or nothing at all, when the final layer wasn't selected even though earlier
+// ones were.
+//
+// These compile real `.sd` source rather than hand-building a context: the
+// selection runs against the reference shapes the compiler actually emits
+// (bare references carry `$type: ""`, and `assets` keys survive verbatim), so
+// the test can't drift from the real struct layout.
+//
+// `filterMatchesName` needs the standalone word `filter` in the name it tests,
+// and never selects a name tagged `default`. Positional `assets` entries are
+// matched on the layer's `$name`, which is a sparkdown identifier and so can
+// never contain a standalone `filter`; the keyed form below is the shape that
+// actually reaches the selection. Whether the selected set denotes the layers
+// to draw or the layers to drop is a separate question this test takes no
+// position on — it pins accumulation only.
+
+import { describe, expect, it } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+import { File } from "../../compiler/types/File";
+import { filterImage } from "../../compiler/utils/filterImage";
+
+const MAIN_URI = "file://proj/main.sd";
+
+const assetFile = (name: string): File => ({
+  uri: `file://proj/assets/${name}.png`,
+  type: "image",
+  name,
+  ext: "png",
+  src: `/file:/local/assets/${name}.png?v=1`,
+});
+
+const compile = (text: string, assets: string[]) => {
+  const compiler = new SparkdownCompiler();
+  compiler.configure({
+    files: [
+      {
+        uri: MAIN_URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text,
+        version: 1,
+        languageId: "sparkdown",
+      },
+      ...assets.map(assetFile),
+    ],
+  });
+  return compiler.compile({ textDocument: { uri: MAIN_URI } }).program;
+};
+
+/** `.sd` source for a filtered layered image, with `excludes` as authored. */
+const source = (
+  layers: Record<string, string>,
+  excludes: string[],
+) => `define hat_filter as filter with
+  includes = { "" },
+  excludes = { ${excludes.map((e) => `"${e}"`).join(", ")} }
+end
+
+define portrait as layered_image with
+  assets = {
+${Object.entries(layers)
+  .map(([key, asset]) => `    ["${key}"] = ${asset},`)
+  .join("\n")}
+  }
+end
+
+define p as filtered_image with
+  image = portrait,
+  filters = { hat_filter }
+end
+`;
+
+const selectedLayers = (program: any) => {
+  const filteredImage = program.context?.filtered_image?.p;
+  filterImage(program.context, filteredImage);
+  return (filteredImage.filtered_layers ?? []).map(
+    (l: { $name: string }) => l.$name,
+  );
+};
+
+describe("filterImage over a layered_image root", () => {
+  it("accumulates every selected layer, not just the last one", () => {
+    const program = compile(
+      source(
+        {
+          "filter hat": "portrait__hat",
+          "filter default body": "portrait__body",
+          "filter scarf": "portrait__scarf",
+        },
+        ["hat", "scarf"],
+      ),
+      ["portrait__hat", "portrait__body", "portrait__scarf"],
+    );
+    expect(selectedLayers(program)).toEqual([
+      "portrait__hat",
+      "portrait__scarf",
+    ]);
+  });
+
+  it("keeps an earlier selection when the final layer is not selected", () => {
+    // The overwrite's worst shape: the last iteration replaced a real result
+    // with an empty array, reporting that nothing was selected at all.
+    const program = compile(
+      source(
+        {
+          "filter hat": "portrait__hat",
+          "filter default body": "portrait__body",
+        },
+        ["hat"],
+      ),
+      ["portrait__hat", "portrait__body"],
+    );
+    expect(selectedLayers(program)).toEqual(["portrait__hat"]);
+  });
+
+  it("survives a layered_image that has no assets yet", () => {
+    // Reached on every hover and preview, so a half-typed define must not
+    // throw `Object.entries(undefined)` out of the compile.
+    const program = compile(
+      `define portrait as layered_image with
+  scale = 1
+end
+
+define p as filtered_image with
+  image = portrait
+end
+`,
+      [],
+    );
+    expect(() => selectedLayers(program)).not.toThrow();
+    expect(selectedLayers(program)).toEqual([]);
+  });
+
+  it("re-derives the same set when called again on the same struct", () => {
+    // A layered root never sets `filtered_src`, so the early-out in filterImage
+    // never latches and the loop re-runs on every hover, preview and image
+    // lookup. Accumulating INTO the existing array would grow it each time.
+    const program = compile(
+      source(
+        {
+          "filter hat": "portrait__hat",
+          "filter scarf": "portrait__scarf",
+        },
+        ["hat", "scarf"],
+      ),
+      ["portrait__hat", "portrait__scarf"],
+    );
+    expect(selectedLayers(program)).toEqual([
+      "portrait__hat",
+      "portrait__scarf",
+    ]);
+    expect(selectedLayers(program)).toEqual([
+      "portrait__hat",
+      "portrait__scarf",
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #302.

Filtering a `layered_image` didn't work at all. Three things were wrong, and
fixing only the one in the ticket would have left the feature dead — so this
does all three.

## 1. The layer set was overwritten on every iteration

`filterImage` built `filtered_layers` inside its per-asset loop, so each layer
discarded the previous result: at most one layer survived, and none at all when
the last layer wasn't the deciding one. Hoisted above the loop, assigned once
after it.

## 2. It collected the complement of what it should

`filtered_layers` is the set of layers to **draw** — `UIModule.getImageAssets`
renders it. But `filterMatchesName` selects what gets filtered **out**: it's the
same predicate `filterSVG` uses to *delete* nodes. The loop pushed on a match,
so it accumulated exactly the layers meant to disappear.

Verified through both tables, since each drives a different clause:

| filter | layer | `filterMatchesName` |
| --- | --- | --- |
| `excludes: ["hat"]` | `filter hat` | **true** |
| | `filter default body` | false |
| `includes: ["look_left"]` | `filter look_right` | **true** |
| | `filter look_left` | false |

`true` lands on the layer being filtered away in both directions. The condition
is now `!filterMatchesName(...)`.

This also makes `SparkdownCompiler.ts:3250` true as written — the implicit
`filtered_image` is created with `filters: []` and the comment *"so it only
displays default layers by default"*. Under `filters: []` the predicate is true
for filterable non-`default` layers, so the surviving set is exactly the
`default` and non-filterable ones.

## 3. Nothing ever read the result

`getImageSrcsByName` checked only `filtered_src`, which the layered branch never
sets. It then fell through to lookups keyed by the *filtered* name, missed both,
and returned `null` — so a filtered layered image drew nothing. It now resolves
the surviving layers through `getImageAssets`.

`resolveImageLayers` and `getImagePreviewSrc` now honour `filtered_layers` too.
Without both, the editor and the game disagree: hover previews and thumbnails
descended into the *unfiltered* root and showed exactly the layer the filter
removes. `getImagePreviewSrc` matters specifically because `getImageComposite`
skips compositing below two layers, so it's the path taken whenever a filter
leaves a single variant — the common case.

Also:

- `getImageAssets` now threads a visited set. The filtered branch recurses
  through the untyped fan-out, and `layered_image portrait { p }` +
  `filtered_image p { portrait }` is authorable — that recursed until the stack
  blew. Pinned by a test that fails with `RangeError: Maximum call stack size
  exceeded` when the guard is disabled. The set is branched per layer, matching
  `resolveImageLayers`, so a repeated asset isn't dropped.
- `getImageSrcsByName` only claims the lookup when a layer actually survived —
  an empty array joins into a trailing empty `background-image` component,
  which invalidates the whole declaration and blanks sibling images too.
- `Object.entries(assets)` is guarded for a still-being-typed `layered_image`,
  which previously threw `TypeError` out of every hover and preview.
- `filtered_layers` is cleared on the plain-image branch so a stale layer set
  can't be drawn beside a fresh `filtered_src`.

## Verified in the running editor

Same script, same beat, same route (`main : 29 → main : 32`), two opaque CDN
layers where `excludes = { "hat" }`:

| | Game Preview |
| --- | --- |
| `origin/main`, `[[p]]` | **nothing renders** |
| this branch, `[[portrait]]` (unfiltered) | **HAT** — top layer covers the body |
| this branch, `[[p]]` (filtered) | **BODY** — hat removed, survivor composites |

I looked at all three. Screenshots attached below.

## Tests

`packages/sparkdown/src/tests/compiler/FilterImageLayers.test.ts` (5) compiles
real `.sd` source rather than hand-building a context — my first draft built it
by hand with `$type: "image"`, but real compiled references carry `$type: ""`,
so that fixture would have stayed green while every real program broke.
Compiling also pins that positional `assets` entries can never reach this code
(their `$name` is a sparkdown identifier; `filterMatchesName` needs a standalone
`filter`, which `_` word-boundaries block) — the keyed form is the only route.

`packages/spark-engine/src/game/modules/ui/classes/FilteredLayeredImage.test.ts`
(4) pins the render path end to end, including the cycle and a surviving layer
that is itself a group.

Red/green (§5b):

- All 7 compiler tests fail against `origin/main`'s `filterImage`, e.g.
  `expected [] to deeply equal [ 'portrait__body', 'portrait__shoes' ]`, and the
  missing-`assets` case fails by throwing `TypeError`.
- The render-path test fails with the UIModule change reverted:
  `expected null to deeply equal [ Array(1) ]`.
- The cycle test fails with the visited guard disabled:
  `RangeError: Maximum call stack size exceeded`.

The lead case uses four layers with two non-adjacent survivors spanning the
first and last iterations — a shape the per-iteration overwrite could not
produce regardless of which layer decided it.

## Suites

| Suite | Result |
| --- | --- |
| `packages/sparkdown` compiler + runtime | 67 files (2 skipped), 872 tests (24 skipped), all passing |
| `packages/spark-engine` | 11 files, 229 tests, all passing |

No pre-existing failures encountered. The pre-existing `ImagePreviewSrc`,
`ImageComposite` and `ResolveImageLayerSrcs` suites all still pass, which is
the check that matters for the preview-path changes.

## Deliberately not changed

- **`populateFilteredImages` is dead code** (zero callers). It would populate
  `filtered_layers` for every `filtered_image` at compile time; the lazy
  `filterImage` call makes the feature work without it, and wiring it in would
  grow the program payload that #299 exists to shrink.
- **`keyIsArrayIndex` misclassifies non-index keys.** `!Number.isNaN(Number(key))`
  is true for `""`, `"1990"`, `"1e3"`, `"Infinity"`, so those keys match on the
  layer `$name` instead of the key. Pre-existing and orthogonal.
- **The `image` → `layered_image` staleness direction.** `filterImage` early-outs
  on `filtered_src`, so a root flipping that way never re-derives. Fixing it
  means reworking that memo, which is beyond this change; the comment now says
  so rather than implying both directions are covered.
- **The untyped fan-out can double-draw** a name that is both an `image` and a
  same-named implicit `filtered_image` once something has latched
  `filtered_src` onto it. Pre-existing on the `layered_image` recursion path.

Happy to file any of these as follow-ups.
