### PR TITLE
perf(profiler): clear user-timing entries after emitting them (#321)

### DIFF
--- a/impower-dev/src/modules/spark-editor/components/preview-game/previewInspect.ts
+++ b/impower-dev/src/modules/spark-editor/components/preview-game/previewInspect.ts
@@ -34,7 +34,14 @@ export interface PreviewInspector {
   game(): Element | null;
   /** outerHTML of the matched element, or the whole document if no selector. */
   html(selector?: string): string | null;
-  /** Performance entries from inside the iframe (optionally filtered by type). */
+  /**
+   * Performance entries from inside the iframe (optionally filtered by type).
+   *
+   * `"mark"` and `"measure"` come back empty: the profiler clears each entry as
+   * soon as it emits it, because user timing has no buffer cap and the player
+   * runs with profiling permanently on. Read those live with a
+   * `PerformanceObserver` in the iframe, which still receives every entry.
+   */
   perf(type?: string): PerformanceEntry[];
   /**
    * Resolves once the iframe document is loaded and the `#game` scaffold exists

--- a/impower-dev/src/modules/spark-editor/workspace/WorkspaceLanguageServer.ts
+++ b/impower-dev/src/modules/spark-editor/workspace/WorkspaceLanguageServer.ts
@@ -21,6 +21,7 @@ import {
   CompiledProgramMessage,
   CompiledProgramParams,
 } from "@impower/sparkdown/src/compiler/classes/messages/CompiledProgramMessage";
+import { profilePhase } from "@impower/sparkdown/src/compiler/utils/profile";
 import {
   BrowserMessageReader,
   BrowserMessageWriter,
@@ -241,15 +242,13 @@ export default class WorkspaceLanguageServer {
     this._connection.onNotification(
       CompiledProgramMessage.method,
       (params: CompiledProgramParams) => {
-        performance.mark(`CompiledProgramMessage start`);
+        // Via the shared helper rather than raw marks: this fires once per
+        // compile for the life of the page, and user-timing entries are never
+        // evicted by the platform.
+        profilePhase("start", `CompiledProgramMessage`);
         this.updateProgram(params.program);
         sendProtocolMessage(CompiledProgramMessage.type.notification(params));
-        performance.mark(`CompiledProgramMessage end`);
-        performance.measure(
-          `CompiledProgramMessage`,
-          `CompiledProgramMessage start`,
-          `CompiledProgramMessage end`,
-        );
+        profilePhase("end", `CompiledProgramMessage`);
       },
     );
     this._connection.onClose(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17811,7 +17811,10 @@
     },
     "packages/jsonrpc": {
       "name": "@impower/jsonrpc",
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "devDependencies": {
+        "vitest": "^2.1.9"
+      }
     },
     "packages/opfs-workspace": {
       "name": "@impower/opfs-workspace",
@@ -17876,7 +17879,8 @@
         "@types/node": "^22.14.1",
         "chokidar": "^4.0.3",
         "dts-bundle-generator": "^9.5.1",
-        "ts-morph": "^25.0.1"
+        "ts-morph": "^25.0.1",
+        "vitest": "^2.1.9"
       },
       "peerDependencies": {
         "preact": "^10.29.1",

--- a/packages/jsonrpc/package.json
+++ b/packages/jsonrpc/package.json
@@ -2,5 +2,11 @@
   "name": "@impower/jsonrpc",
   "displayName": "JSON-RPC",
   "description": "A light-weight library used to create json-rpc 2.0 messages.",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.9"
+  }
 }

--- a/packages/jsonrpc/src/browser/utils/profile.ts
+++ b/packages/jsonrpc/src/browser/utils/profile.ts
@@ -1,17 +1,131 @@
+// The one profiler implementation. Every other `profile()` helper in the repo
+// is a thin wrapper over `profilePhase`, so there is a single place for this to
+// be right — the leak this fixes existed in five independent copies.
+//
+// User-timing entries have no buffer cap — unlike resource timing, which the
+// platform evicts at 250 — so every mark and measure is retained by the global
+// `performance` object for the life of the realm. A long-lived realm (compiler
+// worker, player main thread, language server) therefore accumulates one mark
+// per phase boundary and one measure per phase forever, and the shipped hosts
+// run with profiling permanently on. So each entry is cleared as soon as it has
+// been emitted.
+//
+// A PerformanceObserver still receives every entry: delivery happens when the
+// entry is created, not when the buffer is read. What is given up is reading
+// the buffer back afterwards — `window.__preview.perf("measure")` and the
+// perf-report test are the only two places that do, and the latter opts out via
+// `setRetainProfilerEntries`.
+//
+// Elapsed time is measured from a timestamp captured here, NOT by naming the
+// two marks. Mark-name resolution cannot survive clearing: `measure()` binds to
+// the *most recent* mark of a name and `clearMarks(name)` removes *every* mark
+// of that name, so with two overlapping phases of the same name the first to
+// finish would delete the second's start mark and the second's measurement
+// would be lost entirely. Phase names carry no request id, and the callers
+// bracket `await`s, so same-name overlap is routine — every connection handles
+// concurrent requests of the same method.
+//
+// The timestamps reproduce the old pairing rule exactly (see `takeStart`), so
+// no reported duration changes; only the retention does.
+const pending = new Map<string, number[]>();
+
+// A phase that starts and never reaches its end — an early return, a throw —
+// would otherwise pin its start timestamp forever. This map is the only state
+// the profiler keeps, so bound it in both directions: how many starts one name
+// may have outstanding, and how many names may be tracked at all. Some names
+// embed unbounded values (`lsp: onCompletionResolve ${item.label}`), so without
+// the second cap a throwing resolve on distinct labels would grow the map for
+// the life of the realm — a smaller version of the leak being fixed.
+const MAX_PENDING_PER_NAME = 32;
+const MAX_PENDING_NAMES = 256;
+
+const pushStart = (name: string, at: number) => {
+  const starts = pending.get(name);
+  if (!starts) {
+    if (pending.size >= MAX_PENDING_NAMES) {
+      // Map iteration is insertion-ordered, so this evicts the oldest name.
+      const oldest = pending.keys().next().value;
+      if (oldest !== undefined) {
+        pending.delete(oldest);
+      }
+    }
+    pending.set(name, [at]);
+    return;
+  }
+  starts.push(at);
+  if (starts.length > MAX_PENDING_PER_NAME) {
+    starts.shift();
+  }
+};
+
+// Take the MOST RECENT outstanding start, which is exactly what resolving a
+// mark name did before ("convert a mark to a timestamp" uses the last mark of
+// that name). Durations are therefore unchanged by this fix.
+//
+// Pairing oldest-first instead looks more correct for genuinely overlapping
+// phases, but it is much worse in practice: a phase that starts and never ends
+// (`SparkdownWorkspace.compile` returns early on the no-change and piggyback
+// paths; `SparkdownCompiler` swallows a mid-parse throw) leaves a start that
+// oldest-first would hand to the *next unrelated* end, shifting every later
+// measurement for that name by one, forever. Measured on a 100ms phase after
+// one orphaned start and a 300ms idle: oldest-first reported 419ms then 276ms,
+// newest-first reported 107ms then 107ms — the same as before this change.
+const takeStart = (name: string) => {
+  const starts = pending.get(name);
+  if (!starts || starts.length === 0) {
+    return undefined;
+  }
+  const at = starts.pop();
+  if (starts.length === 0) {
+    pending.delete(name);
+  }
+  return at;
+};
+
+let retainEntries = false;
+
+// Opt out of the clearing above, for measurement harnesses that aggregate
+// `getEntriesByType("measure")` retrospectively — a synchronous run never gets
+// a PerformanceObserver flush, so reading the buffer back is their only option.
+export const setRetainProfilerEntries = (retain: boolean) => {
+  retainEntries = retain;
+};
+
+/** Bracket a named phase. `name` is the fully composed phase name. */
+export const profilePhase = (mark: "start" | "end", name: string) => {
+  if (mark !== "end") {
+    const startMark = `${name} start`;
+    performance.mark(startMark);
+    if (!retainEntries) {
+      performance.clearMarks(startMark);
+    }
+    pushStart(name, performance.now());
+    return;
+  }
+  const end = performance.now();
+  const endMark = `${name} end`;
+  performance.mark(endMark);
+  if (!retainEntries) {
+    performance.clearMarks(endMark);
+  }
+  const start = takeStart(name);
+  if (start === undefined) {
+    // An "end" with no matching "start" — nothing to measure.
+    return;
+  }
+  performance.measure(name, { start, end });
+  if (!retainEntries) {
+    performance.clearMeasures(name);
+  }
+};
+
 export const profile = (
   mark: "start" | "end",
   profilerId: string | undefined,
   method: string,
 ) => {
-  if (profilerId) {
-    const measureName = `${profilerId} ${method}`;
-    const startMark = `${measureName} start`;
-    const endMark = `${measureName} end`;
-    if (mark === "end") {
-      performance.mark(endMark);
-      performance.measure(measureName, startMark, endMark);
-    } else {
-      performance.mark(startMark);
-    }
+  if (!profilerId) {
+    return;
   }
+  profilePhase(mark, `${profilerId} ${method}`);
 };

--- a/packages/jsonrpc/test/profile.test.ts
+++ b/packages/jsonrpc/test/profile.test.ts
@@ -1,0 +1,145 @@
+import { PerformanceObserver } from "node:perf_hooks";
+import { beforeEach, describe, expect, it } from "vitest";
+import { profile } from "../src/browser/utils/profile";
+
+// `profile()` writes to the *global* performance timeline.
+const perf = globalThis.performance;
+
+const countEntries = () =>
+  perf.getEntriesByType("mark").length +
+  perf.getEntriesByType("measure").length;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Entries are cleared as soon as they are emitted, so the buffer cannot be read
+// back. An observer still receives them — that is the whole basis for clearing.
+const observeMeasures = async (run: () => void | Promise<void>) => {
+  const seen: { name: string; duration: number }[] = [];
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      seen.push({ name: entry.name, duration: entry.duration });
+    }
+  });
+  observer.observe({ entryTypes: ["measure"] });
+  try {
+    await run();
+    await sleep(50);
+  } finally {
+    observer.disconnect();
+  }
+  return seen;
+};
+
+describe("jsonrpc profile()", () => {
+  beforeEach(() => {
+    perf.clearMarks();
+    perf.clearMeasures();
+  });
+
+  it("does not accumulate entries across repeated messages", () => {
+    // This helper brackets every request and response of a connection that
+    // lives as long as the worker does.
+    for (let i = 0; i < 200; i += 1) {
+      profile("start", "player", "request compiler/compile");
+      profile("end", "player", "request compiler/compile");
+    }
+    expect(countEntries()).toBe(0);
+  });
+
+  it("still emits a measure for every completed phase", async () => {
+    const seen = await observeMeasures(() => {
+      for (let i = 0; i < 5; i += 1) {
+        profile("start", "player", "request compiler/compile");
+        profile("end", "player", "request compiler/compile");
+      }
+    });
+    expect(seen).toHaveLength(5);
+    expect(seen[0]?.name).toBe("player request compiler/compile");
+  });
+
+  it("measures BOTH of two overlapping same-name phases", async () => {
+    // A connection handles concurrent requests of the same method, and the
+    // phase name carries no request id — so this interleaving is routine.
+    const seen = await observeMeasures(async () => {
+      profile("start", "player", "request compiler/compile"); // A
+      await sleep(80);
+      profile("start", "player", "request compiler/compile"); // B
+      await sleep(80);
+      profile("end", "player", "request compiler/compile"); // A ends (~160ms)
+      await sleep(80);
+      profile("end", "player", "request compiler/compile"); // B ends (~160ms)
+    });
+    // Both phases must be measured. Clearing marks by name would have deleted
+    // B's start mark when A finished, losing B's measurement entirely.
+    expect(seen).toHaveLength(2);
+    expect(countEntries()).toBe(0);
+  });
+
+  it("a phase that never ended does not corrupt the next one's duration", async () => {
+    // `SparkdownWorkspace.compile` opens a phase and returns early on the
+    // no-change path, so a stale start sitting in the bookkeeping is routine.
+    // Pairing an end with the OLDEST outstanding start would charge it the
+    // whole idle gap, and stay one behind forever.
+    const seen = await observeMeasures(async () => {
+      profile("start", "player", "request compiler/compile"); // orphaned
+      await sleep(300);
+      profile("start", "player", "request compiler/compile");
+      await sleep(100);
+      profile("end", "player", "request compiler/compile");
+      await sleep(50);
+      profile("start", "player", "request compiler/compile");
+      await sleep(100);
+      profile("end", "player", "request compiler/compile");
+    });
+    expect(seen).toHaveLength(2);
+    for (const measure of seen) {
+      expect(measure.duration).toBeGreaterThan(80);
+      expect(measure.duration).toBeLessThan(200);
+    }
+  });
+
+  it("retains nothing for phases that never end, and still drains", async () => {
+    const seen = await observeMeasures(async () => {
+      for (let i = 0; i < 200; i += 1) {
+        profile("start", "player", "request compiler/compile");
+      }
+      expect(countEntries()).toBe(0);
+      profile("end", "player", "request compiler/compile");
+    });
+    expect(seen).toHaveLength(1);
+    expect(countEntries()).toBe(0);
+  });
+
+  it("bounds its own bookkeeping for unbounded phase names", async () => {
+    // `lsp: onCompletionResolve ${item.label}` embeds an unbounded value, and
+    // those handlers have no try/finally — a throw leaves the phase open under
+    // a name that may never be seen again.
+    const seen = await observeMeasures(async () => {
+      for (let i = 0; i < 5000; i += 1) {
+        profile("start", "player", `request unique/${i}`);
+      }
+      expect(countEntries()).toBe(0);
+      // The most recent names are still tracked; the oldest were evicted.
+      profile("end", "player", "request unique/4999");
+      profile("end", "player", "request unique/0");
+    });
+    expect(seen.map((s) => s.name)).toEqual(["player request unique/4999"]);
+    expect(countEntries()).toBe(0);
+  });
+
+  it("writes nothing at all when no profiler id is set", async () => {
+    const seen = await observeMeasures(() => {
+      profile("start", undefined, "request compiler/compile");
+      profile("end", undefined, "request compiler/compile");
+    });
+    expect(seen).toHaveLength(0);
+    expect(countEntries()).toBe(0);
+  });
+
+  it("does not throw when a message ends without a start", () => {
+    expect(() =>
+      profile("end", "player", "response compiler/compile"),
+    ).not.toThrow();
+    expect(countEntries()).toBe(0);
+  });
+});

--- a/packages/jsonrpc/vitest.config.ts
+++ b/packages/jsonrpc/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.{test,spec}.{ts,tsx}"],
+    exclude: ["**/node_modules/**", "**/dist/**", "**/out/**"],
+    // Run sequentially with a single fork and let the caller cap the heap via
+    // NODE_OPTIONS=--max-old-space-size. The repo has OOM-crashed on uncapped /
+    // parallel runs, so keep the pool small and disable file parallelism.
+    pool: "forks",
+    poolOptions: { forks: { singleFork: true } },
+    fileParallelism: false,
+  },
+});

--- a/packages/spark-web-player/package.json
+++ b/packages/spark-web-player/package.json
@@ -24,7 +24,8 @@
     "@types/node": "^22.14.1",
     "chokidar": "^4.0.3",
     "dts-bundle-generator": "^9.5.1",
-    "ts-morph": "^25.0.1"
+    "ts-morph": "^25.0.1",
+    "vitest": "^2.1.9"
   },
   "peerDependencies": {
     "preact": "^10.29.1",

--- a/packages/spark-web-player/src/utils/profile.test.ts
+++ b/packages/spark-web-player/src/utils/profile.test.ts
@@ -1,0 +1,107 @@
+import { PerformanceObserver } from "node:perf_hooks";
+import { beforeEach, describe, expect, it } from "vitest";
+import { profile } from "./profile";
+
+// `profile()` writes to the *global* performance timeline.
+const perf = globalThis.performance;
+
+const countEntries = () =>
+  perf.getEntriesByType("mark").length +
+  perf.getEntriesByType("measure").length;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Entries are cleared as soon as they are emitted, so the buffer cannot be read
+// back. An observer still receives them — that is the whole basis for clearing.
+const observeMeasures = async (run: () => void | Promise<void>) => {
+  const seen: { name: string; duration: number }[] = [];
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      seen.push({ name: entry.name, duration: entry.duration });
+    }
+  });
+  observer.observe({ entryTypes: ["measure"] });
+  try {
+    await run();
+    await sleep(50);
+  } finally {
+    observer.disconnect();
+  }
+  return seen;
+};
+
+describe("player profile()", () => {
+  beforeEach(() => {
+    perf.clearMarks();
+    perf.clearMeasures();
+  });
+
+  it("does not accumulate entries across repeated phases", () => {
+    // This helper brackets every protocol message the player handles, so
+    // anything retained here grows for the life of the page.
+    for (let i = 0; i < 200; i += 1) {
+      profile("start", "game/update");
+      profile("end", "game/update");
+    }
+    expect(countEntries()).toBe(0);
+  });
+
+  it("still emits a measure for every completed phase", async () => {
+    const seen = await observeMeasures(() => {
+      for (let i = 0; i < 5; i += 1) {
+        profile("start", "game/update");
+        profile("end", "game/update");
+      }
+    });
+    expect(seen).toHaveLength(5);
+    expect(seen[0]?.name).toBe("game/update");
+  });
+
+  it("measures BOTH of two overlapping same-name phases", async () => {
+    // `profileMessageHandling` brackets an awaited handler and keys the phase
+    // on message.method alone, so two notifications of the same method overlap.
+    const seen = await observeMeasures(async () => {
+      profile("start", "compiler/didCompile"); // A
+      await sleep(80);
+      profile("start", "compiler/didCompile"); // B
+      await sleep(80);
+      profile("end", "compiler/didCompile"); // A ends (~160ms)
+      await sleep(80);
+      profile("end", "compiler/didCompile"); // B ends (~160ms)
+    });
+    // Both phases must be measured. Clearing marks by name would have deleted
+    // B's start mark when A finished, losing B's measurement entirely.
+    expect(seen).toHaveLength(2);
+    expect(countEntries()).toBe(0);
+  });
+
+  it("a phase that never ended does not corrupt the next one's duration", async () => {
+    const seen = await observeMeasures(async () => {
+      profile("start", "game/create"); // orphaned
+      await sleep(300);
+      profile("start", "game/create");
+      await sleep(100);
+      profile("end", "game/create");
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.duration).toBeGreaterThan(80);
+    expect(seen[0]!.duration).toBeLessThan(200);
+  });
+
+  it("retains nothing for phases that never end, and still drains", async () => {
+    const seen = await observeMeasures(async () => {
+      for (let i = 0; i < 200; i += 1) {
+        profile("start", "game/create");
+      }
+      expect(countEntries()).toBe(0);
+      profile("end", "game/create");
+    });
+    expect(seen).toHaveLength(1);
+    expect(countEntries()).toBe(0);
+  });
+
+  it("does not throw when a phase ends without a start", () => {
+    expect(() => profile("end", "game/destroy")).not.toThrow();
+    expect(countEntries()).toBe(0);
+  });
+});

--- a/packages/spark-web-player/src/utils/profile.ts
+++ b/packages/spark-web-player/src/utils/profile.ts
@@ -1,8 +1,9 @@
+import { profilePhase } from "@impower/jsonrpc/src/browser/utils/profile";
+
+// One implementation lives in @impower/jsonrpc; see the notes there for why
+// entries are cleared and why the duration is not resolved through mark names.
+// This helper is unconditional — it brackets every protocol message the player
+// handles — so before the entries were cleared it grew for the life of the page.
 export const profile = (mark: "start" | "end", method: string) => {
-  if (mark === "end") {
-    performance.mark(`${method} end`);
-    performance.measure(`${method}`.trim(), `${method} start`, `${method} end`);
-  } else {
-    performance.mark(`${method} start`);
-  }
+  profilePhase(mark, method.trim());
 };

--- a/packages/sparkdown-language-server/src/sparkdown-language-server.ts
+++ b/packages/sparkdown-language-server/src/sparkdown-language-server.ts
@@ -10,6 +10,7 @@ import {
   TextDocumentSyncKind,
 } from "vscode-languageserver/browser";
 import { SparkdownLanguageServerWorkspace } from "./classes/SparkdownLanguageServerWorkspace";
+import { profile } from "./utils/logging/profile";
 import { canRename } from "./utils/providers/canRename";
 import { getCodeLenses } from "./utils/providers/getCodeLenses";
 import { getColorPresentations } from "./utils/providers/getColorPresentations";
@@ -178,14 +179,9 @@ try {
     ) {
       return cached.result;
     }
-    performance.mark(`lsp: onFoldingRanges ${uri} start`);
+    profile("start", "lsp: onFoldingRanges", uri);
     const result = getFoldingRanges(document, annotations, program);
-    performance.mark(`lsp: onFoldingRanges ${uri} end`);
-    performance.measure(
-      `lsp: onFoldingRanges ${uri}`,
-      `lsp: onFoldingRanges ${uri} start`,
-      `lsp: onFoldingRanges ${uri} end`,
-    );
+    profile("end", "lsp: onFoldingRanges", uri);
     if (document) {
       foldingRangeCache.set(uri, {
         documentVersion: document.version,
@@ -202,25 +198,15 @@ try {
     const document = workspace.document(uri);
     const annotations = workspace.annotations(uri);
     const program = workspace.program(uri);
-    performance.mark(`lsp: onDocumentColor ${uri} start`);
+    profile("start", "lsp: onDocumentColor", uri);
     const result = getDocumentColors(document, annotations, program);
-    performance.mark(`lsp: onDocumentColor ${uri} end`);
-    performance.measure(
-      `lsp: onDocumentColor ${uri}`,
-      `lsp: onDocumentColor ${uri} start`,
-      `lsp: onDocumentColor ${uri} end`,
-    );
+    profile("end", "lsp: onDocumentColor", uri);
     return result;
   });
   connection.onColorPresentation((params) => {
-    performance.mark(`lsp: onDocumentColor start`);
+    profile("start", "lsp: onDocumentColor");
     const result = getColorPresentations(params.color);
-    performance.mark(`lsp: onDocumentColor end`);
-    performance.measure(
-      `lsp: onDocumentColor`,
-      `lsp: onDocumentColor start`,
-      `lsp: onDocumentColor end`,
-    );
+    profile("end", "lsp: onDocumentColor");
     return result;
   });
 
@@ -229,14 +215,9 @@ try {
     const uri = params.textDocument.uri;
     const document = workspace.document(uri);
     const annotations = workspace.annotations(uri);
-    performance.mark(`lsp: onDocumentSymbol ${uri} start`);
+    profile("start", "lsp: onDocumentSymbol", uri);
     const result = getDocumentSymbols(document, annotations);
-    performance.mark(`lsp: onDocumentSymbol ${uri} end`);
-    performance.measure(
-      `lsp: onDocumentSymbol ${uri}`,
-      `lsp: onDocumentSymbol ${uri} start`,
-      `lsp: onDocumentSymbol ${uri} end`,
-    );
+    profile("end", "lsp: onDocumentSymbol", uri);
     return result;
   });
 
@@ -247,7 +228,7 @@ try {
     const annotations = workspace.annotations(uri);
     const program = workspace.program(uri);
     const config = workspace.compilerConfig;
-    performance.mark(`lsp: onHover ${uri} start`);
+    profile("start", "lsp: onHover", uri);
     const result = getHover(
       document,
       annotations,
@@ -256,12 +237,7 @@ try {
       params.position,
       imageCompositeOptions,
     );
-    performance.mark(`lsp: onHover ${uri} end`);
-    performance.measure(
-      `lsp: onHover ${uri}`,
-      `lsp: onHover ${uri} start`,
-      `lsp: onHover ${uri} end`,
-    );
+    profile("end", "lsp: onHover", uri);
     return result;
   });
 
@@ -277,7 +253,7 @@ try {
     for (const uri of Object.keys(scripts)) {
       scriptAnnotations.set(uri, workspace.annotations(uri));
     }
-    performance.mark(`lsp: onCompletion ${uri} start`);
+    profile("start", "lsp: onCompletion", uri);
     const result = getCompletions(
       document,
       tree,
@@ -287,12 +263,7 @@ try {
       params.position,
       params.context,
     );
-    performance.mark(`lsp: onCompletion ${uri} end`);
-    performance.measure(
-      `lsp: onCompletion ${uri}`,
-      `lsp: onCompletion ${uri} start`,
-      `lsp: onCompletion ${uri} end`,
-    );
+    profile("end", "lsp: onCompletion", uri);
     // `workspace.program()` is keyed by the REQUESTED document uri, not by
     // `program.uri` (which is the compiled root), so resolve has to be told
     // which document it came from. Stamped here to keep uri plumbing out of
@@ -313,19 +284,14 @@ try {
     if (!data?.uri) {
       return item;
     }
-    performance.mark(`lsp: onCompletionResolve ${item.label} start`);
+    profile("start", "lsp: onCompletionResolve", item.label);
     const program = workspace.program(data.uri);
     const resolved = await resolveCompletion(
       item,
       program,
       imageCompositeOptions,
     );
-    performance.mark(`lsp: onCompletionResolve ${item.label} end`);
-    performance.measure(
-      `lsp: onCompletionResolve ${item.label}`,
-      `lsp: onCompletionResolve ${item.label} start`,
-      `lsp: onCompletionResolve ${item.label} end`,
-    );
+    profile("end", "lsp: onCompletionResolve", item.label);
     return resolved;
   });
 
@@ -337,7 +303,7 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const annotations = workspace.annotations(uri);
-    performance.mark(`lsp: onDocumentFormatting ${uri} start`);
+    profile("start", "lsp: onDocumentFormatting", uri);
     // Incremental (delta) formatting for format-on-save: only reprocess
     // the construct(s) changed since the last format. The dirty range is
     // the diff against the last formatted output — safe because outside
@@ -363,12 +329,7 @@ try {
         : document.getText();
       workspace.markFormatted(uri, formatted);
     }
-    performance.mark(`lsp: onDocumentFormatting ${uri} end`);
-    performance.measure(
-      `lsp: onDocumentFormatting ${uri}`,
-      `lsp: onDocumentFormatting ${uri} start`,
-      `lsp: onDocumentFormatting ${uri} end`,
-    );
+    profile("end", "lsp: onDocumentFormatting", uri);
     return result;
   });
 
@@ -380,7 +341,7 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const annotations = workspace.annotations(uri);
-    performance.mark(`lsp: onDocumentRangeFormatting ${uri} start`);
+    profile("start", "lsp: onDocumentRangeFormatting", uri);
     const result = getDocumentFormattingEdits(
       document,
       tree,
@@ -388,12 +349,7 @@ try {
       params.options,
       params.range,
     );
-    performance.mark(`lsp: onDocumentRangeFormatting ${uri} end`);
-    performance.measure(
-      `lsp: onDocumentRangeFormatting ${uri}`,
-      `lsp: onDocumentRangeFormatting ${uri} start`,
-      `lsp: onDocumentRangeFormatting ${uri} end`,
-    );
+    profile("end", "lsp: onDocumentRangeFormatting", uri);
     return result;
   });
 
@@ -405,7 +361,7 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const annotations = workspace.annotations(uri);
-    performance.mark(`lsp: onDocumentOnTypeFormatting ${uri} start`);
+    profile("start", "lsp: onDocumentOnTypeFormatting", uri);
     const result = getDocumentFormattingEdits(
       document,
       tree,
@@ -414,12 +370,7 @@ try {
       undefined,
       params.position,
     );
-    performance.mark(`lsp: onDocumentOnTypeFormatting ${uri} end`);
-    performance.measure(
-      `lsp: onDocumentOnTypeFormatting ${uri}`,
-      `lsp: onDocumentOnTypeFormatting ${uri} start`,
-      `lsp: onDocumentOnTypeFormatting ${uri} end`,
-    );
+    profile("end", "lsp: onDocumentOnTypeFormatting", uri);
     return result;
   });
 
@@ -428,14 +379,9 @@ try {
     const uri = params.textDocument.uri;
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
-    performance.mark(`lsp: onPrepareRename ${uri} start`);
+    profile("start", "lsp: onPrepareRename", uri);
     const result = canRename(document, tree, params.position);
-    performance.mark(`lsp: onPrepareRename ${uri} end`);
-    performance.measure(
-      `lsp: onPrepareRename ${uri}`,
-      `lsp: onPrepareRename ${uri} start`,
-      `lsp: onPrepareRename ${uri} end`,
-    );
+    profile("end", "lsp: onPrepareRename", uri);
     return result;
   });
 
@@ -447,7 +393,7 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const program = workspace.program(uri);
-    performance.mark(`lsp: onRenameRequest ${uri} start`);
+    profile("start", "lsp: onRenameRequest", uri);
     const result = getRenameEdits(
       settings,
       document,
@@ -457,12 +403,7 @@ try {
       params.newName,
       params.position,
     );
-    performance.mark(`lsp: onRenameRequest ${uri} end`);
-    performance.measure(
-      `lsp: onRenameRequest ${uri}`,
-      `lsp: onRenameRequest ${uri} start`,
-      `lsp: onRenameRequest ${uri} end`,
-    );
+    profile("end", "lsp: onRenameRequest", uri);
     return result;
   });
 
@@ -518,7 +459,7 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const program = workspace.program(uri);
-    performance.mark(`lsp: onReferences ${uri} start`);
+    profile("start", "lsp: onReferences", uri);
     const { references } = getReferences(
       document,
       tree,
@@ -532,12 +473,7 @@ try {
         includeLinks: true,
       },
     );
-    performance.mark(`lsp: onReferences ${uri} end`);
-    performance.measure(
-      `lsp: onReferences ${uri}`,
-      `lsp: onReferences ${uri} start`,
-      `lsp: onReferences ${uri} end`,
-    );
+    profile("end", "lsp: onReferences", uri);
     return references;
   });
 
@@ -547,7 +483,7 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const program = workspace.program(uri);
-    performance.mark(`lsp: onDeclaration ${uri} start`);
+    profile("start", "lsp: onDeclaration", uri);
     const { references } = getReferences(
       document,
       tree,
@@ -562,12 +498,7 @@ try {
         includeLinks: false,
       },
     );
-    performance.mark(`lsp: onDeclaration ${uri} end`);
-    performance.measure(
-      `lsp: onDeclaration ${uri}`,
-      `lsp: onDeclaration ${uri} start`,
-      `lsp: onDeclaration ${uri} end`,
-    );
+    profile("end", "lsp: onDeclaration", uri);
     return references;
   });
 
@@ -577,7 +508,7 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const program = workspace.program(uri);
-    performance.mark(`lsp: onDefinition ${uri} start`);
+    profile("start", "lsp: onDefinition", uri);
     const { references } = getReferences(
       document,
       tree,
@@ -592,12 +523,7 @@ try {
         includeLinks: false,
       },
     );
-    performance.mark(`lsp: onDefinition ${uri} end`);
-    performance.measure(
-      `lsp: onDefinition ${uri}`,
-      `lsp: onDefinition ${uri} start`,
-      `lsp: onDefinition ${uri} end`,
-    );
+    profile("end", "lsp: onDefinition", uri);
     return references;
   });
 
@@ -607,14 +533,9 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const annotations = workspace.annotations(uri);
-    performance.mark(`lsp: onDocumentLinks ${uri} start`);
+    profile("start", "lsp: onDocumentLinks", uri);
     const result = getDocumentLinks(document, tree, annotations, workspace);
-    performance.mark(`lsp: onDocumentLinks ${uri} end`);
-    performance.measure(
-      `lsp: onDocumentLinks ${uri}`,
-      `lsp: onDocumentLinks ${uri} start`,
-      `lsp: onDocumentLinks ${uri} end`,
-    );
+    profile("end", "lsp: onDocumentLinks", uri);
     return result;
   });
 
@@ -624,7 +545,7 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const program = workspace.program(uri);
-    performance.mark(`lsp: onDocumentHighlight ${uri} start`);
+    profile("start", "lsp: onDocumentHighlight", uri);
     const { references } = getReferences(
       document,
       tree,
@@ -638,12 +559,7 @@ try {
         includeLinks: true,
       },
     );
-    performance.mark(`lsp: onDocumentHighlight ${uri} end`);
-    performance.measure(
-      `lsp: onDocumentHighlight ${uri}`,
-      `lsp: onDocumentHighlight ${uri} start`,
-      `lsp: onDocumentHighlight ${uri} end`,
-    );
+    profile("end", "lsp: onDocumentHighlight", uri);
     return references;
   });
 
@@ -666,14 +582,9 @@ try {
     ) {
       return cached.result;
     }
-    performance.mark(`lsp: semanticTokens.on ${uri} start`);
+    profile("start", "lsp: semanticTokens.on", uri);
     const result = getSemanticTokens(document, annotations, program);
-    performance.mark(`lsp: semanticTokens.on ${uri} end`);
-    performance.measure(
-      `lsp: semanticTokens.on ${uri}`,
-      `lsp: semanticTokens.on ${uri} start`,
-      `lsp: semanticTokens.on ${uri} end`,
-    );
+    profile("end", "lsp: semanticTokens.on", uri);
     if (document) {
       semanticTokensCache.set(uri, {
         documentVersion: document.version,
@@ -689,19 +600,14 @@ try {
       workspace.program(uri) || (await workspace.compile(uri, false));
     const document = workspace.document(uri);
     const annotations = workspace.annotations(uri);
-    performance.mark(`lsp: semanticTokens.onRange ${uri} start`);
+    profile("start", "lsp: semanticTokens.onRange", uri);
     const result = getSemanticTokens(
       document,
       annotations,
       program,
       params.range,
     );
-    performance.mark(`lsp: semanticTokens.onRange ${uri} end`);
-    performance.measure(
-      `lsp: semanticTokens.onRange ${uri}`,
-      `lsp: semanticTokens.onRange ${uri} start`,
-      `lsp: semanticTokens.onRange ${uri} end`,
-    );
+    profile("end", "lsp: semanticTokens.onRange", uri);
     return result;
   });
 
@@ -710,14 +616,9 @@ try {
     const uri = params.textDocument.uri;
     const document = workspace.document(uri);
     const annotations = workspace.annotations(uri);
-    performance.mark(`lsp: onCodeLens ${uri} start`);
+    profile("start", "lsp: onCodeLens", uri);
     const result = getCodeLenses(document, annotations);
-    performance.mark(`lsp: onCodeLens ${uri} end`);
-    performance.measure(
-      `lsp: onCodeLens ${uri}`,
-      `lsp: onCodeLens ${uri} start`,
-      `lsp: onCodeLens ${uri} end`,
-    );
+    profile("end", "lsp: onCodeLens", uri);
     return result;
   });
 

--- a/packages/sparkdown-language-server/src/tests/logging/profile.test.ts
+++ b/packages/sparkdown-language-server/src/tests/logging/profile.test.ts
@@ -1,0 +1,124 @@
+import { PerformanceObserver } from "node:perf_hooks";
+import { beforeEach, describe, expect, it } from "vitest";
+import { profile } from "../../utils/logging/profile";
+
+// `profile()` writes to the *global* performance timeline.
+const perf = globalThis.performance;
+
+const countEntries = () =>
+  perf.getEntriesByType("mark").length +
+  perf.getEntriesByType("measure").length;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Entries are cleared as soon as they are emitted, so the buffer cannot be read
+// back. An observer still receives them — that is the whole basis for clearing.
+const observeMeasures = async (run: () => void | Promise<void>) => {
+  const seen: { name: string; duration: number }[] = [];
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      seen.push({ name: entry.name, duration: entry.duration });
+    }
+  });
+  observer.observe({ entryTypes: ["measure"] });
+  try {
+    await run();
+    await sleep(50);
+  } finally {
+    observer.disconnect();
+  }
+  return seen;
+};
+
+describe("language server profile()", () => {
+  beforeEach(() => {
+    perf.clearMarks();
+    perf.clearMeasures();
+  });
+
+  it("does not accumulate entries across repeated requests", () => {
+    // A language server is long-lived and this helper is unconditional, so
+    // anything retained here grows for as long as the server runs.
+    for (let i = 0; i < 200; i += 1) {
+      profile("start", "lsp: onHover", "file:///main.sd");
+      profile("end", "lsp: onHover", "file:///main.sd");
+    }
+    expect(countEntries()).toBe(0);
+  });
+
+  it("does not accumulate entries for a phase with no uri", () => {
+    for (let i = 0; i < 200; i += 1) {
+      profile("start", "lsp: onDocumentColor");
+      profile("end", "lsp: onDocumentColor");
+    }
+    expect(countEntries()).toBe(0);
+  });
+
+  it("still emits a measure named after the phase and uri", async () => {
+    const seen = await observeMeasures(() => {
+      profile("start", "lsp: onHover", "file:///main.sd");
+      profile("end", "lsp: onHover", "file:///main.sd");
+      // A uri-less phase keeps its name untouched — no trailing space.
+      profile("start", "lsp: onDocumentColor");
+      profile("end", "lsp: onDocumentColor");
+    });
+    expect(seen.map((s) => s.name)).toEqual([
+      "lsp: onHover file:///main.sd",
+      "lsp: onDocumentColor",
+    ]);
+  });
+
+  it("measures BOTH of two overlapping same-name requests", async () => {
+    // vscode-jsonrpc does not serialize async handlers, so two requests for the
+    // same document can be in flight at once and the phase names collide.
+    const seen = await observeMeasures(async () => {
+      profile("start", "lsp: semanticTokens.on", "file:///main.sd"); // A
+      await sleep(80);
+      profile("start", "lsp: semanticTokens.on", "file:///main.sd"); // B
+      await sleep(80);
+      profile("end", "lsp: semanticTokens.on", "file:///main.sd"); // A (~160ms)
+      await sleep(80);
+      profile("end", "lsp: semanticTokens.on", "file:///main.sd"); // B (~160ms)
+    });
+    // Both requests must be measured. Clearing marks by name would have deleted
+    // B's start mark when A finished, losing B's measurement entirely.
+    expect(seen).toHaveLength(2);
+    expect(countEntries()).toBe(0);
+  });
+
+  it("a request that never ended does not corrupt the next one's duration", async () => {
+    // `resolveCompletion` and friends are awaited with no try/finally, so a
+    // throw leaves a stale start behind.
+    const seen = await observeMeasures(async () => {
+      profile("start", "lsp: onCompletion", "file:///main.sd"); // orphaned
+      await sleep(300);
+      profile("start", "lsp: onCompletion", "file:///main.sd");
+      await sleep(100);
+      profile("end", "lsp: onCompletion", "file:///main.sd");
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.duration).toBeGreaterThan(80);
+    expect(seen[0]!.duration).toBeLessThan(200);
+  });
+
+  it("retains nothing for requests that never end, and still drains", async () => {
+    // `resolveCompletion` and friends are awaited with no try/finally, so a
+    // throw leaves the phase permanently open.
+    const seen = await observeMeasures(async () => {
+      for (let i = 0; i < 200; i += 1) {
+        profile("start", "lsp: onCompletion", "file:///main.sd");
+      }
+      expect(countEntries()).toBe(0);
+      profile("end", "lsp: onCompletion", "file:///main.sd");
+    });
+    expect(seen).toHaveLength(1);
+    expect(countEntries()).toBe(0);
+  });
+
+  it("does not throw when a request ends without a start", () => {
+    expect(() =>
+      profile("end", "lsp: onReferences", "file:///main.sd"),
+    ).not.toThrow();
+    expect(countEntries()).toBe(0);
+  });
+});

--- a/packages/sparkdown-language-server/src/utils/logging/profile.ts
+++ b/packages/sparkdown-language-server/src/utils/logging/profile.ts
@@ -1,16 +1,13 @@
+import { profilePhase } from "@impower/jsonrpc/src/browser/utils/profile";
+
+// One implementation lives in @impower/jsonrpc; see the notes there for why
+// entries are cleared and why the duration is not resolved through mark names.
+// A language server is long-lived and this helper is unconditional, so before
+// the entries were cleared it grew across requests without bound.
 export const profile = (
   mark: "start" | "end",
   method: string,
   uri: string = "",
 ) => {
-  if (mark === "end") {
-    performance.mark(`${method} ${uri} end`);
-    performance.measure(
-      `${method} ${uri}`.trim(),
-      `${method} ${uri} start`,
-      `${method} ${uri} end`,
-    );
-  } else {
-    performance.mark(`${method} ${uri} start`);
-  }
+  profilePhase(mark, `${method} ${uri}`.trim());
 };

--- a/packages/sparkdown/src/compiler/utils/profile.ts
+++ b/packages/sparkdown/src/compiler/utils/profile.ts
@@ -1,19 +1,20 @@
+import { profilePhase } from "@impower/jsonrpc/src/browser/utils/profile";
+
+// One implementation lives in @impower/jsonrpc; see the notes there for why
+// entries are cleared and why the duration is not resolved through mark names.
+export {
+  profilePhase,
+  setRetainProfilerEntries,
+} from "@impower/jsonrpc/src/browser/utils/profile";
+
 export const profile = (
   mark: "start" | "end",
   profilerId: string | undefined,
   method: string,
   uri: string = "",
 ) => {
-  if (profilerId) {
-    if (mark === "end") {
-      performance.mark(`${profilerId} ${method} ${uri} end`);
-      performance.measure(
-        `${profilerId} ${method} ${uri}`.trim(),
-        `${profilerId} ${method} ${uri} start`,
-        `${profilerId} ${method} ${uri} end`,
-      );
-    } else {
-      performance.mark(`${profilerId} ${method} ${uri} start`);
-    }
+  if (!profilerId) {
+    return;
   }
+  profilePhase(mark, `${profilerId} ${method} ${uri}`.trim());
 };

--- a/packages/sparkdown/src/tests/compiler/perfProfile.test.ts
+++ b/packages/sparkdown/src/tests/compiler/perfProfile.test.ts
@@ -1,7 +1,8 @@
 import "../../inkjs/engine/Container";
 import { performance } from "node:perf_hooks";
-import { describe, it } from "vitest";
+import { afterAll, beforeAll, describe, it } from "vitest";
 import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+import { setRetainProfilerEntries } from "../../compiler/utils/profile";
 import { generatePerfScreenplay } from "./perfFixture";
 
 interface PhaseStat {
@@ -41,6 +42,12 @@ function report(label: string, stats: Map<string, PhaseStat>) {
 }
 
 describe("compiler perf profile", () => {
+  // `profile()` clears each mark/measure pair as soon as it measures, so a
+  // long-lived worker doesn't retain them forever. This report aggregates
+  // measures retrospectively and is the one caller that needs them kept.
+  beforeAll(() => setRetainProfilerEntries(true));
+  afterAll(() => setRetainProfilerEntries(false));
+
   it("profiles cold compile + per-edit recompile", () => {
     const PROFILER_ID = "perf";
     const uri = "inmemory:///main.sd";

--- a/packages/sparkdown/src/tests/compiler/profilerEntryRetention.test.ts
+++ b/packages/sparkdown/src/tests/compiler/profilerEntryRetention.test.ts
@@ -1,0 +1,238 @@
+import "../../inkjs/engine/Container";
+import { PerformanceObserver } from "node:perf_hooks";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+import {
+  profile,
+  setRetainProfilerEntries,
+} from "../../compiler/utils/profile";
+import { generatePerfScreenplay } from "./perfFixture";
+
+// `profile()` writes to the *global* performance timeline, which is what these
+// assertions read back.
+const perf = globalThis.performance;
+
+const countEntries = () =>
+  perf.getEntriesByType("mark").length +
+  perf.getEntriesByType("measure").length;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Entries are cleared as soon as they are emitted, so the buffer cannot be read
+// back. An observer still receives them — that is the whole basis for clearing.
+const observeMeasures = async (run: () => void | Promise<void>) => {
+  const seen: { name: string; duration: number }[] = [];
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      seen.push({ name: entry.name, duration: entry.duration });
+    }
+  });
+  observer.observe({ entryTypes: ["measure"] });
+  try {
+    await run();
+    await sleep(50);
+  } finally {
+    observer.disconnect();
+  }
+  return seen;
+};
+
+describe("profiler user-timing entries", () => {
+  beforeEach(() => {
+    setRetainProfilerEntries(false);
+    perf.clearMarks();
+    perf.clearMeasures();
+  });
+
+  it("retains nothing once a phase is measured", () => {
+    for (let i = 0; i < 50; i += 1) {
+      profile("start", "test", "phase", "inmemory:///main.sd");
+      profile("end", "test", "phase", "inmemory:///main.sd");
+    }
+    expect(countEntries()).toBe(0);
+  });
+
+  it("still emits a measure for every completed phase", async () => {
+    const seen = await observeMeasures(() => {
+      for (let i = 0; i < 5; i += 1) {
+        profile("start", "test", "phase", "inmemory:///main.sd");
+        profile("end", "test", "phase", "inmemory:///main.sd");
+      }
+    });
+    expect(seen).toHaveLength(5);
+    expect(seen[0]?.name).toBe("test phase inmemory:///main.sd");
+  });
+
+  it("measures BOTH of two overlapping same-name phases", async () => {
+    // Phase names are `${profilerId} ${method} ${uri}` — no request id — and the
+    // workspace brackets awaited compiles, so same-name overlap is routine.
+    const seen = await observeMeasures(async () => {
+      profile("start", "test", "compile", "inmemory:///main.sd"); // A
+      await sleep(80);
+      profile("start", "test", "compile", "inmemory:///main.sd"); // B
+      await sleep(80);
+      profile("end", "test", "compile", "inmemory:///main.sd"); // A (~160ms)
+      await sleep(80);
+      profile("end", "test", "compile", "inmemory:///main.sd"); // B (~160ms)
+    });
+    // Both phases must be measured. Clearing marks by name would have deleted
+    // B's start mark when A finished, losing B's measurement entirely.
+    expect(seen).toHaveLength(2);
+    expect(countEntries()).toBe(0);
+  });
+
+  it("a phase that never ended does not corrupt the next one's duration", async () => {
+    // `SparkdownWorkspace.compile` returns early on the no-change and piggyback
+    // paths, and `SparkdownCompiler` swallows a mid-parse throw, so a stale
+    // start is routine. Charging the next phase the whole idle gap would make
+    // every later compile timing wrong, permanently.
+    const seen = await observeMeasures(async () => {
+      profile("start", "test", "compile", "inmemory:///main.sd"); // orphaned
+      await sleep(300);
+      profile("start", "test", "compile", "inmemory:///main.sd");
+      await sleep(100);
+      profile("end", "test", "compile", "inmemory:///main.sd");
+      await sleep(50);
+      profile("start", "test", "compile", "inmemory:///main.sd");
+      await sleep(100);
+      profile("end", "test", "compile", "inmemory:///main.sd");
+    });
+    expect(seen).toHaveLength(2);
+    for (const measure of seen) {
+      expect(measure.duration).toBeGreaterThan(80);
+      expect(measure.duration).toBeLessThan(200);
+    }
+  });
+
+  it("retains nothing for phases that never end, and still drains", async () => {
+    // `SparkdownWorkspace.compile` opens a phase and then returns early on the
+    // no-op and piggyback paths, so unmatched starts are a real occurrence.
+    const seen = await observeMeasures(async () => {
+      for (let i = 0; i < 200; i += 1) {
+        profile("start", "test", "orphan", "inmemory:///main.sd");
+      }
+      expect(countEntries()).toBe(0);
+      profile("end", "test", "orphan", "inmemory:///main.sd");
+    });
+    expect(seen).toHaveLength(1);
+    expect(countEntries()).toBe(0);
+  });
+
+  it("writes nothing at all when no profiler id is set", async () => {
+    const seen = await observeMeasures(() => {
+      profile("start", undefined, "phase", "inmemory:///main.sd");
+      profile("end", undefined, "phase", "inmemory:///main.sd");
+    });
+    expect(seen).toHaveLength(0);
+    expect(countEntries()).toBe(0);
+  });
+
+  it("clears by default — a freshly loaded module retains nothing", async () => {
+    // Every other test here forces the flag off in `beforeEach`, so without
+    // this one, flipping the module's initial value would go unnoticed.
+    vi.resetModules();
+    const fresh = await import("../../compiler/utils/profile");
+    fresh.profile("start", "test", "default", "inmemory:///main.sd");
+    fresh.profile("end", "test", "default", "inmemory:///main.sd");
+    expect(countEntries()).toBe(0);
+  });
+
+  it("retains entries for a harness that opts in", () => {
+    setRetainProfilerEntries(true);
+    try {
+      for (let i = 0; i < 3; i += 1) {
+        profile("start", "test", "phase", "inmemory:///main.sd");
+        profile("end", "test", "phase", "inmemory:///main.sd");
+      }
+      expect(perf.getEntriesByType("measure")).toHaveLength(3);
+    } finally {
+      setRetainProfilerEntries(false);
+    }
+  });
+
+  // The behaviour from the ticket: with profiling on, a long-lived compiler
+  // realm must not grow its user-timing buffer edit after edit.
+  it("does not accumulate entries across repeated compiles", async () => {
+    const uri = "inmemory:///main.sd";
+    const sceneCount = 4;
+    let source = generatePerfScreenplay(sceneCount);
+
+    // The compiler logs diagnostics verbosely; keep the test output readable.
+    const realWarn = console.warn;
+    const realError = console.error;
+    console.warn = () => {};
+    console.error = () => {};
+
+    try {
+      const compiler = new SparkdownCompiler();
+      compiler.profilerId = "test";
+      compiler.configure({
+        files: [
+          {
+            uri,
+            type: "script",
+            name: "main",
+            ext: "sd",
+            text: source,
+            version: 1,
+            languageId: "sparkdown",
+          },
+        ],
+      });
+      compiler.compile({ textDocument: { uri } });
+
+      // Insert one character immediately AFTER a stable marker each iteration,
+      // so the marker survives and the edit stays in the same place — mirrors a
+      // keystroke, and is the shape that was measured on the ticket.
+      const marker = `This is dialogue line one in scene ${Math.floor(
+        sceneCount / 2,
+      )}.`;
+      let version = 1;
+      const edit = () => {
+        version += 1;
+        const markerIndex = source.indexOf(marker);
+        if (markerIndex < 0) {
+          throw new Error("marker not found — edit relocated unexpectedly");
+        }
+        const insertOffset = markerIndex + marker.length;
+        const before = source.slice(0, insertOffset);
+        const line = before.split("\n").length - 1;
+        const character = insertOffset - (before.lastIndexOf("\n") + 1);
+        compiler.updateDocument({
+          textDocument: { uri, version },
+          contentChanges: [
+            {
+              range: { start: { line, character }, end: { line, character } },
+              text: "x",
+            },
+          ],
+        });
+        source =
+          source.slice(0, insertOffset) + "x" + source.slice(insertOffset);
+        compiler.compile({ textDocument: { uri } });
+      };
+
+      // The profiler must actually be live, or the counts below are vacuous.
+      const seen = await observeMeasures(() => edit());
+      expect(seen.length).toBeGreaterThan(0);
+
+      for (let i = 0; i < 4; i += 1) {
+        edit();
+      }
+      const afterFiveEdits = countEntries();
+
+      for (let i = 0; i < 15; i += 1) {
+        edit();
+      }
+      const afterTwentyEdits = countEntries();
+
+      // Tripling the edit count must not move the retained-entry count at all.
+      expect(afterTwentyEdits).toBe(afterFiveEdits);
+      // And whatever it settles at is a handful of in-flight phases, not a log.
+      expect(afterTwentyEdits).toBeLessThan(50);
+    } finally {
+      console.warn = realWarn;
+      console.error = realError;
+    }
+  });
+});

--- a/packages/sparkdown/src/workspace/utils/logging/profile.ts
+++ b/packages/sparkdown/src/workspace/utils/logging/profile.ts
@@ -1,19 +1,6 @@
-export const profile = (
-  mark: "start" | "end",
-  profilerId: string | undefined,
-  method: string,
-  uri: string = "",
-) => {
-  if (profilerId) {
-    if (mark === "end") {
-      performance.mark(`${profilerId} ${method} ${uri} end`);
-      performance.measure(
-        `${profilerId} ${method} ${uri}`.trim(),
-        `${profilerId} ${method} ${uri} start`,
-        `${profilerId} ${method} ${uri} end`,
-      );
-    } else {
-      performance.mark(`${profilerId} ${method} ${uri} start`);
-    }
-  }
-};
+// Same package, same signature — re-export the compiler's copy rather than keep
+// a second implementation that has to be fixed twice.
+export {
+  profile,
+  setRetainProfilerEntries,
+} from "../../../compiler/utils/profile";


### PR DESCRIPTION
Fixes #321.

## What broke

`profile()` wrote a `performance.mark()` per phase boundary and a
`performance.measure()` per completed phase, and nothing ever cleared them.
User-timing entries have **no buffer cap** — unlike resource timing, which the
platform evicts at 250 — so every entry was retained by the global `performance`
object for the life of the realm.

Both shipped hosts turn profiling on unconditionally:
`installWorkspaceWorker.ts:131` constructs `new SparkdownGameWorkspace("player")`
with a hardcoded id, and `SparkdownDocumentManager.ts:20` sets
`profilerId = "editor"`. So the web player's compiler worker and the VS Code
extension both accumulated entries per keystroke, unbounded.

The ticket named three copies of the helper. There were **five**, and the two it
missed are worse — `packages/spark-web-player/src/utils/profile.ts` and
`packages/sparkdown-language-server/src/utils/logging/profile.ts` take no
profiler id at all, so they leaked in every session with no way to turn them off.
`sparkdown-language-server.ts` also carried ~20 hand-rolled
`performance.mark`/`measure` brackets, and `WorkspaceLanguageServer.ts:244` one
more.

## The fix

One implementation, in `packages/jsonrpc/src/browser/utils/profile.ts`
(`profilePhase`) — the lowest layer every other package already sits above. The
other four helpers became thin wrappers over it, so there is a single place for
this to be right. The ~20 raw brackets in `sparkdown-language-server.ts` now
route through that package's wrapper; measure names are unchanged.

Each mark and measure is cleared as soon as it is emitted. A `PerformanceObserver`
still receives every entry — delivery happens when the entry is created, not when
the buffer is read — so live profiling is unaffected. This is verified live
below, not assumed.

**The duration is measured from a captured `performance.now()`, not by naming the
two marks.** This is the part that matters: mark-name resolution cannot survive
clearing. `measure()` binds to the *most recent* mark of a name and
`clearMarks(name)` removes *every* mark of that name, so two overlapping phases
of the same name would have the first to finish delete the second's start mark,
and the second measurement would be lost entirely. Phase names carry no request
id and the callers bracket `await`s, so same-name overlap is routine — see
"Review" below, where this is exactly what an earlier revision of this PR got
wrong.

Timestamps are held in a module-level `Map<string, number[]>`. Each `end` takes
the **most recent** outstanding start, which is exactly what mark-name
resolution did before ("convert a mark to a timestamp" uses the last mark of
that name) — **so no reported duration changes; only the retention does.**

Pairing oldest-first looks more correct for genuinely overlapping phases, and an
earlier revision of this PR did that. It is much worse in practice, and that is
also caught by review below: a phase that starts and never ends
(`SparkdownWorkspace.compile` returns early on the no-change and piggyback
paths; `SparkdownCompiler` swallows a mid-parse throw) leaves a start that
oldest-first hands to the *next unrelated* end, shifting every later measurement
for that name by one, forever. Measured on a 100 ms phase after one orphaned
start and a 300 ms idle:

```
OLD (mark names)  : [107,106]   # correct
oldest-first      : [419,276]   # corrupted, and stays one behind forever
newest-first      : [107,107]   # matches OLD
```

The map is the only state the profiler keeps and is bounded in both directions —
32 outstanding starts per name, 256 names — because some names embed unbounded
values (`lsp: onCompletionResolve ${item.label}`) and those handlers have no
`try/finally`.

`perfProfile.test.ts` aggregates measures retrospectively and is the one caller
that needs entries kept; it opts in via `setRetainProfilerEntries`.

## Regression tests

| File | Tests |
| --- | --- |
| `packages/jsonrpc/test/profile.test.ts` | 8 |
| `packages/spark-web-player/src/utils/profile.test.ts` | 6 |
| `packages/sparkdown-language-server/src/tests/logging/profile.test.ts` | 7 |
| `packages/sparkdown/src/tests/compiler/profilerEntryRetention.test.ts` | 9 |

`packages/jsonrpc` had no test harness at all; it now has a `vitest.config.ts`
(copied from `opfs-workspace`, single-fork settings intact), a `test` script and
a declared `vitest` devDependency. `spark-web-player` had a `test` script but no
declared `vitest` — added, since it now has a second test file.

They pin behaviour, not patch shape: that entries are **not retained**, that a
measure is still **emitted** for every completed phase (observed via
`PerformanceObserver`, since the buffer can no longer be read back), that **both**
of two overlapping same-name phases are measured, that a phase which never ended
**does not corrupt the next one's duration**, that the bookkeeping stays bounded
under 5000 unique orphaned names, and — because every other test forces the
retain flag off — that a freshly loaded module clears **by default**.

### Red/green

Reverting `profilePhase` to the pre-fix body (mark-name resolution, no clearing)
and re-running `packages/jsonrpc`:

```
× does not accumulate entries across repeated messages
  → expected 600 to be +0
× retains nothing for phases that never end, and still drains
  → expected 200 to be +0
× does not throw when a message ends without a start
  → 'SyntaxError: The "player response com…' was thrown
Tests  4 failed | 2 passed (6)
```

The `SyntaxError` is a genuine pre-existing bug — `measure()` throws when the
start mark is missing, so any unpaired `end` threw out of the caller.

Flipping only the pairing rule to oldest-first fails the orphan test for exactly
the reason above:

```
× a phase that never ended does not corrupt the next one's duration
  → expected 422.34659999999985 to be less than 200
```

The compiler-level test, with clearing disabled:

```
× does not accumulate entries across repeated compiles
  → expected 1071 to be 306
```

306 entries after 5 edits, 1071 after 20 — 51 per edit, matching the ticket's
measured 34 marks + 17 measures exactly. All green with the fix in place.

## Suites run

| Suite | Result |
| --- | --- |
| `packages/sparkdown` `src/tests/compiler` + `src/tests/runtime` | 69 passed / 2 skipped (71 files); 853 passed / 24 skipped (877 tests) |
| `packages/sparkdown-language-server` (full) | 93 passed, **2 pre-existing failures** (95) |
| `packages/spark-web-player` (full) | 19 passed (2 files) |
| `packages/jsonrpc` (full) | 8 passed |

The 2 failures are `delta format ≡ full format > screen element (bad attr
spacing)` and its `diff-driven dirty range` twin. Confirmed unrelated: they fail
identically on an unmodified `main` checkout (`AssertionError: fixture line for
"screen element (bad attr spacing)": expected -1 to be greater than or equal
to 0` — a missing fixture, not a formatter defect).

## Live verification

Driven through the running editor at `driver.mjs`'s pinned port: load the repro,
type 20 real characters into CodeMirror, then read retained entries in both
realms the page can reach, and observe measures live.

**Before** (pre-fix player + editor code, same running server):

| Realm | entries at load | after 20 keystrokes |
| --- | --- | --- |
| editor page | 2 marks / 1 measure | 8 marks / 4 measures |
| player iframe | 67 marks / 33 measures | 314 marks / 157 measures |

~18.5 retained entries per keystroke in the player realm alone, with names like
`player workspace request compiler/initialize start`.

**After**:

| Realm | entries at load | after 20 keystrokes | measures seen by observer |
| --- | --- | --- | --- |
| editor page | 0 / 0 | 0 / 0 | 3 (`CompiledProgramMessage`) |
| player iframe | 0 / 0 | 0 / 0 | 127 (`player workspace request compiler/updateDocument`, …) |

Nothing retained, and profiling data fully intact — 130 measures still delivered
to observers across the two realms during those 20 keystrokes. The editor renders
correctly throughout: the preview follows the cursor to the edited line and shows
the typed text (`route: main : 1 → main : 8`, then line 9 after typing).

## Review

Two rounds of adversarial review, five reviewers, and both rounds found a real
defect in what I had written.

**Round 1** (four reviewers, all independently): the first revision cleared marks
*by name*, so overlapping same-name phases lost their measurements (N phases →
1 measure). Reproduced before acting —

```
OLD: [["old",63],["old",130]]     # 2 measures
NEW: [["new",102]]                # 1 measure
```

— which is why the implementation measures from timestamps at all.

**Round 2** (one reviewer, on the reworked engine): the timestamp version paired
oldest-first, which corrupts every later duration for a name once any phase
orphans a start. Also reproduced before acting (the `[419,276]` vs `[107,107]`
numbers above), and fixed by taking the newest start — which restores the exact
pre-fix pairing semantics. Both defects now have a dedicated test in each of the
four test files.

Also acted on:

- `window.__preview.perf("measure")` really is a shipping reader of the buffer,
  so the helper comments claiming "nothing reads the buffer back" were wrong.
  Corrected, and `previewInspect.ts`'s interface doc now says those types come
  back empty and points at `PerformanceObserver`.
- The pending map's *key* count was only bounded if phase names were; added the
  256-name cap and a test.
- The retain flag's default was unpinned by any test; added one.
- Mark names for uri-less LSP phases had gained a double space; names are now
  built from the trimmed base, so `lsp: onDocumentColor start` is preserved.
- `WorkspaceLanguageServer.ts` was a fifth hand-rolled copy; it now calls the
  shared helper.

Declined, with reasons:

- **Not routing every early-return path through `try/finally`.**
  `SparkdownWorkspace.compile` opens a phase and returns early on the no-op and
  piggyback paths; `sparkdown-language-server.ts` awaits providers with no
  `finally`. Those orphaned phases are now bounded rather than unbounded, which
  is the leak this ticket is about. Making the brackets exception-safe is a
  correctness change to a dozen handlers and belongs in its own PR.
- **Not adding CI.** None of these tests run in CI because the repo has no test
  workflow at all — that is #320's territory, not this fix's.
- **`setRetainProfilerEntries` remains exported.** It is a global switch and
  could in principle be called from product code to re-enable retention. Scoping
  it to tests needs a build-time condition the repo does not currently have; a
  test now pins that the default is "clear". It is also, as review noted, of no
  use to `window.__preview.perf()` — that reads the *iframe's* buffer from the
  editor realm and cannot reach the flag. Hence the doc pointing at
  `PerformanceObserver` instead.
- **Not fixing durations for genuinely overlapping phases.** They were already
  mis-attributed before this change (name resolution bound to the newest start),
  and this PR reproduces that exactly rather than silently changing timings.
  Getting it right needs a per-invocation token threaded through every
  `profile()` call site — a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
