### PR TITLE
fix(jsonrpc): always send exactly one of result/error so requests settle (#332)

### DIFF
--- a/packages/jsonrpc/src/browser/classes/MessageConnection.ts
+++ b/packages/jsonrpc/src/browser/classes/MessageConnection.ts
@@ -9,6 +9,10 @@ import { ResponseError } from "../../common/types/ResponseError";
 import { ResponseMessage } from "../../common/types/ResponseMessage";
 import { isProgressResponse } from "../../common/utils/isProgressResponse";
 import { isResponse } from "../../common/utils/isResponse";
+import {
+  INTERNAL_ERROR,
+  toResponseError,
+} from "../../common/utils/toResponseError";
 import { profile } from "../utils/profile";
 
 export type MessageConnectionEvents = {
@@ -97,6 +101,36 @@ export abstract class MessageConnection {
               }
             } else if (isProgressResponse(message, request.method)) {
               onProgress?.(message.value);
+            } else if (
+              message.method === request.method &&
+              message.params === undefined &&
+              message.value === undefined
+            ) {
+              // Addressed to this request, but carries neither `result` nor
+              // `error`, so `isResponse` rejected it. Settle rather than wait
+              // forever — a silent hang is far harder to diagnose than a
+              // rejection.
+              //
+              // The two exclusions are load-bearing, because `id` alone does
+              // not identify a response: `isRequest` is also true for a
+              // message with neither field, and requests always carry `params`
+              // (this connection's ids are short `Math.random()` strings, not
+              // uuids, so id uniqueness cannot be relied on either). Progress
+              // messages carry `value` and are meant to be ignored here —
+              // `MessageProtocolRequestType.progress()` emits them under the
+              // bare method name, which `isProgressResponse` does not match,
+              // so without the `value` guard they would land in this branch
+              // and kill a healthy in-flight request.
+              profile("end", this._profilerId, "request " + request.method);
+              reject(
+                new RequestError({
+                  code: INTERNAL_ERROR,
+                  message:
+                    `Malformed response to "${request.method}": ` +
+                    `carries neither "result" nor "error"`,
+                }),
+              );
+              this.removeEventListener("message", onResponse);
             }
           }
         }
@@ -137,11 +171,7 @@ export abstract class MessageConnection {
       responseResult = typeof result === "function" ? await result() : result;
     } catch (e) {
       console.error(e);
-      if (typeof e === "object" && e) {
-        if ("message" in e) {
-          responseError = e as ResponseError;
-        }
-      }
+      responseError = toResponseError(e);
     }
     profile("start", this._profilerId, "send response " + method);
     const response: ResponseMessage<M, R> = {
@@ -149,13 +179,30 @@ export abstract class MessageConnection {
       method,
       id,
     };
-    if (responseResult !== undefined) {
-      response.result = responseResult;
-    }
+    // Every response MUST carry exactly one of `result` / `error`. JSON-RPC 2.0
+    // requires it, and more concretely `isResponse` keys on their presence: a
+    // response with neither is not recognized as a response at all, so the
+    // requester never resolves, never rejects, and never removes its listener.
+    // A handler that returns nothing therefore has to send an explicit `null`.
     if (responseError !== undefined) {
       response.error = responseError;
+    } else {
+      response.result = (responseResult ?? null) as R;
     }
-    this.postMessage(response, transfer);
+    try {
+      this.postMessage(response, transfer);
+    } catch (e) {
+      // A result that cannot be structured-cloned throws here, and an
+      // unsent response is the same permanent hang this method exists to
+      // avoid — so fall back to reporting the failure instead of nothing.
+      console.error(e);
+      this.postMessage({
+        jsonrpc: "2.0",
+        method,
+        id,
+        error: toResponseError(e),
+      } as ResponseMessage<M, R>);
+    }
     profile("end", this._profilerId, "send response " + method);
     profile("end", this._profilerId, "response " + method);
   }

--- a/packages/jsonrpc/src/common/utils/toResponseError.ts
+++ b/packages/jsonrpc/src/common/utils/toResponseError.ts
@@ -1,0 +1,51 @@
+import { ResponseError } from "../types/ResponseError";
+
+/** JSON-RPC 2.0 "Internal error". */
+export const INTERNAL_ERROR = -32603;
+
+// `String(e)` is not safe on arbitrary values: it throws for symbols and for
+// objects with a null prototype or a hostile `toString`. This must never throw
+// — it runs inside the catch that produces the error response, so a throw here
+// means no response is sent at all and the caller hangs, which is the very bug
+// this file exists to prevent.
+const describe = (e: unknown): string => {
+  try {
+    return String(e);
+  } catch {
+    return "unknown error";
+  }
+};
+
+/**
+ * Coerce anything a handler threw into a `ResponseError`. Total by construction.
+ *
+ * A response carries either `result` or `error`, and the requester only settles
+ * when one of them is present — so a throw that failed to produce an error
+ * object left the caller waiting forever.
+ */
+export const toResponseError = (e: unknown): ResponseError => {
+  // Errors (including DOMException) carry a legacy numeric `code` that has
+  // nothing to do with JSON-RPC — DataCloneError is 25, NotFoundError is 8 —
+  // so never let one through as an error code.
+  if (e instanceof Error) {
+    return { code: INTERNAL_ERROR, message: e.message || describe(e) };
+  }
+  if (typeof e === "object" && e !== null) {
+    let message: unknown;
+    let code: unknown;
+    let data: unknown;
+    try {
+      ({ message, code, data } = e as Record<string, unknown>);
+    } catch {
+      // A hostile or revoked proxy — fall through to the generic shape.
+    }
+    if (typeof message === "string") {
+      return {
+        code: typeof code === "number" ? code : INTERNAL_ERROR,
+        message,
+        ...(data !== undefined ? { data: data as never } : {}),
+      };
+    }
+  }
+  return { code: INTERNAL_ERROR, message: describe(e) };
+};

--- a/packages/jsonrpc/test/responseSettles.test.ts
+++ b/packages/jsonrpc/test/responseSettles.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+import { MessageConnection } from "../src/browser/classes/MessageConnection";
+import { RequestError } from "../src/common/classes/RequestError";
+import { RequestMessage } from "../src/common/types/RequestMessage";
+
+// A pair of in-memory connections. `MessageConnection` is abstract over the
+// transport, so this needs no worker, port or DOM — and it lets the tests
+// assert that the response listener is actually torn down.
+class TestConnection extends MessageConnection {
+  protected _listeners = new Set<(e: MessageEvent) => void>();
+  peer?: TestConnection;
+
+  constructor() {
+    super((message: any) => {
+      // Deliver asynchronously, like a real port would.
+      queueMicrotask(() => this.peer?.receive(message));
+    });
+  }
+
+  override addEventListener(_event: "message", listener: any) {
+    this._listeners.add(listener);
+  }
+
+  override removeEventListener(_event: "message", listener: any) {
+    this._listeners.delete(listener);
+  }
+
+  receive(data: any) {
+    for (const listener of [...this._listeners]) {
+      listener({ data } as unknown as MessageEvent);
+    }
+  }
+
+  get listenerCount() {
+    return this._listeners.size;
+  }
+}
+
+const pair = () => {
+  const a = new TestConnection();
+  const b = new TestConnection();
+  a.peer = b;
+  b.peer = a;
+  return { a, b };
+};
+
+let nextId = 1;
+const requestMessage = (method: string): RequestMessage<string, {}, any> =>
+  ({
+    jsonrpc: "2.0",
+    method,
+    id: nextId++,
+    params: {},
+  }) as RequestMessage<string, {}, any>;
+
+// Answer whatever the peer asks with `handler`, then let the request settle.
+const serve = (b: TestConnection, handler: () => any) => {
+  b.addEventListener("message", (e: MessageEvent) => {
+    const message = (e as any).data;
+    if (message?.id !== undefined && message?.params !== undefined) {
+      b.sendResponse(message, handler);
+    }
+  });
+};
+
+// A request that never settles would hang the test runner, so race it.
+const TIMED_OUT = Symbol("timed out");
+const settlesWithin = async (promise: Promise<unknown>, ms = 500) => {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise((resolve) => {
+    timer = setTimeout(() => resolve(TIMED_OUT), ms);
+  });
+  try {
+    return await Promise.race([
+      promise.then(
+        (value) => ({ status: "resolved" as const, value }),
+        (error) => ({ status: "rejected" as const, error }),
+      ),
+      timeout,
+    ]);
+  } finally {
+    clearTimeout(timer!);
+  }
+};
+
+describe("MessageConnection response handling", () => {
+  it("settles when the handler returns a value", async () => {
+    const { a, b } = pair();
+    serve(b, () => ({ ok: true }));
+    const outcome = await settlesWithin(a.request(requestMessage("test/ok")));
+    expect(outcome).toEqual({ status: "resolved", value: { ok: true } });
+    expect(a.listenerCount).toBe(0);
+  });
+
+  // The bug: `WorkspaceFileSystem.executeCommand` returns undefined for an
+  // unknown uri or an unrecognized command, so the response carried neither
+  // `result` nor `error`, `isResponse` rejected it, and the awaiting promise
+  // never settled.
+  it("settles when the handler returns undefined", async () => {
+    const { a, b } = pair();
+    serve(b, () => undefined);
+    const outcome = await settlesWithin(
+      a.request(requestMessage("test/undefined")),
+    );
+    expect(outcome).not.toBe(TIMED_OUT);
+    expect((outcome as any).status).toBe("resolved");
+    expect((outcome as any).value).toBeNull();
+  });
+
+  it("does not leak its response listener when the handler returns undefined", async () => {
+    const { a, b } = pair();
+    serve(b, () => undefined);
+    await settlesWithin(a.request(requestMessage("test/undefined-listener")));
+    expect(a.listenerCount).toBe(0);
+  });
+
+  it("rejects with the handler's own code when it throws a ResponseError shape", async () => {
+    const { a, b } = pair();
+    serve(b, () => {
+      throw { code: 1, message: "boom" };
+    });
+    const outcome = await settlesWithin(a.request(requestMessage("test/throw")));
+    expect((outcome as any).status).toBe("rejected");
+    expect((outcome as any).error).toBeInstanceOf(RequestError);
+    expect((outcome as any).error.code).toBe(1);
+    expect((outcome as any).error.message).toBe("boom");
+    expect(a.listenerCount).toBe(0);
+  });
+
+  it("rejects with an internal-error code when the handler throws an Error", async () => {
+    const { a, b } = pair();
+    serve(b, () => {
+      throw new Error("kaboom");
+    });
+    const outcome = await settlesWithin(
+      a.request(requestMessage("test/throw-error")),
+    );
+    expect((outcome as any).status).toBe("rejected");
+    // An Error's own numeric `code` (DOMException uses 8, 20, 25 …) is not a
+    // JSON-RPC code and must not be forwarded as one.
+    expect((outcome as any).error.code).toBe(-32603);
+    expect((outcome as any).error.message).toBe("kaboom");
+  });
+
+  it("does not settle on a progress message for the same request", async () => {
+    // `MessageProtocolRequestType.progress()` emits the bare method name, which
+    // `isProgressResponse` does not match — so without an explicit guard these
+    // land in the malformed-response branch and kill a healthy request.
+    const { a, b } = pair();
+    const request = requestMessage("test/progress");
+    const pending = a.request(request);
+    queueMicrotask(() =>
+      a.receive({
+        jsonrpc: "2.0",
+        method: request.method,
+        id: request.id,
+        value: { percentage: 50 },
+      }),
+    );
+    const outcome = await settlesWithin(pending, 200);
+    expect(outcome).toBe(TIMED_OUT);
+    // Still waiting for the real response, listener intact.
+    expect(a.listenerCount).toBe(1);
+    // …which then settles it normally.
+    b.sendResponse(request as any, () => ({ ok: true }));
+    expect(await settlesWithin(pending)).toEqual({
+      status: "resolved",
+      value: { ok: true },
+    });
+  });
+
+  it("does not settle on an echo of the request itself", async () => {
+    // The editor relays messages between window and iframe without filtering
+    // by origin, so a request can come back to its own sender with a matching
+    // id and method.
+    const { a } = pair();
+    const request = requestMessage("test/echo-self");
+    const pending = a.request(request);
+    queueMicrotask(() => a.receive({ ...request }));
+    const outcome = await settlesWithin(pending, 200);
+    expect(outcome).toBe(TIMED_OUT);
+    expect(a.listenerCount).toBe(1);
+  });
+
+  // Defence in depth: even if some other producer emits a response with
+  // neither field, the requester must not wait forever.
+  it("rejects a hand-crafted response carrying neither result nor error", async () => {
+    const { a } = pair();
+    const request = requestMessage("test/malformed");
+    const pending = a.request(request);
+    queueMicrotask(() =>
+      a.receive({ jsonrpc: "2.0", method: request.method, id: request.id }),
+    );
+    const outcome = await settlesWithin(pending);
+    expect(outcome).not.toBe(TIMED_OUT);
+    expect((outcome as any).status).toBe("rejected");
+    expect((outcome as any).error.message).toContain("Malformed response");
+    expect(a.listenerCount).toBe(0);
+  });
+
+  // `sendResponse`'s catch only built a ResponseError for objects carrying a
+  // `message` property, so a bare string left both fields absent.
+  it("settles when the handler throws a value that is not an Error", async () => {
+    const { a, b } = pair();
+    serve(b, () => {
+      throw "just a string";
+    });
+    const outcome = await settlesWithin(
+      a.request(requestMessage("test/throw-string")),
+    );
+    expect(outcome).not.toBe(TIMED_OUT);
+    expect((outcome as any).status).toBe("rejected");
+    expect((outcome as any).error.message).toBe("just a string");
+    expect(a.listenerCount).toBe(0);
+  });
+
+  // The coercion runs inside the catch that builds the error response, so if it
+  // throws, no response is sent at all and the caller hangs — the original bug.
+  it("settles when the handler throws a value that cannot be stringified", async () => {
+    const { a, b } = pair();
+    serve(b, () => {
+      throw Object.create(null);
+    });
+    const outcome = await settlesWithin(
+      a.request(requestMessage("test/throw-exotic")),
+    );
+    expect(outcome).not.toBe(TIMED_OUT);
+    expect((outcome as any).status).toBe("rejected");
+    expect(a.listenerCount).toBe(0);
+  });
+});

--- a/vscode-sparkdown/src/managers/SparkdownPreviewGamePanelManager.ts
+++ b/vscode-sparkdown/src/managers/SparkdownPreviewGamePanelManager.ts
@@ -169,10 +169,17 @@ export class SparkdownPreviewGamePanelManager {
       }
       if (ExecuteCommandMessage.type.isRequest(message)) {
         const params = message.params;
+        // Always answer. `executeLanguageCommand` returns undefined for an
+        // unrecognized command and for a missing/non-string uri, and the
+        // webview player awaits this request — skipping the response leaves
+        // it waiting for the life of the panel (#332). `null` is the
+        // JSON-RPC "no value" result.
         const result = await executeLanguageCommand(params);
-        if (result !== undefined) {
-          this.sendResponse(ExecuteCommandMessage.type, message.id, result);
-        }
+        this.sendResponse(
+          ExecuteCommandMessage.type,
+          message.id,
+          result ?? null,
+        );
       }
       if (HoveredOnPreviewMessage.type.isNotification(message)) {
         if (message.params.type === "game") {


### PR DESCRIPTION
Fixes #332.

## What broke

`MessageConnection.sendResponse` set `response.result` only when the handler's
value was not `undefined`, and `response.error` only when the thrown value was
an object carrying a `message` property. A response with **neither** field fails
`isResponse` — which requires one of them — so the requester's `onResponse`
matched no branch: the awaiting promise never resolved, never rejected, and its
listener was never removed.

Reachable from the shipped web editor ↔ player channel:

1. `installWorkspaceWorker.ts:80` — the player awaits `getFileSrc(uri)`.
2. `PreviewGame.tsx:203` — the editor answers with
   `await Workspace.fs.executeCommand(params)`, passed to `sendResponse` **as a
   value, not a thunk**.
3. `WorkspaceFileSystem.ts:223` returns `undefined` for any unrecognized
   command, and `getFileSrc` (`:232`) returns `undefined` for a uri not in
   `_files`.
4. → response carries neither field → `isResponse.ts:13` says it is not a
   response → the `await` hangs for the life of the page and a listener leaks.

The everyday trigger is a script referencing a deleted or misspelled asset.

## The fix

- **Always exactly one of `result`/`error`.** `result: null` when the handler
  returned nothing — JSON-RPC 2.0 requires a success response to carry `result`.
- **Total error coercion.** New `toResponseError` turns anything thrown into a
  `ResponseError`. It must never throw itself, because it runs *inside* the
  catch that builds the error response: `String(e)` is guarded (symbols and
  null-prototype objects throw), and property reads are guarded (a revoked
  proxy throws).
- **`Error` codes are not JSON-RPC codes.** `DOMException` carries a legacy
  numeric `code` (`DataCloneError` = 25, `NotFoundError` = 8); those are mapped
  to `-32603` rather than forwarded onto the wire.
- **`postMessage` is guarded.** A result that cannot be structured-cloned threw
  out of `sendResponse` and sent nothing at all — the same hang. It now falls
  back to posting an error response.
- **A fallback in `request()`.** A message addressed to this request carrying
  neither field now rejects instead of being ignored.
- **The VS Code host too.** `SparkdownPreviewGamePanelManager.ts:173` skipped
  the response entirely when `executeLanguageCommand` returned `undefined`, so
  the webview player hung identically — and no protocol-layer fix can reach it,
  because there is no message. It now always answers.

## Regression tests

`packages/jsonrpc/test/responseSettles.test.ts` — 10 tests over an in-memory
`MessageConnection` pair (the class is abstract over its transport, so this
needs no worker or DOM), which also lets the tests assert the **listener** is
torn down, not just that the promise settled.

Red against the pre-fix `MessageConnection`:

```
× settles when the handler returns undefined
  → expected Symbol(timed out) not to be Symbol(timed out)
× does not leak its response listener when the handler returns undefined
  → expected 1 to be +0
× rejects a hand-crafted response carrying neither result nor error
  → expected Symbol(timed out) not to be Symbol(timed out)
× settles when the handler throws a value that is not an Error
  → expected Symbol(timed out) not to be Symbol(timed out)
Tests  4 failed | 2 passed (6)
```

The timeouts *are* the bug: the request never settles. All green with the fix.

## Suites run

| Suite | Result |
| --- | --- |
| `packages/jsonrpc` | 18 passed (2 files) |
| `packages/spark-web-player` | 19 passed (2 files) |
| `packages/sparkdown` compiler + runtime | 71 passed / 2 skipped (73 files); 861 passed / 24 skipped (885 tests) |

## Live verification

Driven through the running editor: the script loads, the preview follows the
cursor and renders the beat (`route: main : 1 → main : 8`, BOB's line on screen).
The protocol layer is on the path of every compile and every asset fetch, so the
point here is that nothing regressed — the hang itself is pinned by the red/green
above.

## Review

Two adversarial reviewers, and both found real defects in the first cut:

- **The fallback branch could kill a healthy request.**
  `MessageProtocolRequestType.progress()` emits the *bare* method name, but
  `isProgressResponse` requires `${method}/progress` — so a progress message
  matches neither predicate and landed in the new branch, rejecting a request
  whose real response was still in flight. Now guarded on `value === undefined`,
  with a test that fails without the guard.
- **`isRequest` is also true for a neither-field message**, so `id` alone does
  not identify a response and the `params` exclusion is load-bearing. The
  editor relays messages between window and iframe without an origin filter, so
  a request really can come back to its own sender — there is now a test for
  that too.
- **My justifying comment was wrong**: `uuid()` here is 8 characters of
  `Math.random()`, not an RFC-4122 UUID, so id uniqueness cannot carry the
  argument. Comment corrected.
- `toResponseError` was not total, `postMessage` was unguarded, and the VS Code
  host was untouched — all three fixed above.

Deliberately not changed:

- **`isProgressResponse`'s `/progress` mismatch.** `progress()` emits the bare
  method name, so progress callbacks never fire today. That is a real
  pre-existing bug, but fixing it changes delivery behaviour for a feature with
  no call sites — it wants its own ticket, not a rider on a hang fix.
- **The declared types.** `request()` still says `Promise<R>` while it can now
  resolve `null`, so `getFileSrc(): Promise<string>` can hand back `null`. Its
  two consumers already treat it as absent (`file?.src` guards), and the
  alternative was leaving them hung. Widening the signatures to `R | null`
  touches every protocol type and belongs in its own change.
- **CI.** None of these tests run automatically, because the repo has no test
  workflow — that is #320's territory.

Related: #331 (its fourth site is this bug; that phase stops being orphaned as a
side effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
