### PR TITLE
fix(profiler): close profiler phases on every exit path (#331)

### DIFF
--- a/packages/sparkdown-language-server/src/sparkdown-language-server.ts
+++ b/packages/sparkdown-language-server/src/sparkdown-language-server.ts
@@ -10,7 +10,7 @@ import {
   TextDocumentSyncKind,
 } from "vscode-languageserver/browser";
 import { SparkdownLanguageServerWorkspace } from "./classes/SparkdownLanguageServerWorkspace";
-import { profile } from "./utils/logging/profile";
+import { profiled } from "./utils/logging/profiled";
 import { canRename } from "./utils/providers/canRename";
 import { getCodeLenses } from "./utils/providers/getCodeLenses";
 import { getColorPresentations } from "./utils/providers/getColorPresentations";
@@ -179,9 +179,9 @@ try {
     ) {
       return cached.result;
     }
-    profile("start", "lsp: onFoldingRanges", uri);
-    const result = getFoldingRanges(document, annotations, program);
-    profile("end", "lsp: onFoldingRanges", uri);
+    const result = profiled("lsp: onFoldingRanges", uri, () =>
+      getFoldingRanges(document, annotations, program),
+    );
     if (document) {
       foldingRangeCache.set(uri, {
         documentVersion: document.version,
@@ -198,15 +198,17 @@ try {
     const document = workspace.document(uri);
     const annotations = workspace.annotations(uri);
     const program = workspace.program(uri);
-    profile("start", "lsp: onDocumentColor", uri);
-    const result = getDocumentColors(document, annotations, program);
-    profile("end", "lsp: onDocumentColor", uri);
+    const result = profiled("lsp: onDocumentColor", uri, () =>
+      getDocumentColors(document, annotations, program),
+    );
     return result;
   });
   connection.onColorPresentation((params) => {
-    profile("start", "lsp: onDocumentColor");
-    const result = getColorPresentations(params.color);
-    profile("end", "lsp: onDocumentColor");
+    // Its own name: this used to share "lsp: onDocumentColor" with the handler
+    // above, so two different requests aggregated into one phase.
+    const result = profiled("lsp: onColorPresentation", undefined, () =>
+      getColorPresentations(params.color),
+    );
     return result;
   });
 
@@ -215,9 +217,9 @@ try {
     const uri = params.textDocument.uri;
     const document = workspace.document(uri);
     const annotations = workspace.annotations(uri);
-    profile("start", "lsp: onDocumentSymbol", uri);
-    const result = getDocumentSymbols(document, annotations);
-    profile("end", "lsp: onDocumentSymbol", uri);
+    const result = profiled("lsp: onDocumentSymbol", uri, () =>
+      getDocumentSymbols(document, annotations),
+    );
     return result;
   });
 
@@ -228,16 +230,16 @@ try {
     const annotations = workspace.annotations(uri);
     const program = workspace.program(uri);
     const config = workspace.compilerConfig;
-    profile("start", "lsp: onHover", uri);
-    const result = getHover(
-      document,
-      annotations,
-      program,
-      config,
-      params.position,
-      imageCompositeOptions,
+    const result = profiled("lsp: onHover", uri, () =>
+      getHover(
+        document,
+        annotations,
+        program,
+        config,
+        params.position,
+        imageCompositeOptions,
+      ),
     );
-    profile("end", "lsp: onHover", uri);
     return result;
   });
 
@@ -253,17 +255,17 @@ try {
     for (const uri of Object.keys(scripts)) {
       scriptAnnotations.set(uri, workspace.annotations(uri));
     }
-    profile("start", "lsp: onCompletion", uri);
-    const result = getCompletions(
-      document,
-      tree,
-      scriptAnnotations,
-      program,
-      config,
-      params.position,
-      params.context,
+    const result = profiled("lsp: onCompletion", uri, () =>
+      getCompletions(
+        document,
+        tree,
+        scriptAnnotations,
+        program,
+        config,
+        params.position,
+        params.context,
+      ),
     );
-    profile("end", "lsp: onCompletion", uri);
     // `workspace.program()` is keyed by the REQUESTED document uri, not by
     // `program.uri` (which is the compiled root), so resolve has to be told
     // which document it came from. Stamped here to keep uri plumbing out of
@@ -284,14 +286,14 @@ try {
     if (!data?.uri) {
       return item;
     }
-    profile("start", "lsp: onCompletionResolve", item.label);
-    const program = workspace.program(data.uri);
-    const resolved = await resolveCompletion(
-      item,
-      program,
-      imageCompositeOptions,
+    const resolved = await profiled(
+      "lsp: onCompletionResolve",
+      item.label,
+      () => {
+        const program = workspace.program(data.uri);
+        return resolveCompletion(item, program, imageCompositeOptions);
+      },
     );
-    profile("end", "lsp: onCompletionResolve", item.label);
     return resolved;
   });
 
@@ -303,33 +305,34 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const annotations = workspace.annotations(uri);
-    profile("start", "lsp: onDocumentFormatting", uri);
-    // Incremental (delta) formatting for format-on-save: only reprocess
-    // the construct(s) changed since the last format. The dirty range is
-    // the diff against the last formatted output — safe because outside
-    // it the text equals an already-formatted baseline.
-    const dirtyRange = document
-      ? workspace.formatDirtyRange(uri, document.getText())
-      : undefined;
-    const result = getDocumentFormattingEdits(
-      document,
-      tree,
-      annotations,
-      params.options,
-      undefined,
-      undefined,
-      dirtyRange,
-    );
-    // Cache the resulting (fully formatted) text as the next diff
-    // baseline. Apply our own edits to compute it — that's what the
-    // editor will materialize.
-    if (document) {
-      const formatted = result
-        ? applyTextEdits(document, result)
-        : document.getText();
-      workspace.markFormatted(uri, formatted);
-    }
-    profile("end", "lsp: onDocumentFormatting", uri);
+    const result = profiled("lsp: onDocumentFormatting", uri, () => {
+      // Incremental (delta) formatting for format-on-save: only reprocess
+      // the construct(s) changed since the last format. The dirty range is
+      // the diff against the last formatted output — safe because outside
+      // it the text equals an already-formatted baseline.
+      const dirtyRange = document
+        ? workspace.formatDirtyRange(uri, document.getText())
+        : undefined;
+      const edits = getDocumentFormattingEdits(
+        document,
+        tree,
+        annotations,
+        params.options,
+        undefined,
+        undefined,
+        dirtyRange,
+      );
+      // Cache the resulting (fully formatted) text as the next diff
+      // baseline. Apply our own edits to compute it — that's what the
+      // editor will materialize.
+      if (document) {
+        const formatted = edits
+          ? applyTextEdits(document, edits)
+          : document.getText();
+        workspace.markFormatted(uri, formatted);
+      }
+      return edits;
+    });
     return result;
   });
 
@@ -341,15 +344,15 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const annotations = workspace.annotations(uri);
-    profile("start", "lsp: onDocumentRangeFormatting", uri);
-    const result = getDocumentFormattingEdits(
-      document,
-      tree,
-      annotations,
-      params.options,
-      params.range,
+    const result = profiled("lsp: onDocumentRangeFormatting", uri, () =>
+      getDocumentFormattingEdits(
+        document,
+        tree,
+        annotations,
+        params.options,
+        params.range,
+      ),
     );
-    profile("end", "lsp: onDocumentRangeFormatting", uri);
     return result;
   });
 
@@ -361,16 +364,16 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const annotations = workspace.annotations(uri);
-    profile("start", "lsp: onDocumentOnTypeFormatting", uri);
-    const result = getDocumentFormattingEdits(
-      document,
-      tree,
-      annotations,
-      params.options,
-      undefined,
-      params.position,
+    const result = profiled("lsp: onDocumentOnTypeFormatting", uri, () =>
+      getDocumentFormattingEdits(
+        document,
+        tree,
+        annotations,
+        params.options,
+        undefined,
+        params.position,
+      ),
     );
-    profile("end", "lsp: onDocumentOnTypeFormatting", uri);
     return result;
   });
 
@@ -379,9 +382,9 @@ try {
     const uri = params.textDocument.uri;
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
-    profile("start", "lsp: onPrepareRename", uri);
-    const result = canRename(document, tree, params.position);
-    profile("end", "lsp: onPrepareRename", uri);
+    const result = profiled("lsp: onPrepareRename", uri, () =>
+      canRename(document, tree, params.position),
+    );
     return result;
   });
 
@@ -393,17 +396,17 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const program = workspace.program(uri);
-    profile("start", "lsp: onRenameRequest", uri);
-    const result = getRenameEdits(
-      settings,
-      document,
-      tree,
-      program,
-      workspace,
-      params.newName,
-      params.position,
+    const result = profiled("lsp: onRenameRequest", uri, () =>
+      getRenameEdits(
+        settings,
+        document,
+        tree,
+        program,
+        workspace,
+        params.newName,
+        params.position,
+      ),
     );
-    profile("end", "lsp: onRenameRequest", uri);
     return result;
   });
 
@@ -459,21 +462,14 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const program = workspace.program(uri);
-    profile("start", "lsp: onReferences", uri);
-    const { references } = getReferences(
-      document,
-      tree,
-      program,
-      workspace,
-      params.position,
-      {
+    const { references } = profiled("lsp: onReferences", uri, () =>
+      getReferences(document, tree, program, workspace, params.position, {
         ...params.context,
         searchOtherFiles: true,
         includeInterdependent: true,
         includeLinks: true,
-      },
+      }),
     );
-    profile("end", "lsp: onReferences", uri);
     return references;
   });
 
@@ -483,22 +479,15 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const program = workspace.program(uri);
-    profile("start", "lsp: onDeclaration", uri);
-    const { references } = getReferences(
-      document,
-      tree,
-      program,
-      workspace,
-      params.position,
-      {
+    const { references } = profiled("lsp: onDeclaration", uri, () =>
+      getReferences(document, tree, program, workspace, params.position, {
         searchOtherFiles: true,
         includeDeclaration: true,
         excludeUses: true,
         includeInterdependent: false,
         includeLinks: false,
-      },
+      }),
     );
-    profile("end", "lsp: onDeclaration", uri);
     return references;
   });
 
@@ -508,22 +497,15 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const program = workspace.program(uri);
-    profile("start", "lsp: onDefinition", uri);
-    const { references } = getReferences(
-      document,
-      tree,
-      program,
-      workspace,
-      params.position,
-      {
+    const { references } = profiled("lsp: onDefinition", uri, () =>
+      getReferences(document, tree, program, workspace, params.position, {
         searchOtherFiles: true,
         includeDeclaration: true,
         excludeUses: true,
         includeInterdependent: false,
         includeLinks: false,
-      },
+      }),
     );
-    profile("end", "lsp: onDefinition", uri);
     return references;
   });
 
@@ -533,9 +515,9 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const annotations = workspace.annotations(uri);
-    profile("start", "lsp: onDocumentLinks", uri);
-    const result = getDocumentLinks(document, tree, annotations, workspace);
-    profile("end", "lsp: onDocumentLinks", uri);
+    const result = profiled("lsp: onDocumentLinks", uri, () =>
+      getDocumentLinks(document, tree, annotations, workspace),
+    );
     return result;
   });
 
@@ -545,21 +527,14 @@ try {
     const document = workspace.document(uri);
     const tree = workspace.tree(uri);
     const program = workspace.program(uri);
-    profile("start", "lsp: onDocumentHighlight", uri);
-    const { references } = getReferences(
-      document,
-      tree,
-      program,
-      workspace,
-      params.position,
-      {
+    const { references } = profiled("lsp: onDocumentHighlight", uri, () =>
+      getReferences(document, tree, program, workspace, params.position, {
         searchOtherFiles: false,
         includeDeclaration: true,
         includeInterdependent: true,
         includeLinks: true,
-      },
+      }),
     );
-    profile("end", "lsp: onDocumentHighlight", uri);
     return references;
   });
 
@@ -582,9 +557,9 @@ try {
     ) {
       return cached.result;
     }
-    profile("start", "lsp: semanticTokens.on", uri);
-    const result = getSemanticTokens(document, annotations, program);
-    profile("end", "lsp: semanticTokens.on", uri);
+    const result = profiled("lsp: semanticTokens.on", uri, () =>
+      getSemanticTokens(document, annotations, program),
+    );
     if (document) {
       semanticTokensCache.set(uri, {
         documentVersion: document.version,
@@ -600,14 +575,9 @@ try {
       workspace.program(uri) || (await workspace.compile(uri, false));
     const document = workspace.document(uri);
     const annotations = workspace.annotations(uri);
-    profile("start", "lsp: semanticTokens.onRange", uri);
-    const result = getSemanticTokens(
-      document,
-      annotations,
-      program,
-      params.range,
+    const result = profiled("lsp: semanticTokens.onRange", uri, () =>
+      getSemanticTokens(document, annotations, program, params.range),
     );
-    profile("end", "lsp: semanticTokens.onRange", uri);
     return result;
   });
 
@@ -616,9 +586,9 @@ try {
     const uri = params.textDocument.uri;
     const document = workspace.document(uri);
     const annotations = workspace.annotations(uri);
-    profile("start", "lsp: onCodeLens", uri);
-    const result = getCodeLenses(document, annotations);
-    profile("end", "lsp: onCodeLens", uri);
+    const result = profiled("lsp: onCodeLens", uri, () =>
+      getCodeLenses(document, annotations),
+    );
     return result;
   });
 

--- a/packages/sparkdown-language-server/src/tests/logging/profiled.test.ts
+++ b/packages/sparkdown-language-server/src/tests/logging/profiled.test.ts
@@ -1,0 +1,116 @@
+import { PerformanceObserver } from "node:perf_hooks";
+import { beforeEach, describe, expect, it } from "vitest";
+import { profiled } from "../../utils/logging/profiled";
+
+const perf = globalThis.performance;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Entries are cleared as soon as they are emitted (#321), so the buffer cannot
+// be read back — an observer is the only way to see what was measured.
+// Observer delivery is asynchronous and the callback can be delayed well past
+// a fixed sleep when the suite runs under load, so wait for the entries rather
+// than for the clock.
+const observeMeasures = async (
+  run: () => void | Promise<void>,
+  minCount = 1,
+  timeoutMs = 5000,
+) => {
+  const seen: { name: string; duration: number }[] = [];
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      seen.push({ name: entry.name, duration: entry.duration });
+    }
+  });
+  observer.observe({ entryTypes: ["measure"] });
+  try {
+    await run();
+    const start = Date.now();
+    while (seen.length < minCount && Date.now() - start < timeoutMs) {
+      await sleep(10);
+    }
+    await sleep(20);
+  } finally {
+    observer.disconnect();
+  }
+  return seen;
+};
+
+describe("profiled()", () => {
+  beforeEach(() => {
+    perf.clearMarks();
+    perf.clearMeasures();
+  });
+
+  it("measures a synchronous phase", async () => {
+    const seen = await observeMeasures(() => {
+      const value = profiled("lsp: sync", "file:///main.sd", () => 42);
+      expect(value).toBe(42);
+    });
+    expect(seen.map((s) => s.name)).toEqual(["lsp: sync file:///main.sd"]);
+  });
+
+  // The whole point: a hand-written start/end pair loses the phase whenever the
+  // body throws, which is exactly when the timing is worth having.
+  it("still measures a phase whose body throws", async () => {
+    const seen = await observeMeasures(() => {
+      expect(() =>
+        profiled("lsp: throws", "file:///main.sd", () => {
+          throw new Error("boom");
+        }),
+      ).toThrow("boom");
+    });
+    expect(seen.map((s) => s.name)).toEqual(["lsp: throws file:///main.sd"]);
+  });
+
+  it("measures an async phase across its whole settle, not just the call", async () => {
+    const seen = await observeMeasures(async () => {
+      await profiled("lsp: async", "file:///main.sd", async () => {
+        await sleep(80);
+        return "done";
+      });
+    });
+    expect(seen).toHaveLength(1);
+    // A bare try/finally would end the phase at the first await and report ~0.
+    expect(seen[0]!.duration).toBeGreaterThan(50);
+  });
+
+  it("still measures an async phase that rejects, across its whole settle", async () => {
+    const seen = await observeMeasures(async () => {
+      await expect(
+        profiled("lsp: rejects", "file:///main.sd", async () => {
+          await sleep(80);
+          throw new Error("nope");
+        }),
+      ).rejects.toThrow("nope");
+    });
+    expect(seen.map((s) => s.name)).toEqual(["lsp: rejects file:///main.sd"]);
+    // Ending at the first await would emit a measure too — but a ~0ms one.
+    expect(seen[0]!.duration).toBeGreaterThan(50);
+  });
+
+  it("omits the uri from the name when there is none", async () => {
+    const seen = await observeMeasures(() => {
+      profiled("lsp: no-uri", undefined, () => 1);
+    });
+    expect(seen.map((s) => s.name)).toEqual(["lsp: no-uri"]);
+  });
+
+  it("measures both a throwing phase and the next one of the same name", async () => {
+    const seen = await observeMeasures(async () => {
+      // A throwing phase, an idle gap, then a short phase of the same name.
+      expect(() =>
+        profiled("lsp: reused", "file:///main.sd", () => {
+          throw new Error("boom");
+        }),
+      ).toThrow();
+      await sleep(200);
+      profiled("lsp: reused", "file:///main.sd", () => 1);
+    }, 2);
+    // Without the fix the throwing phase emits nothing and only one measure
+    // arrives. (The second phase's duration is not the discriminator — the
+    // profiler pairs newest-first, so it never absorbs the gap either way.)
+    expect(seen).toHaveLength(2);
+    expect(seen[1]!.duration).toBeLessThan(100);
+  });
+});

--- a/packages/sparkdown-language-server/src/utils/logging/profiled.ts
+++ b/packages/sparkdown-language-server/src/utils/logging/profiled.ts
@@ -1,0 +1,45 @@
+import { profile } from "./profile";
+
+/**
+ * Run `fn` bracketed by a profiler phase, ending the phase on every exit path.
+ *
+ * Hand-written `profile("start", …)` / `profile("end", …)` pairs only close the
+ * phase on the happy path: a throw between them leaves the phase open and it
+ * never produces a measurement — losing exactly the requests worth looking at.
+ * None of the LSP handlers had a `try/finally`.
+ *
+ * Most of the wrapped bodies are synchronous; `onCompletionResolve` is the one
+ * that awaits inside its phase. A returned promise is handled explicitly rather
+ * than by a bare `finally`, so the phase covers the whole settle rather than
+ * just the synchronous call that produced it.
+ */
+export const profiled = <T>(
+  method: string,
+  uri: string | undefined,
+  fn: () => T,
+): T => {
+  profile("start", method, uri);
+  let deferred = false;
+  try {
+    const result = fn();
+    // Gate on `then` alone and adopt with `Promise.resolve`. A bare
+    // `PromiseLike` — which is how vscode-jsonrpc types handler returns —
+    // declares only `then`, and requiring `finally` too would silently route it
+    // down the synchronous path and measure ~0ms.
+    if (result && typeof (result as { then?: unknown }).then === "function") {
+      const settled = Promise.resolve(result).finally(() => {
+        profile("end", method, uri);
+      });
+      // Only hand the phase over once `finally` has actually been attached —
+      // a non-native thenable whose `finally` throws would otherwise leave the
+      // phase open, which is the failure this helper exists to prevent.
+      deferred = true;
+      return settled as T;
+    }
+    return result;
+  } finally {
+    if (!deferred) {
+      profile("end", method, uri);
+    }
+  }
+};

--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -981,6 +981,21 @@ export class SparkdownCompiler {
       }
     } catch (e) {
       compileThrew = true;
+      // Close whichever phase was in flight. This catch swallows the throw and
+      // the compiler keeps serving, so a phase left open here produces no
+      // measurement at all — losing exactly the compiles worth looking at, and
+      // `ink/compile` (ExportRuntime) is the very phase this catch was written
+      // for. Ending a phase that already ended is a no-op, so naming all five
+      // is safe. Add any new phase opened inside this `try` to the list.
+      for (const phase of [
+        "ink/parse",
+        "ink/canonicalizeSyntheticNames",
+        "ink/compile",
+        "ink/json",
+        "populateLocations",
+      ]) {
+        profile("end", this._profilerId, phase, uri);
+      }
       console.error(e);
       // Restore the parents of containers committed to reuse — the previous
       // RuntimeStory is still live (checkpoint-builder Game) and generation

--- a/packages/sparkdown/src/tests/compiler/profilerPhaseClosure.test.ts
+++ b/packages/sparkdown/src/tests/compiler/profilerPhaseClosure.test.ts
@@ -1,0 +1,132 @@
+import "../../inkjs/engine/Container";
+import { PerformanceObserver } from "node:perf_hooks";
+import { beforeEach, describe, expect, it } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+
+const perf = globalThis.performance;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Entries are cleared as soon as they are emitted (#321), so the buffer cannot
+// be read back — an observer is the only way to see what was measured.
+// Observer delivery is asynchronous and the callback can be delayed well past
+// a fixed sleep when the suite runs under load, so wait for the entries rather
+// than for the clock.
+const observeMeasures = async (
+  run: () => void | Promise<void>,
+  minCount = 1,
+  timeoutMs = 5000,
+) => {
+  const seen: string[] = [];
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      seen.push(entry.name);
+    }
+  });
+  observer.observe({ entryTypes: ["measure"] });
+  try {
+    await run();
+    const start = Date.now();
+    while (seen.length < minCount && Date.now() - start < timeoutMs) {
+      await sleep(10);
+    }
+    await sleep(20);
+  } finally {
+    observer.disconnect();
+  }
+  return seen;
+};
+
+const URI = "inmemory:///main.sd";
+
+const SOURCE = ["$:", "  A ROOFTOP", "", "ALICE:", "  Hello.", ""].join("\n");
+
+const newCompiler = () => {
+  const compiler = new SparkdownCompiler();
+  compiler.profilerId = "test";
+  compiler.configure({
+    files: [
+      {
+        uri: URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text: SOURCE,
+        version: 1,
+        languageId: "sparkdown",
+      },
+    ],
+  });
+  return compiler;
+};
+
+describe("compiler profiler phases close on every exit path", () => {
+  const realWarn = console.warn;
+  const realError = console.error;
+
+  beforeEach(() => {
+    perf.clearMarks();
+    perf.clearMeasures();
+    console.warn = () => {};
+    console.error = () => {};
+  });
+
+  const restore = () => {
+    console.warn = realWarn;
+    console.error = realError;
+  };
+
+  it("emits an ink/parse measure on a normal compile", async () => {
+    try {
+      const compiler = newCompiler();
+      const seen = await observeMeasures(() => {
+        compiler.compile({ textDocument: { uri: URI } });
+      });
+      expect(seen.some((name) => name.includes("ink/parse"))).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  // `compile` catches a mid-parse throw, logs it and keeps serving, so the
+  // trailing `profile("end", …)` was never reached and the compile that failed
+  // — the one worth looking at — contributed no measurement at all.
+  it("emits an ink/parse measure even when parsing throws", async () => {
+    try {
+      const compiler = newCompiler();
+      // Stub after configure(), which parses once itself.
+      (compiler as unknown as Record<string, unknown>)["parseIncrementally"] =
+        () => {
+          throw new Error("boom");
+        };
+      const seen = await observeMeasures(() => {
+        // The compiler swallows the throw by design; this must not reject.
+        compiler.compile({ textDocument: { uri: URI } });
+      });
+      expect(seen.some((name) => name.includes("ink/parse"))).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  // `ink/parse` is only the first of five phases under that same swallowing
+  // catch. A throw in a later one has to close its phase too — `ink/compile`
+  // (ExportRuntime) is the phase the catch was written for.
+  it("emits a measure for a later phase when that phase throws", async () => {
+    try {
+      const compiler = newCompiler();
+      (compiler as unknown as Record<string, unknown>)["populateAllLocations"] =
+        () => {
+          throw new Error("boom");
+        };
+      const seen = await observeMeasures(() => {
+        compiler.compile({ textDocument: { uri: URI } });
+      });
+      expect(seen.some((name) => name.includes("populateLocations"))).toBe(
+        true,
+      );
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/sparkdown/src/workspace/classes/SparkdownWorkspace.ts
+++ b/packages/sparkdown/src/workspace/classes/SparkdownWorkspace.ts
@@ -713,7 +713,6 @@ export abstract class SparkdownWorkspace {
     uri: string,
     force: boolean,
   ): Promise<SparkProgram | undefined> {
-    profile("start", this._profilerId, "workspace" + " " + "compile", uri);
     let anyDocChanged = false;
     for (let [documentUri] of this._programStates) {
       const state = this.getProgramState(documentUri);
@@ -755,110 +754,120 @@ export abstract class SparkdownWorkspace {
         this._onNextCompiled.set(uri, nextCompiledCallbacks);
       });
     }
-    state.compilingDocumentVersion = this._documentVersions.get(uri);
-    let result: CompileProgramResult | undefined = undefined;
-    // When the compiler's no-change short-circuit serves its cached program,
-    // it returns the SAME object as last time. Bumping our version counter on
-    // that would advertise a "new" program that is bit-identical -- and the
-    // player rebuilds its whole Game whenever program.version changes -- so
-    // detect identity and keep the version stable.
-    let programUnchanged = false;
-    const mainScriptUri = this.getMainScriptUri(uri);
+    // Start the phase only once the cheap exits above are behind us. The
+    // no-change and piggyback returns do no compile work — one of them just
+    // waits on somebody else's compile — so measuring them under this name
+    // would fold queue time into the metric and understate what a compile
+    // actually costs. The `finally` is what the ticket is about: the body
+    // below rethrows, and a bare trailing call would drop that measurement.
+    profile("start", this._profilerId, "workspace" + " " + "compile", uri);
     try {
-      if (mainScriptUri) {
-        const previousProgram = this.getProgramState(mainScriptUri).program;
-        result = await this.compileDocument(mainScriptUri);
-        programUnchanged = result.program === previousProgram;
-        this.getProgramState(mainScriptUri).program = result.program;
-        if (result.program.scripts) {
-          for (const [uri, version] of Object.entries(result.program.scripts)) {
-            const state = this.getProgramState(uri);
-            state.program = result.program;
-            state.compilingDocumentVersion = undefined;
-            state.compiledDocumentVersion = version;
-            if (!programUnchanged) {
-              state.version++;
+      state.compilingDocumentVersion = this._documentVersions.get(uri);
+      let result: CompileProgramResult | undefined = undefined;
+      // When the compiler's no-change short-circuit serves its cached program,
+      // it returns the SAME object as last time. Bumping our version counter on
+      // that would advertise a "new" program that is bit-identical -- and the
+      // player rebuilds its whole Game whenever program.version changes -- so
+      // detect identity and keep the version stable.
+      let programUnchanged = false;
+      const mainScriptUri = this.getMainScriptUri(uri);
+      try {
+        if (mainScriptUri) {
+          const previousProgram = this.getProgramState(mainScriptUri).program;
+          result = await this.compileDocument(mainScriptUri);
+          programUnchanged = result.program === previousProgram;
+          this.getProgramState(mainScriptUri).program = result.program;
+          if (result.program.scripts) {
+            for (const [uri, version] of Object.entries(result.program.scripts)) {
+              const state = this.getProgramState(uri);
+              state.program = result.program;
+              state.compilingDocumentVersion = undefined;
+              state.compiledDocumentVersion = version;
+              if (!programUnchanged) {
+                state.version++;
+              }
+              this._onNextCompiled.get(uri)?.forEach((c) => c?.(result?.program));
+              this._onNextCompiled.delete(uri);
             }
-            this._onNextCompiled.get(uri)?.forEach((c) => c?.(result?.program));
-            this._onNextCompiled.delete(uri);
           }
         }
-      }
-      if (uri !== mainScriptUri && result?.program?.scripts[uri] == null) {
-        // Target script is not included by main,
-        // So it must be parsed on its own to report diagnostics
-        const previousProgram = this.getProgramState(uri).program;
-        result = await this.compileDocument(uri);
-        programUnchanged = result.program === previousProgram;
-        const state = this.getProgramState(uri);
-        state.program = result.program;
+        if (uri !== mainScriptUri && result?.program?.scripts[uri] == null) {
+          // Target script is not included by main,
+          // So it must be parsed on its own to report diagnostics
+          const previousProgram = this.getProgramState(uri).program;
+          result = await this.compileDocument(uri);
+          programUnchanged = result.program === previousProgram;
+          const state = this.getProgramState(uri);
+          state.program = result.program;
+          state.compilingDocumentVersion = undefined;
+          state.compiledDocumentVersion = result.program?.scripts[uri];
+          if (!programUnchanged) {
+            state.version++;
+          }
+          this._onNextCompiled.get(uri)?.forEach((c) => c?.(result?.program));
+          this._onNextCompiled.delete(uri);
+        }
+      } catch (e) {
+        // Settle instead of strand: piggybacked callers (pull diagnostics etc.)
+        // are awaiting these resolvers, and a compile failure must not turn
+        // their requests into permanent hangs.
+        const flush = (flushUri: string) => {
+          const callbacks = this._onNextCompiled.get(flushUri);
+          if (callbacks) {
+            this._onNextCompiled.delete(flushUri);
+            callbacks.forEach((c) => c?.(undefined));
+          }
+        };
+        flush(uri);
+        if (mainScriptUri) {
+          flush(mainScriptUri);
+        }
         state.compilingDocumentVersion = undefined;
-        state.compiledDocumentVersion = result.program?.scripts[uri];
+        throw e;
+      }
+      if (result?.program) {
+        const state = this.getProgramState(uri);
         if (!programUnchanged) {
-          state.version++;
+          result.program.version = state.version;
         }
-        this._onNextCompiled.get(uri)?.forEach((c) => c?.(result?.program));
-        this._onNextCompiled.delete(uri);
+        // With slimProgramNotifications, relay only what the notification's
+        // consumers actually read instead of the whole program (which is ~9MB on
+        // a large project and re-broadcast on EVERY compile; the receiver pays a
+        // structured-clone of all of it per keystroke).
+        //
+        // The impower web editor's main thread needs just `diagnosticsSummary`
+        // (file/tab error+warning colors). Everything else is fetched on demand
+        // or delivered through a dedicated channel:
+        //   - full diagnostics    → textDocument/publishDiagnostics
+        //   - prev/next beat      → sparkdown/offsetSourceLocation
+        // uri/scripts/files/version ride along because they're small and
+        // identify the compile. Resist adding heavy fields back here — prefer an
+        // on-demand request.
+        const notificationParams: CompiledProgramParams = this
+          .slimProgramNotifications
+          ? {
+              ...result,
+              program: {
+                uri: result.program.uri,
+                scripts: result.program.scripts,
+                files: result.program.files,
+                version: result.program.version,
+              },
+              diagnosticsSummary: summarizeDiagnostics(
+                result.program.diagnostics,
+              ),
+            }
+          : result;
+        this.sendNotification(CompiledProgramMessage.method, notificationParams);
+        this.onCompiledTextDocument({
+          textDocument: { uri },
+          program: result.program,
+        });
       }
-    } catch (e) {
-      // Settle instead of strand: piggybacked callers (pull diagnostics etc.)
-      // are awaiting these resolvers, and a compile failure must not turn
-      // their requests into permanent hangs.
-      const flush = (flushUri: string) => {
-        const callbacks = this._onNextCompiled.get(flushUri);
-        if (callbacks) {
-          this._onNextCompiled.delete(flushUri);
-          callbacks.forEach((c) => c?.(undefined));
-        }
-      };
-      flush(uri);
-      if (mainScriptUri) {
-        flush(mainScriptUri);
-      }
-      state.compilingDocumentVersion = undefined;
-      throw e;
+      return result?.program;
+    } finally {
+      profile("end", this._profilerId, "workspace" + " " + "compile", uri);
     }
-    if (result?.program) {
-      const state = this.getProgramState(uri);
-      if (!programUnchanged) {
-        result.program.version = state.version;
-      }
-      // With slimProgramNotifications, relay only what the notification's
-      // consumers actually read instead of the whole program (which is ~9MB on
-      // a large project and re-broadcast on EVERY compile; the receiver pays a
-      // structured-clone of all of it per keystroke).
-      //
-      // The impower web editor's main thread needs just `diagnosticsSummary`
-      // (file/tab error+warning colors). Everything else is fetched on demand
-      // or delivered through a dedicated channel:
-      //   - full diagnostics    → textDocument/publishDiagnostics
-      //   - prev/next beat      → sparkdown/offsetSourceLocation
-      // uri/scripts/files/version ride along because they're small and
-      // identify the compile. Resist adding heavy fields back here — prefer an
-      // on-demand request.
-      const notificationParams: CompiledProgramParams = this
-        .slimProgramNotifications
-        ? {
-            ...result,
-            program: {
-              uri: result.program.uri,
-              scripts: result.program.scripts,
-              files: result.program.files,
-              version: result.program.version,
-            },
-            diagnosticsSummary: summarizeDiagnostics(
-              result.program.diagnostics,
-            ),
-          }
-        : result;
-      this.sendNotification(CompiledProgramMessage.method, notificationParams);
-      this.onCompiledTextDocument({
-        textDocument: { uri },
-        program: result.program,
-      });
-    }
-    profile("end", this._profilerId, "workspace" + " " + "compile", uri);
-    return result?.program;
   }
 
   stripMarkdown(markdown: string): string {


### PR DESCRIPTION
Fixes #331. Stacked conceptually on #333 (which fixes the issue's fourth site).

## What broke

Profiler phases were opened with a bare `profile("start", …)` /
`profile("end", …)` pair. An early return or a throw between them left the phase
open, and an open phase produces **no measurement at all** — so the compiles and
requests worth looking at are exactly the ones that vanish from the profile.
After #330 the leftover bookkeeping is bounded, so this is a data-quality bug,
not a memory one.

| Site | Unmatched paths |
| --- | --- |
| `SparkdownWorkspace.compile` | no-change short-circuit, two piggyback returns, and a rethrow |
| `SparkdownCompiler` | five phases under one `catch` that swallows and keeps serving |
| `sparkdown-language-server.ts` | 20 handlers, zero `finally` in the whole file |

## The fix

**`SparkdownWorkspace.compile`** — the phase now starts *after* the cheap exits
and ends in a `finally`.

Starting it later is deliberate, and is a change from my first cut. Bracketing
the whole method also emitted a measure for the no-change and piggyback returns,
which do no compile work — one of them just waits on somebody else's compile. A
second caller arriving 10 ms into a 400 ms compile would have emitted a 390 ms
`workspace compile` measure for zero work, and `scheduleChangeCompile`'s batch
loop deliberately drives every same-tree document into the no-change return, so
a 10-file edit would have turned `count=1, avg=400ms` into `count=10, avg=40ms`.
The metric would have understated a compile by 10×. Review the diff with
`git diff -w` — most of the churn is one indent level.

**`SparkdownCompiler`** — five phases (`ink/parse`,
`ink/canonicalizeSyntheticNames`, `ink/compile`, `ink/json`,
`populateLocations`) sit inside one `try` whose `catch` swallows the throw. The
catch now closes all five up front; ending a phase that already ended is a
no-op. `ink/compile` is `ExportRuntime` — the phase that catch was *written*
for, per its own comment about generation re-parenting containers.

**`sparkdown-language-server.ts`** — 20 pairs replaced by a `profiled()` helper
that ends the phase in a `finally`, and for a returned promise ends it in
`.finally()` so the phase covers the whole settle. Measure names are unchanged,
with one deliberate exception: `onColorPresentation` had been sharing
`lsp: onDocumentColor` with a different handler, so two requests aggregated into
one phase.

## Regression tests

- `packages/sparkdown/src/tests/compiler/profilerPhaseClosure.test.ts` (3) —
  a normal compile still measures; a throwing `parseIncrementally` still
  measures `ink/parse`; a throwing `populateAllLocations` still measures
  `populateLocations` (i.e. a *later* phase, not just the first).
- `packages/sparkdown-language-server/src/tests/logging/profiled.test.ts` (6) —
  sync, throwing, async, rejecting, no-uri, and two same-name phases.

Both read entries through a `PerformanceObserver`, since #330 clears the buffer.

### Red/green

Against pre-fix `SparkdownCompiler`:

```
✓ emits an ink/parse measure on a normal compile        ← positive control
× emits an ink/parse measure even when parsing throws   → expected false to be true
× emits a measure for a later phase when that phase throws → expected false to be true
```

Against a naive `profiled()` (bare start/end, the shape the handlers had):

```
× still measures a phase whose body throws        → expected [] to deeply equal [...]
× measures an async phase across its whole settle → expected 0.2188 to be greater than 50
× measures both a throwing phase and the next one → expected length 2 but got 1
```

The positive control passing in both directions is what shows the red isn't trivial.

## Suites run

| Suite | Result |
| --- | --- |
| `packages/sparkdown` compiler + runtime | 72 passed / 2 skipped (74 files); 864 passed / 24 skipped (888 tests) |
| `packages/sparkdown-language-server` | 99 passed, **2 pre-existing failures** (101) |

The 2 failures are `screen element (bad attr spacing)` in the formatter
equivalence tests. Confirmed unrelated — they fail identically on an unmodified
`main` checkout (`fixture line for "screen element (bad attr spacing)": expected
-1 to be greater than or equal to 0` — a missing fixture).

## Live verification

Driven through the running editor: script loads, semantic highlighting is live
(which exercises the rewritten `semanticTokens` handlers), and the preview
follows the cursor and renders the beat — `route: main : 1 → main : 8`, BOB's
line on screen.

## Review

Two reviewers. A dedicated audit walked all 20 rewrites argument-for-argument
against the original and found **no defects** — names, measured regions, return
values, destructuring and scope all preserved, confirmed independently with
`tsc`. The undirected reviewer found real problems, all fixed above:

- The whole-method bracket aliased queue-wait onto the compile metric (the
  restructure described above).
- Four sibling compiler phases with the identical defect were left unfixed.
- `profiled()` gated on both `then` *and* `finally`, so a bare `PromiseLike` —
  which is how vscode-jsonrpc types handler returns — would take the sync path
  and measure ~0 ms. Now gates on `then` and adopts with `Promise.resolve`.
- One test's load-bearing assertion was vacuous: it claimed the second phase
  must not absorb the idle gap, but the profiler pairs newest-first so it never
  could. Retitled and re-commented around what actually discriminates.
- `deferred` was set before `.finally()` was attached; a thenable whose
  `finally` threw would leak the phase.
- The helper's doc comment overclaimed how many handlers await.

Deliberately not changed:

- **The `semanticTokens` awaits cited in the ticket** (`workspace.compile`) sit
  *outside* the phase, before and after this change. Moving the bracket to cover
  them would change what the measurement means; it is a separate decision.
- **`compileUnprofiled` is gone**, so there is no unprofiled entry point for a
  subclass to accidentally use.
- **`no-return-await`.** There is now no `return await` to simplify away, which
  removes the trap where a lint autofix would silently zero every
  `workspace compile` measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
