### PR TITLE
fix(compiler): stop formatting annotations accumulating per keystroke (#322)

### DIFF
--- a/packages/sparkdown/src/compiler/classes/SparkdownCombinedAnnotator.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCombinedAnnotator.ts
@@ -156,6 +156,100 @@ export class SparkdownCombinedAnnotator {
     return ranges;
   }
 
+  /**
+   * Drop re-emissions that the delete-filter would not have removed.
+   *
+   * The incremental update deletes every existing annotation overlapping the
+   * re-annotated window `[keptFrom, keptTo]` and re-adds whatever the partial
+   * `tree.iterate` produced. The DELETE half is exact: Lezer only enters a node
+   * that overlaps the iterate range, so an annotation carrying its node's own
+   * `[from, to]` overlaps the window too and is always removed before it can be
+   * re-added.
+   *
+   * Annotations anchored somewhere OTHER than the node's full range escape
+   * that. A zero-width mark at a node's START (`top_level_begin`) sits before
+   * `keptFrom` whenever the parser restarts at an in-block split point, and a
+   * mark at a node's END (`frontmatter_end`, `keyword_separator`) can sit past
+   * `keptTo`; either way the node is still entered, so the old copy is KEPT
+   * *and* an identical fresh copy is added. `RangeSet` does not dedup, so the
+   * set grows by one entry per keystroke, unbounded, for as long as typing
+   * continues inside one block (#322).
+   *
+   * So: for a candidate outside the window, keep it only to the extent that
+   * the surviving copies do not already account for it. Prune is by COUNT, not
+   * by presence: if this pass emits K identical out-of-window annotations and
+   * M survive, keep `K - M` of them. Testing presence alone would collapse a
+   * legitimate 1 → K increase down to M (cold parses really do emit identical
+   * duplicate `formatting` marks — e.g. two `separator`s at the same offset).
+   *
+   * Value identity is `===` on `type`. That covers the annotators whose `type`
+   * is a string or `undefined` — `formatting`, `declarations`, `characters`,
+   * `links`. The rest (`semantics`, `colors`, `references`, `lenses`,
+   * `compilations`, `validations`, `implicits`) carry a freshly allocated
+   * object per `enter`, so `===` never holds and this guard is a no-op for
+   * them. That is deliberately conservative — never dropping something that
+   * might not be a duplicate.
+   *
+   * What this does NOT fix, all pre-existing and tracked in #326:
+   * - `references` and `validations` also emit non-node-anchored ranges, and
+   *   being object-valued they keep the #322 growth shape.
+   * - The RE-ADD half of the window is not exact in the other direction
+   *   either: a partial pass is not the cold pass restricted to the window,
+   *   because annotators carry cross-window state that `begin()` resets
+   *   (`SemanticAnnotator.scopeStack`, `FormattingAnnotator.processedLineFrom`).
+   *   An in-block window can therefore DROP annotations a cold parse emits.
+   * - Nothing removes an out-of-window annotation the new parse no longer
+   *   emits; the filter keeps it and the partial iterate never visits it.
+   * - A set that already carries N stale copies stays pinned at N: this stops
+   *   the growth, it does not repair a set that has already grown.
+   */
+  protected pruneRedundant<T extends SparkdownAnnotation<any>>(
+    add: Range<T>[],
+    current: RangeSet<T>,
+    keptFrom: number,
+    keptTo: number,
+  ): Range<T>[] {
+    let redundant: Set<number> | undefined;
+    // How many identical copies this pass has already pruned, so a second
+    // identical candidate is measured against the survivors the first one did
+    // not already account for.
+    let prunedSoFar: Map<string, number> | undefined;
+    for (let i = 0; i < add.length; i++) {
+      const candidate = add[i]!;
+      if (candidate.to >= keptFrom && candidate.from <= keptTo) {
+        // Inside the window: the old copy is deleted, so this is the only one.
+        continue;
+      }
+      let survivors = 0;
+      current.between(candidate.from, candidate.to, (from, to, value) => {
+        if (
+          from === candidate.from &&
+          to === candidate.to &&
+          value.type === candidate.value.type
+        ) {
+          survivors += 1;
+        }
+        return undefined;
+      });
+      if (survivors === 0) {
+        continue;
+      }
+      const key = `${candidate.from}:${candidate.to}:${String(
+        candidate.value.type,
+      )}`;
+      prunedSoFar ??= new Map();
+      const alreadyPruned = prunedSoFar.get(key) ?? 0;
+      if (alreadyPruned < survivors) {
+        prunedSoFar.set(key, alreadyPruned + 1);
+        (redundant ??= new Set()).add(i);
+      }
+    }
+    if (!redundant) {
+      return add;
+    }
+    return add.filter((_, i) => !redundant!.has(i));
+  }
+
   protected remove<T>(
     from: number,
     to: number,
@@ -239,6 +333,18 @@ export class SparkdownCombinedAnnotator {
           if (annotator) {
             const removed: Range<typeof annotator._annotationType>[] = [];
             annotator.current = annotator.current.map(changeDesc);
+            // `end()` receives `kept`, not `add`, so it sees what actually
+            // entered the set. Note `CompilationAnnotator.end` pairs
+            // `added[i]` with `removed[i]` POSITIONALLY; pruning is a no-op
+            // for `compilations` (node-anchored, and object-valued so `===`
+            // never holds), so that pairing is unchanged. Anything that makes
+            // compilation values comparable by value has to revisit this.
+            const kept = this.pruneRedundant(
+              add as any,
+              annotator.current,
+              editStart,
+              Infinity,
+            );
             annotator.current = annotator.current.update({
               filter: (from, to, value) => {
                 if (to < editStart) {
@@ -248,13 +354,13 @@ export class SparkdownCombinedAnnotator {
                 this.remove(from, to, value, annotate);
                 return false;
               },
-              add,
+              add: kept,
               sort: true,
             });
             annotator.end(
               iteratingFrom,
               iteratingTo,
-              add as any,
+              kept as any,
               removed as any,
             );
           }
@@ -271,6 +377,15 @@ export class SparkdownCombinedAnnotator {
         if (annotator) {
           const removed: Range<typeof annotator._annotationType>[] = [];
           annotator.current = annotator.current.map(changeDesc);
+          // See the note on the `reparsedTo == null` branch above about
+          // `end()` receiving `kept` and `CompilationAnnotator`'s positional
+          // `added[i]`/`removed[i]` pairing.
+          const kept = this.pruneRedundant(
+            add as any,
+            annotator.current,
+            editStart,
+            reparsedTo,
+          );
           annotator.current = annotator.current.update({
             filter: (from, to, value) => {
               if (to < editStart || from > reparsedTo) {
@@ -280,10 +395,15 @@ export class SparkdownCombinedAnnotator {
               this.remove(from, to, value, annotate);
               return false;
             },
-            add,
+            add: kept,
             sort: true,
           });
-          annotator.end(iteratingFrom, iteratingTo, add as any, removed as any);
+          annotator.end(
+            iteratingFrom,
+            iteratingTo,
+            kept as any,
+            removed as any,
+          );
         }
       }
     }

--- a/packages/sparkdown/src/tests/compiler/incrementalAnnotationStability.test.ts
+++ b/packages/sparkdown/src/tests/compiler/incrementalAnnotationStability.test.ts
@@ -1,0 +1,280 @@
+// Incremental annotation stability.
+//
+// `SparkdownCombinedAnnotator.update` re-annotates only the window
+// `[editStart, reparsedTo]` and drops the superseded annotations with the
+// complementary predicate (`to < editStart || from > reparsedTo` is KEPT).
+// Nothing is double-counted as long as every annotation an annotator emits
+// overlaps the window it was produced in — which is what carrying the entered
+// node's own `[from, to]` guarantees, since Lezer only enters a node that
+// overlaps the iterate range.
+//
+// Annotations anchored somewhere OTHER than the node's full range escape that.
+// A zero-width mark at a node's START (`top_level_begin`) sits before
+// `editStart` whenever the parser restarts at an in-block split point, so the
+// old copy is KEPT and an identical fresh copy is added. `RangeSet` does not
+// dedup, so the set grows by one entry per keystroke, unbounded, for as long
+// as typing continues inside one top-level block (issue #322).
+//
+// SCOPE: these pin the DUPLICATION direction only. The incremental window has
+// separate, pre-existing holes in the other direction — an in-block window can
+// drop annotations a cold parse emits (annotator state like
+// `SemanticAnnotator.scopeStack` is rebuilt from the window, not the document),
+// and nothing removes an out-of-window annotation the new parse stopped
+// emitting. Those are tracked in #326; do not read a green run here as
+// incremental ≡ cold in general.
+//
+// Each edit here is round-tripped (insert a character, then delete it) so the
+// document ends byte-identical to where it started — any drift in the
+// annotations is pure accumulation, with no legitimate content change to
+// explain it away. The insertion point is the end of an identifier so the
+// transient text stays valid Luau; a transient parse error perturbs the
+// annotations for reasons that have nothing to do with the delete window.
+//
+// The bug is only REACHABLE when the parser restarts at a split point strictly
+// inside the top-level block — otherwise `editStart <= block.from`, the mark is
+// inside the window, and the whole scenario is moot. `expectReachedTheBug`
+// asserts that precondition against the tree's own recorded reparse spans over
+// the real edit sequence, so these stay honest if the parser's chunking or
+// reuse policy changes: they go red rather than silently passing on a document
+// that can no longer trigger it.
+//
+// They are deliberately host-level (`SparkdownDocumentRegistry`) rather than
+// compiler-level: `formatting` is not in `SparkdownCompiler`'s annotate set,
+// so a bare-compiler harness cannot see this class of bug at all.
+import { cachedCompilerProp } from "@impower/textmate-grammar-tree/src/tree/props/cachedCompilerProp";
+import { describe, expect, it } from "vitest";
+import type { SparkdownAnnotators } from "../../compiler/classes/SparkdownCombinedAnnotator";
+import { SparkdownDocumentRegistry } from "../../compiler/classes/SparkdownDocumentRegistry";
+
+const URI = "inmemory:///main.sd";
+
+// Mirrors `SparkdownLanguageServerWorkspace`'s set.
+const ANNOTATE: (keyof SparkdownAnnotators)[] = [
+  "characters",
+  "colors",
+  "declarations",
+  "formatting",
+  "links",
+  "lenses",
+  "references",
+  "semantics",
+];
+
+// `SparkdownDocumentRegistry.update` ignores a change whose version equals the
+// current one, so keep one ever-increasing counter for the whole file.
+let nextVersion = 2;
+
+/** Every annotation in every set, as comparable `set from-to type` strings. */
+function snapshot(registry: SparkdownDocumentRegistry) {
+  const annotations = registry.annotations(URI) as Record<string, any>;
+  const out: string[] = [];
+  for (const key of ANNOTATE) {
+    const iter = annotations[key]!.iter(0);
+    while (iter.value) {
+      out.push(
+        `${key} ${iter.from}-${iter.to} ${JSON.stringify(iter.value.type)}`,
+      );
+      iter.next();
+    }
+  }
+  return out;
+}
+
+function counts(snap: string[]) {
+  const out: Record<string, number> = {};
+  for (const key of ANNOTATE) {
+    out[key] = 0;
+  }
+  for (const entry of snap) {
+    out[entry.slice(0, entry.indexOf(" "))]! += 1;
+  }
+  return out;
+}
+
+function posAt(text: string, offset: number) {
+  let line = 0;
+  let lineStart = 0;
+  for (let i = 0; i < offset; i++) {
+    if (text[i] === "\n") {
+      line++;
+      lineStart = i + 1;
+    }
+  }
+  return { line, character: offset - lineStart };
+}
+
+function open(text: string) {
+  const registry = new SparkdownDocumentRegistry(ANNOTATE);
+  registry.add({
+    textDocument: { uri: URI, text, version: 1, languageId: "sparkdown" },
+  });
+  return registry;
+}
+
+function reparsedSpan(registry: SparkdownDocumentRegistry) {
+  const cached: any = registry.tree(URI)?.prop(cachedCompilerProp as any);
+  if (!cached || cached.reparsedFrom == null) {
+    return null;
+  }
+  return {
+    from: cached.reparsedFrom as number,
+    to: cached.reparsedTo as number,
+  };
+}
+
+/**
+ * Simulate `cycles` keystrokes at `offset`, each one inserted and then
+ * immediately deleted, exactly as the language server receives them (one
+ * content change per event). The document is byte-identical afterwards.
+ *
+ * Returns the `editStart` the annotator computed for each update — that is
+ * `min(reparsedFrom, edit start)`, the lower bound of the re-annotation window
+ * (see `SparkdownCombinedAnnotator.update`).
+ */
+function typeAndUndo(
+  registry: SparkdownDocumentRegistry,
+  text: string,
+  offset: number,
+  cycles: number,
+) {
+  const at = posAt(text, offset);
+  const after = posAt(text, offset + 1);
+  const editStarts: (number | null)[] = [];
+  const record = () => {
+    const span = reparsedSpan(registry);
+    editStarts.push(span == null ? null : Math.min(span.from, offset));
+  };
+  for (let i = 0; i < cycles; i++) {
+    registry.update({
+      textDocument: { uri: URI, version: nextVersion++ },
+      contentChanges: [{ range: { start: at, end: at }, text: "x" }],
+    });
+    record();
+    registry.update({
+      textDocument: { uri: URI, version: nextVersion++ },
+      contentChanges: [{ range: { start: at, end: after }, text: "" }],
+    });
+    record();
+  }
+  // The whole design rests on the document being restored exactly.
+  expect(registry.get(URI)!.getText()).toBe(text);
+  return editStarts;
+}
+
+/**
+ * Assert the block actually emits the mark this is all about. Without this the
+ * fixture could drift to a shape that produces no `top_level_begin` and every
+ * assertion below would hold vacuously.
+ */
+function expectMarkPresent(text: string, blockFrom: number) {
+  // The block start also carries a zero-width `indent` (it is a column-0
+  // line), so assert containment rather than exclusivity.
+  expect(snapshot(open(text)), `top_level_begin at ${blockFrom}`).toContain(
+    `formatting ${blockFrom}-${blockFrom} "top_level_begin"`,
+  );
+}
+
+/**
+ * Assert the typing burst actually reached the bug: at least one update must
+ * have re-annotated a window that STARTS AFTER the block, leaving the
+ * `top_level_begin` at `[blockFrom, blockFrom]` behind it. Only then is the
+ * old mark kept by the delete-filter while the still-entered node re-emits it.
+ *
+ * The first edit after a cold parse always reparses the whole document, so
+ * this only becomes true from the second edit onward; the assertion is over
+ * the real sequence rather than a probe, so it stays honest if the parser's
+ * chunking or reuse policy changes — the tests go red instead of silently
+ * passing on a document that can no longer trigger the bug.
+ */
+function expectReachedTheBug(editStarts: (number | null)[], blockFrom: number) {
+  expect(
+    editStarts.filter((s) => s != null && s > blockFrom).length,
+    `updates whose window starts after block ${blockFrom} (saw ${JSON.stringify(editStarts)})`,
+  ).toBeGreaterThan(0);
+}
+
+/** Canonical sparkdown: front matter, a scene, and top-level `function` blocks. */
+function buildScript(blocks: number, bodyLines: number) {
+  const lines: string[] = [];
+  lines.push("title: Annotation Stability");
+  lines.push("author: Anonymous");
+  lines.push("");
+  lines.push("scene rooftop");
+  lines.push("= INT. ROOFTOP - NIGHT");
+  lines.push(":");
+  lines.push("  A moonlit rooftop, wind moving across the gravel.");
+  lines.push("hero:");
+  lines.push("  Hello there.");
+  lines.push("end");
+  lines.push("");
+  for (let b = 0; b < blocks; b++) {
+    lines.push(`function tally_${b}()`);
+    for (let i = 0; i < bodyLines; i++) {
+      lines.push(`  local slot_${b}_${i} = ${i} + 1`);
+    }
+    lines.push("  return 0");
+    lines.push("end");
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/** Offset of a block's `function` keyword — where `top_level_begin` is anchored. */
+function blockStart(text: string, block: number) {
+  const at = text.indexOf(`function tally_${block}()`);
+  expect(at, `block ${block} present`).toBeGreaterThanOrEqual(0);
+  return at;
+}
+
+/** Offset just past an identifier deep inside a block's body. */
+function deepOffset(text: string, block: number, line: number) {
+  const marker = `local slot_${block}_${line}`;
+  expect(text).toContain(marker);
+  return text.indexOf(marker) + marker.length;
+}
+
+describe("incremental annotation stability", () => {
+  it("does not accumulate annotations while typing inside a top-level function block", () => {
+    const text = buildScript(1, 80);
+    const blockFrom = blockStart(text, 0);
+    const offset = deepOffset(text, 0, 60);
+    expectMarkPresent(text, blockFrom);
+
+    const registry = open(text);
+    const before = snapshot(registry);
+    expectReachedTheBug(typeAndUndo(registry, text, offset, 30), blockFrom);
+
+    // Counts first: a mismatch here is the #322 growth, and the message names
+    // which set drifted. The full positional compare below is the real oracle.
+    expect(counts(snapshot(registry))).toEqual(counts(before));
+    expect(snapshot(registry)).toEqual(before);
+  });
+
+  it("does not accumulate annotations while typing in any of several top-level blocks", () => {
+    // Each block contributes its own `top_level_begin`, and each one is a
+    // separate anchor that can end up behind the window.
+    const text = buildScript(4, 20);
+    const registry = open(text);
+    const before = snapshot(registry);
+
+    for (let b = 0; b < 4; b++) {
+      const blockFrom = blockStart(text, b);
+      const offset = deepOffset(text, b, 15);
+      expectMarkPresent(text, blockFrom);
+      expectReachedTheBug(typeAndUndo(registry, text, offset, 8), blockFrom);
+      expect(snapshot(registry), `after typing in block ${b}`).toEqual(before);
+    }
+  });
+
+  it("matches a cold parse after typing inside a top-level function block", () => {
+    const text = buildScript(1, 40);
+    const blockFrom = blockStart(text, 0);
+    const offset = deepOffset(text, 0, 30);
+    expectMarkPresent(text, blockFrom);
+
+    const incremental = open(text);
+    expectReachedTheBug(typeAndUndo(incremental, text, offset, 12), blockFrom);
+
+    expect(snapshot(incremental)).toEqual(snapshot(open(text)));
+  });
+});


### PR DESCRIPTION
Closes #322.

## What broke

`SparkdownCombinedAnnotator.update` re-annotates only the window `[editStart, reparsedTo]` and drops the superseded annotations with the complementary predicate — `to < editStart || from > reparsedTo` is KEPT (`packages/sparkdown/src/compiler/classes/SparkdownCombinedAnnotator.ts:333` and `:371`).

That reconciles because Lezer only enters a node overlapping the iterate range, so an annotation carrying its node's own `[from, to]` overlaps the window too and is always deleted before it is re-added.

`FormattingAnnotator.enter` breaks that for top-level `LuauFunctionDefinition` / `LuauDefine` / `LuauStyle` / `LuauScreen` / `LuauComponent`: it emits `top_level_begin` at the **zero-width** range `(nodeRef.from, nodeRef.from)` (`packages/sparkdown/src/compiler/classes/annotators/FormattingAnnotator.ts:321-326`). When the parser restarts at an in-block split point, `editStart > node.from`, so the old mark's `to < editStart` and the filter **keeps** it — while the node is still entered and pushes an identical copy. `RangeSet` does not dedup, so the set gains one entry per keystroke, forever, for as long as typing continues inside that block.

Measured on `origin/main`, 60 edit events (30 insert-then-delete cycles) deep inside one top-level `function` block, against the language server's annotate set:

| annotation | before | after | cold parse |
| --- | --- | --- | --- |
| `top_level_begin` | 1 | **60** | 1 |
| `indent` | 90 | 91 | 90 |
| everything else | — | flat | — |

`formatting` overall: 757 → 817. The growth is driven by keystroke count, not document size, and only heals on a cold parse.

`formatting` is in the annotate set of both shipped hosts (`SparkdownLanguageServerWorkspace.ts:43-52`, `vscode-sparkdown/src/managers/SparkdownDocumentManager.ts:16-19`) but not `SparkdownCompiler`'s — which is why a bare-compiler harness cannot see it.

## The fix

One guard, `pruneRedundant`, applied in both incremental branches of `update`. For a candidate annotation that falls **outside** the delete window, it keeps the candidate only to the extent the surviving copies do not already account for it.

Two details that matter:

- **Prune by count, not presence.** If the pass emits K identical out-of-window annotations and M survive, `K - M` are kept. Presence-only would collapse a legitimate 1 → K increase down to M — and cold parses really do emit identical duplicate `formatting` marks (e.g. two `separator`s at the same offset in `grammar/alternator/bare-shuffle.sd`).
- **Never drop something that might not be a duplicate.** When no identical survivor exists, the candidate is kept, because nothing else would put it back.

The guard is in the combined annotator rather than in `FormattingAnnotator` deliberately: it covers all six zero-width/off-node anchor sites in that file (`top_level_begin`, three `keyword_separator` variants, `frontmatter_end`, and the `indent` emitted at a `Newline`'s `to`) and any future one, without changing what the formatter is handed.

## Regression test

`packages/sparkdown/src/tests/compiler/incrementalAnnotationStability.test.ts` — 3 tests, host-level (`SparkdownDocumentRegistry` with the language server's annotate set), because the compiler's set excludes `formatting`.

Each edit is round-tripped (insert a character, delete it) so the document ends byte-identical — asserted — and any drift is pure accumulation. The oracle is the full `(from, to, type)` sequence per annotator set, not just counts.

Two guards keep them from going vacuous:

- `expectMarkPresent` — the fixture must actually emit a `top_level_begin` at the block start.
- `expectReachedTheBug` — at least one update in the real edit sequence must have re-annotated a window that **starts after** the block, leaving the mark behind it. This caught a genuine problem while writing the test: an earlier fixture revision could not reach the bug at all and would have passed green regardless of the annotator's behaviour. (Worth knowing: the first edit after a cold parse always reparses the whole document; the window only narrows from the second edit onward.)

**Red/green (§5b):**

- Against the pre-fix source with the test as merged: **all 3 fail**, `formatting` 757 → 817 after 60 edit events, incremental 470 annotations vs 446 cold — and `expectReachedTheBug` passes, so the failures are the real bug, not a broken fixture.
- With the fix: **all 3 pass.**

## Suite results

- `packages/sparkdown` `src/tests/compiler` + `src/tests/runtime` + `src/tests/incremental` — **77 files (75 passed, 2 skipped) / 1015 tests (991 passed, 24 skipped)**.
- `packages/sparkdown-language-server` (the formatter suites that consume these annotations) — 2 files / 88 tests, **86 passed, 2 failed**. Both failures are **pre-existing**: `deltaFormatEquivalence.test.ts > … > screen element (bad attr spacing)`, failing on a fixture lookup (`lineIndex` is `-1`) that this change cannot touch. Confirmed identical on `origin/main` by reverting the source file and re-running.

## Live verification

Same-origin dev servers, the repro loaded into the editor's OPFS:

1. Baseline — editor + Game Preview render, preview scrubbed to line 8 shows BOB's dialogue.
2. **30 real keystroke cycles inside the top-level `function tally()` block**, driven as genuine contenteditable input (`beforeinput` + DOM mutation, which is what CodeMirror 6's `DOMObserver` consumes) — not synthetic transactions. Document restored byte-for-byte; syntax highlighting fully intact afterwards (including the semantic-token colouring of `total`, which rides on this annotation pipeline); cursor at Ln 11 Col 14.
3. Scrubbed back to line 8 — preview renders BOB's line again, `route: main : 1 → main : 8`.

The console noise (`Unhandled method workspace/*/refresh`, two resource 404s) is the documented pre-existing set.

## Adversarial review — what I did not change

Five independent read-only reviewers (undirected, boundary correctness, blast radius, incrementality, test honesty). Acted on: the count-vs-presence prune, the non-vacuity guards, the full positional oracle, a factually wrong docstring claim (it listed `semantics` as string-valued; it carries an object), Prettier formatting, and **two raw NUL bytes** that had crept into the dedup key's template literal — those would have flipped the file to binary in `git diff` and dropped it out of `rg`/`grep`.

Declined, and filed as **#326** instead of expanded into this PR:

- **`references` and `validations` keep the same growth shape.** Identity is `===` on `type`, which never holds for object-valued annotations. Both of those annotators also emit non-node-anchored ranges (quote-stripped `[from+1, to-1]`; a *sibling* node's range). Mechanism-confirmed in code; neither has a live repro yet. Fixing it needs value equality for object-valued annotations, which is a different and larger change.
- **The window can DROP annotations a cold parse emits.** A partial pass is not the cold pass restricted to the window — `SemanticAnnotator.scopeStack` is rebuilt from the window, so an in-block window loses identifier tokens whose bindings sit behind it. Pre-existing, reproduces with this guard disabled.
- **Nothing removes an out-of-window annotation the new parse stopped emitting.** Also pre-existing, also in #326.

The docstring and the test header both state these limits explicitly, so a green run here is not read as "incremental ≡ cold".

One note kept in the code rather than deferred: `end()` now receives the pruned array. `CompilationAnnotator.end` pairs `added[i]` with `removed[i]` positionally, and pruning is a provable no-op for `compilations` (node-anchored, and object-valued so `===` never holds), so that pairing is unchanged — but the coupling is now commented at both call sites.

An independent A/B differential from one reviewer over 380 seeded edits (guarded vs unguarded vs cold, same edit stream): **0** divergences introduced by the guard, 335 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
