### PR TITLE
refactor(compiler): decouple FunctionCall content add/remove (#323)

### DIFF
--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/FunctionCall.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/FunctionCall.ts
@@ -101,6 +101,27 @@ export class FunctionCall extends Expression {
     return "FunctionCall";
   }
 
+  // `GenerateIntoContainer` runs again on every recompile, and the
+  // incremental pipeline carries parsed nodes forward by identity, so
+  // anything generation adds to `this.content` must be added at most
+  // once. The counted argument is the same parsed node every pass.
+  //
+  // Paired with the proxy-divert splice at the end of
+  // `GenerateIntoContainer`: with only one of the two guards in place
+  // `content` either grows by one entry per pass or empties entirely.
+  private AddContentOnce(subContent: DivertTarget | VariableReference): void {
+    if (this.content.includes(subContent)) {
+      // Already added by an earlier pass. Still re-assert the parent
+      // link, which is `AddContent`'s other effect and is read by
+      // `DivertTarget.ResolveReferences` to decide whether the target
+      // is counted for turns only or for visits as well.
+      subContent.parent = this;
+      return;
+    }
+
+    this.AddContent(subContent);
+  }
+
   public readonly GenerateIntoContainer = (
     container: RuntimeContainer,
   ): void => {
@@ -124,12 +145,12 @@ export class FunctionCall extends Expression {
 
       if (divertTarget) {
         this._divertTargetToCount = divertTarget;
-        this.AddContent(this._divertTargetToCount);
+        this.AddContentOnce(this._divertTargetToCount);
 
         this._divertTargetToCount.GenerateIntoContainer(container);
       } else if (variableDivertTarget) {
         this._variableReferenceToCount = variableDivertTarget;
-        this.AddContent(this._variableReferenceToCount);
+        this.AddContentOnce(this._variableReferenceToCount);
 
         this._variableReferenceToCount.GenerateIntoContainer(container);
       }
@@ -260,9 +281,16 @@ export class FunctionCall extends Expression {
       usingProxyDivert = true;
     }
 
-    // Don't attempt to resolve as a divert if we're not doing a normal function call
+    // Don't attempt to resolve as a divert if we're not doing a normal
+    // function call. Remove the proxy divert only when it is actually
+    // present: `splice(indexOf(...), 1)` finding no match splices at -1
+    // and deletes the LAST element rather than nothing, so on a second
+    // generation pass it removes whatever `content` happens to end with.
     if (!usingProxyDivert) {
-      this.content.splice(this.content.indexOf(this._proxyDivert), 1);
+      const proxyIndex = this.content.indexOf(this._proxyDivert);
+      if (proxyIndex >= 0) {
+        this.content.splice(proxyIndex, 1);
+      }
     }
 
     // Function calls that are used alone on a tilda-based line:

--- a/packages/sparkdown/src/tests/compiler/functionCallContentIdempotence.test.ts
+++ b/packages/sparkdown/src/tests/compiler/functionCallContentIdempotence.test.ts
@@ -1,0 +1,356 @@
+// `FunctionCall.GenerateIntoContainer` must leave `this.content` holding
+// exactly what the rest of the compiler expects, on the first generation pass
+// and on every subsequent one — the incremental pipeline carries parsed chunks
+// forward by identity, so a carried-forward `FunctionCall` generates more than
+// once (measured: deleting a divert target regenerates its caller's node).
+//
+// Two halves of that method write to `content`, and they used to be coupled by
+// accident (issue #323):
+//
+//   - the TURNS_SINCE / READ_COUNT branch `AddContent`s the counted argument —
+//     the same parsed node every pass;
+//   - the tail `splice(this.content.indexOf(this._proxyDivert), 1)` deletes the
+//     TRAILING element once the proxy divert is already gone, because
+//     `indexOf` returns -1 and `splice(-1, 1)` splices from the end.
+//
+// On the counted-argument branch those two cancel exactly — the element the
+// stray splice reaches is the duplicate the stray add just pushed — so
+// `content` settled on the right single entry and nothing accumulated. That
+// cancellation is what makes the two halves impossible to change one at a
+// time: guarding only the splice grows `content` by one entry per pass, and
+// guarding only the `AddContent` empties it, which drops the counted argument
+// out of every content-based tree walk (`ParsedObject.ResolveReferences`'s own
+// recursion, `Find`/`FindAll`, `CollectByType`).
+//
+// The third test below is the one that goes red on the unguarded splice alone:
+// on a branch that adds nothing, there is no duplicate for `splice(-1, 1)` to
+// land on, so it deletes real content instead.
+//
+// A note on assertion style: parsed nodes are deeply cyclic, and a failing
+// `expect(node).toBe(other)` makes vitest build a diff of the whole graph,
+// which exhausts the worker heap and reports as "Worker exited unexpectedly"
+// instead of as the assertion that failed. Every node comparison here is
+// reduced to a boolean BEFORE it reaches `expect`.
+import "../../inkjs/engine/Container";
+import { describe, expect, it } from "vitest";
+import { Container as RuntimeContainer } from "../../inkjs/engine/Container";
+import { FunctionCall } from "../../inkjs/compiler/Parser/ParsedHierarchy/FunctionCall";
+import { Text } from "../../inkjs/compiler/Parser/ParsedHierarchy/Text";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+
+const URI = "inmemory:///main.sd";
+
+const quiet = <T,>(fn: () => T): T => {
+  const w = console.warn;
+  const e = console.error;
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    return fn();
+  } finally {
+    console.warn = w;
+    console.error = e;
+  }
+};
+
+/** Every `FunctionCall` reachable from the compiler, in discovery order. */
+function reachableFunctionCalls(root: object): FunctionCall[] {
+  const seen = new Set<unknown>([root]);
+  const queue: any[] = [root];
+  const found: FunctionCall[] = [];
+  for (let head = 0; head < queue.length; head++) {
+    const cur = queue[head];
+    if (cur instanceof FunctionCall) {
+      found.push(cur);
+    }
+    let children: unknown[];
+    if (Array.isArray(cur)) {
+      children = cur;
+    } else if (cur instanceof Set) {
+      children = [...cur];
+    } else if (cur instanceof Map) {
+      children = [...cur.keys(), ...cur.values()];
+    } else {
+      children = [];
+      for (const key of Object.getOwnPropertyNames(cur)) {
+        // Skip accessors — invoking a getter here could compute or throw.
+        const d = Object.getOwnPropertyDescriptor(cur, key);
+        if (d && !d.get) children.push(d.value);
+      }
+    }
+    for (const child of children) {
+      if (!child) continue;
+      const t = typeof child;
+      if (t !== "object" && t !== "function") continue;
+      if (seen.has(child)) continue;
+      seen.add(child);
+      queue.push(child);
+    }
+  }
+  return found;
+}
+
+/** The one reachable `FunctionCall` with this name. Fails if there isn't exactly one. */
+function soleCall(compiler: SparkdownCompiler, name: string): FunctionCall {
+  const calls = reachableFunctionCalls(compiler).filter((f) => {
+    // `name` throws if a call has no parsed target path; treat that as "not
+    // the one we're looking for" rather than as an opaque TypeError.
+    try {
+      return f.name === name;
+    } catch {
+      return false;
+    }
+  });
+  expect({ name, count: calls.length }).toEqual({ name, count: 1 });
+  return calls[0]!;
+}
+
+/**
+ * `content` must be exactly the counted argument — the parsed node that is
+ * also `args[0]` — and nothing else. Reported as plain numbers/booleans so a
+ * failure prints a readable assertion instead of a graph diff.
+ */
+function expectContentIsCountedArgOnly(call: FunctionCall, label: string) {
+  const countedArg = call.args[0];
+  expect({
+    where: label,
+    length: call.content.length,
+    firstIsCountedArg: call.content[0] === countedArg,
+    holdsProxyDivert: call.content.includes(call.proxyDivert),
+    countedArgParentIsCall: countedArg?.parent === call,
+  }).toEqual({
+    where: label,
+    length: 1,
+    firstIsCountedArg: true,
+    holdsProxyDivert: false,
+    // `AddContent`'s other effect. `DivertTarget.ResolveReferences` reads it
+    // to decide turn-counting vs. count-everything, so it has to survive the
+    // passes that no longer re-add.
+    countedArgParentIsCall: true,
+  });
+}
+
+function posAt(text: string, offset: number) {
+  let line = 0;
+  let lineStart = 0;
+  for (let i = 0; i < offset; i++) {
+    if (text[i] === "\n") {
+      line++;
+      lineStart = i + 1;
+    }
+  }
+  return { line, character: offset - lineStart };
+}
+
+function configured(text: string): SparkdownCompiler {
+  const c = new SparkdownCompiler();
+  c.configure({
+    files: [
+      {
+        uri: URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text,
+        version: 1,
+        languageId: "sparkdown",
+      },
+    ],
+  } as never);
+  return c;
+}
+
+function compiledOnce(text: string): SparkdownCompiler {
+  const compiler = configured(text);
+  quiet(() => compiler.compile({ textDocument: { uri: URI } } as never));
+  return compiler;
+}
+
+// Same document shape as `incrementalStaleTargetPaths.test.ts`: no front
+// matter, a `caller` scene holding the call under test, filler scenes to edit
+// in, and a `gamma` scene to delete. Measured, not assumed: this is the shape
+// that actually drives a SECOND generation pass over a carried-forward
+// `FunctionCall`. Deleting the divert target is what forces the regeneration —
+// warm edits alone leave the node at a single pass, and editing inside the
+// caller scene re-parses it into a fresh node each time.
+function doc(callerLine: string, preamble: string[] = []): string {
+  const L: string[] = [...preamble];
+  L.push("scene caller");
+  L.push(":");
+  L.push("  Caller action.");
+  L.push(callerLine);
+  L.push("-> DONE");
+  L.push("end");
+  L.push("");
+  for (let i = 0; i < 3; i++) {
+    L.push(`scene filler_${i}`);
+    L.push(":");
+    L.push(`  Filler action ${i}.`);
+    L.push("-> DONE");
+    L.push("end");
+    L.push("");
+  }
+  L.push("scene gamma");
+  L.push(":");
+  L.push("  Gamma action.");
+  L.push("-> DONE");
+  L.push("end");
+  L.push("");
+  return L.join("\n");
+}
+
+const CALLER_LINE = "  Caller action {TURNS_SINCE(-> gamma)}.";
+const GAMMA_BLOCK = "scene gamma\n:\n  Gamma action.\n-> DONE\nend\n";
+const WARM = (n: number) => ({
+  find: `Filler action 1.${"!".repeat(n)}`,
+  replace: `Filler action 1.${"!".repeat(n + 1)}`,
+});
+
+// Both counted-argument shapes: a `-> knot` DivertTarget, and the no-arrow
+// VariableReference form (as in the runtime fixture
+// `builtins/read-count-variable-target.sd`), which takes the other arm of the
+// guarded `AddContentOnce` call.
+const COUNTED_FORMS = [
+  { label: "TURNS_SINCE(-> gamma)", name: "TURNS_SINCE", preamble: [] as string[] },
+  { label: "READ_COUNT(-> gamma)", name: "READ_COUNT", preamble: [] as string[] },
+  {
+    label: "READ_COUNT(x) — variable target",
+    name: "READ_COUNT",
+    preamble: ["store x = -> gamma", ""],
+    line: "  Caller action {READ_COUNT(x)}.",
+  },
+];
+
+describe("FunctionCall generation leaves `content` intact", () => {
+  for (const form of COUNTED_FORMS) {
+    it(`repeated generation keeps exactly the counted argument: ${form.label}`, () => {
+      const callerLine = form.line ?? `  Caller action {${form.label}}.`;
+      const compiler = compiledOnce(doc(callerLine, form.preamble));
+
+      const call = soleCall(compiler, form.name);
+      expect(call.args.length).toBe(1);
+
+      // After the first pass the proxy divert is gone (this is not a normal
+      // function call) and the counted argument has taken its place.
+      expectContentIsCountedArgOnly(call, "after first compile");
+
+      const emitted: number[] = [];
+      for (let i = 0; i < 5; i++) {
+        const container = new RuntimeContainer();
+        quiet(() => call.GenerateIntoContainer(container));
+        emitted.push(container.content.length);
+
+        // Guarding only the splice grows this by one entry per pass; guarding
+        // only the `AddContent` empties it.
+        expectContentIsCountedArgOnly(call, `after extra pass ${i + 1}`);
+      }
+
+      // Weak sanity check only, and deliberately so: it catches a guard that
+      // stopped generation emitting altogether, not a change in WHAT is
+      // emitted. The emitted-object-level oracle is the incremental-vs-cold
+      // comparison in `incrementalStaleTargetPaths.test.ts`, which covers this
+      // same fixture.
+      expect(new Set(emitted).size).toBe(1);
+      expect(emitted[0]).toBeGreaterThan(0);
+    });
+  }
+
+  it("the proxy-divert splice removes only the proxy divert", () => {
+    // A builtin whose branch adds nothing to `content`: after pass 1 the proxy
+    // divert has been spliced out and `content` is empty, so a second pass
+    // reaches the splice with `indexOf(...) === -1` and NO duplicate sitting at
+    // the end to absorb it. Whatever `content` ends with is what an unguarded
+    // `splice(-1, 1)` deletes — which is the defect in the ticket title.
+    const compiler = compiledOnce(doc("  Caller action {FLOOR(1.5)}."));
+    const call = soleCall(compiler, "FLOOR");
+
+    expect({ where: "after first compile", length: call.content.length }).toEqual({
+      where: "after first compile",
+      length: 0,
+    });
+
+    const sentinel = new Text("sentinel");
+    call.content.push(sentinel);
+
+    const container = new RuntimeContainer();
+    quiet(() => call.GenerateIntoContainer(container));
+
+    // The sentinel is not the proxy divert, so the splice must not touch it.
+    expect({
+      length: call.content.length,
+      survived: call.content[0] === sentinel,
+    }).toEqual({ length: 1, survived: true });
+  });
+
+  it("survives the real multi-pass path: deleting the divert target", () => {
+    const base = doc(CALLER_LINE);
+    const compiler = compiledOnce(base);
+
+    // Generation pass 1 has happened. Instrument the carried-forward node so
+    // the assertions below cannot pass vacuously by never regenerating.
+    // `GenerateIntoContainer` is an instance field and every caller reaches it
+    // by property access on the instance, so this wrapper sees every pass.
+    const call = soleCall(compiler, "TURNS_SINCE");
+    let passes = 0;
+    const generate = call.GenerateIntoContainer;
+    (call as any).GenerateIntoContainer = (container: RuntimeContainer) => {
+      passes += 1;
+      return generate(container);
+    };
+
+    let text = base;
+    let version = 1;
+    const steps = [
+      WARM(0),
+      WARM(1),
+      WARM(2),
+      { find: GAMMA_BLOCK, replace: "" },
+      WARM(3),
+    ];
+    const deletionStep = 3;
+    let passesBeforeDeletion = -1;
+
+    for (const [i, step] of steps.entries()) {
+      if (i === deletionStep) {
+        passesBeforeDeletion = passes;
+      }
+      const offset = text.indexOf(step.find);
+      expect(offset).toBeGreaterThanOrEqual(0);
+      version += 1;
+      quiet(() => {
+        compiler.updateDocument({
+          textDocument: { uri: URI, version },
+          contentChanges: [
+            {
+              range: {
+                start: posAt(text, offset),
+                end: posAt(text, offset + step.find.length),
+              },
+              text: step.replace,
+            },
+          ],
+        } as never);
+        compiler.compile({ textDocument: { uri: URI } } as never);
+      });
+      text =
+        text.slice(0, offset) +
+        step.replace +
+        text.slice(offset + step.find.length);
+
+      // The node is carried forward by identity for this whole sequence, so
+      // its `content` must survive every one of those compiles.
+      expect(soleCall(compiler, "TURNS_SINCE") === call).toBe(true);
+      expectContentIsCountedArgOnly(call, `after step ${i + 1}`);
+
+      if (i === deletionStep) {
+        // Pin WHICH edit drives the regeneration. If invalidation changes so
+        // that deleting the target no longer regenerates the caller, this
+        // fails rather than quietly covering something else.
+        expect({
+          step: "delete divert target",
+          regenerated: passes > passesBeforeDeletion,
+        }).toEqual({ step: "delete divert target", regenerated: true });
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #323.

## What was wrong

`FunctionCall.GenerateIntoContainer` wrote to `this.content` in two places that were coupled by accident:

- The TURNS_SINCE / READ_COUNT branch called `this.AddContent(this._divertTargetToCount)` on **every** generation pass, with the same parsed node each time — the incremental pipeline carries parsed chunks forward by identity, so a carried-forward `FunctionCall` generates more than once.
- The tail `this.content.splice(this.content.indexOf(this._proxyDivert), 1)` deleted the **trailing** element once the proxy divert was already gone, because `indexOf` returns `-1` and `splice(-1, 1)` splices from the end.

On that branch the two cancelled exactly — the element the stray splice reached was the duplicate the stray add had just pushed — so `content` settled on the correct single entry. Correctness depended on `splice(-1, 1)` deleting an element it never identified, and neither half could be changed alone.

## Scope, stated plainly

**This is tech debt, not a user-visible bug fix.** Nothing else writes to a `FunctionCall`'s `content` (only the constructor at `FunctionCall.ts:97` and the counted-argument branch), so pre-fix the splice could only ever reach the just-pushed duplicate or an empty array. I found no reachable compiler input where old and new differ in output — consistent with #323's own measurement ("nothing accumulates here").

## The fix

Both halves guarded together, in [FunctionCall.ts](../blob/refactor/323-functioncall-content-idempotence/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/FunctionCall.ts):

- `FunctionCall.ts:112` — new `AddContentOnce`, adding the counted argument at most once. It still re-asserts `subContent.parent = this` (`FunctionCall.ts:118`), which is `AddContent`'s *other* effect and is read by `DivertTarget.ResolveReferences` (`Divert/DivertTarget.ts:201`) to choose `turnIndexShouldBeCounted` vs. count-everything. Dropping that re-assert was a real defect in my first draft, caught in review.
- `FunctionCall.ts:290-292` — splice the proxy divert only when `indexOf(...) >= 0`.

## Regression test

`packages/sparkdown/src/tests/compiler/functionCallContentIdempotence.test.ts` — 5 tests.

**One of them is red on unmodified `main`.** `the proxy-divert splice removes only the proxy divert` uses a builtin (`FLOOR`) whose branch adds nothing to `content`, so a second pass reaches the splice with no duplicate at the end to absorb it:

| source | result |
| --- | --- |
| `origin/main` (b91a2c384), unmodified | **FAIL** — `{ length: 0, survived: false }`, expected `{ length: 1, survived: true }` |
| this branch | PASS |

It does place the sentinel in `content` by hand, because the compiler cannot produce that state today — it pins the splice's *contract* (remove the proxy divert, nothing else), which is exactly the defect in the ticket title.

The other four tests pin the coupling, and go red if either half is changed alone — both measured, not assumed:

| variant | result |
| --- | --- |
| splice guard only (unconditional `AddContent`) | **FAIL** — `content.length: 2`, growing one entry per pass |
| `AddContentOnce` only (unguarded splice) | **FAIL** — `content.length: 0`, counted argument gone |
| both (this branch) | PASS |

The `AddContentOnce`-only failure is the one #323 predicted. Coverage is parameterized over `TURNS_SINCE(-> gamma)`, `READ_COUNT(-> gamma)`, and the no-arrow `READ_COUNT(x)` variable-target form, which takes the other arm of the guarded call.

The multi-pass test drives the shape that genuinely regenerates a carried-forward node — deleting the divert target, which I measured at 3 generation passes on one `FunctionCall` instance. Warm edits alone leave it at 1 pass, and editing inside the caller scene re-parses it into a fresh node; the test asserts the pass count increased *at the deletion step* so it cannot go vacuous if invalidation changes.

## Suite results

Run in this worktree, `--pool=forks`, capped, sequentially:

| suite | result |
| --- | --- |
| `src/tests/compiler` | 28 files, **545 passed** |
| `src/tests/runtime` | 41 files (+2 skipped), **304 passed**, 24 skipped |
| `src/tests/luau-conformance` | 70 files, **759 passed** |

No failures and no `Worker exited unexpectedly` in any run; summary lines present in all three. The neighbouring `incrementalStaleTargetPaths.test.ts` and `generationTreeMutation.test.ts` pass.

## Live verification

Editor + player booted via the resolve-issue driver, script loaded into OPFS, preview scrubbed to the `TURNS_SINCE` line. Game Preview renders:

```
BOB
Turns since gamma is -1.
```

`gameMounted: true`, `route: main : 1 → main : 8`, `settled: true`. `-1` is the correct value for a never-visited target. Re-checked after the review fixes. There is no "before" screenshot because there is no user-visible defect to show — the point of the live check here is that the counted-argument path still compiles and evaluates.

## Adversarial review — deliberately not changed

Six read-only reviewers; every finding re-checked against the code before acting. Acted on: the dropped parent re-assert, a comment of mine that described a bug the old code did not have, a false `import type` justification (the import is now gone entirely), a dead `hasOwnProperty` guard, and a per-instance closure (now a prototype method).

Declined, with reasons:

1. **The `usingProxyDivert` flip-back hole.** Three reviewers raised this: if `story.ResolveList(name)` starts and then stops finding a list for the same carried-forward node, the proxy divert is spliced out and never re-added, so `Divert.ResolveReferences` never runs for it. I chased the reachability rather than leaving it hanging, and it **cannot happen** — `usingProxyDivert` is a pure function of `this.name` for any given node, and the one selector reading per-compile state (`foundList`) is always `null`, because no parsed `ListDefinition` is ever constructed anywhere in the repo (sparkdown has no `LIST` type; ink's is replaced by Luau tables, `Lists.test.ts` is `describe.skip` "closed by design"). So the list branch is dead code. Recorded in #329 with the full argument, so it does not get re-filed on a false premise — which is exactly what #323 asked for.
2. **`soleCall`'s whole-heap BFS.** Brittle if the pipeline ever retains a second parse tree. Kept for consistency with the sibling `generationTreeMutation.test.ts`, which uses the same walk; the assertion reports `{ name, count }` so a failure is readable rather than a cyclic-graph diff.
3. **Per-pass `DivertTargetValue` churn.** Each generation pass mints a fresh `DivertTargetValue`; only the newest is fixed up by `ResolveReferences`. Real, pre-existing, and orthogonal to `content` idempotence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
