### PR TITLE
refactor(compiler): drop the dead list-construction branch (#329)

### DIFF
--- a/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/FunctionCall.ts
+++ b/packages/sparkdown/src/inkjs/compiler/Parser/ParsedHierarchy/FunctionCall.ts
@@ -5,13 +5,10 @@ import { Divert } from "./Divert/Divert";
 import { Divert as RuntimeDivert } from "../../../engine/Divert";
 import { DivertTarget } from "./Divert/DivertTarget";
 import { Expression } from "./Expression/Expression";
-import { InkList as RuntimeInkList } from "../../../engine/InkList";
-import { ListValue } from "../../../engine/Value";
 import { NativeFunctionCall } from "../../../engine/NativeFunctionCall";
 import { NumberExpression } from "./Expression/NumberExpression";
 import { Path } from "./Path";
 import { Story } from "./Story";
-import { StringValue } from "../../../engine/Value";
 import { Void as RuntimeVoid } from "../../../engine/Void";
 import { VariableReference } from "./Variable/VariableReference";
 import { Identifier } from "./Identifier";
@@ -125,8 +122,23 @@ export class FunctionCall extends Expression {
   public readonly GenerateIntoContainer = (
     container: RuntimeContainer,
   ): void => {
-    const foundList = this.story.ResolveList(this.name);
-
+    // Which branch below runs is a pure function of `this.name`, which is
+    // fixed at construction (`_proxyDivert` is assigned only in this class's
+    // constructor, `Divert.target` only in `Divert`'s). Every selector is a
+    // name comparison or a static registry lookup — so a parsed node carried
+    // forward by the incremental pipeline always takes the SAME branch, and
+    // in particular `usingProxyDivert` cannot flip between compiles.
+    //
+    // Upstream ink had one selector that read per-compile state, a
+    // `story.ResolveList(this.name)` arm constructing a list value. It is
+    // removed: sparkdown has no LIST type (ink's is replaced by Luau tables —
+    // `tests/runtime/Lists.test.ts` is closed by design, see
+    // docs/runtime/DIVERGENCES.md), no parsed `ListDefinition` is ever
+    // constructed, so `_listDefs` is always empty and that arm was dead. Its
+    // one hazard: it removed `_proxyDivert` from `content` (see the splice
+    // below) without anything re-adding it, so had the branch ever flipped
+    // back to a normal call, the divert would have gone unresolved and
+    // undiagnosed. See #329.
     let usingProxyDivert: boolean = false;
 
     if (this.isTurnsSince || this.isReadCount) {
@@ -257,24 +269,6 @@ export class FunctionCall extends Expression {
       container.AddContent(
         NativeFunctionCall.CallWithName(this.name, this.args.length),
       );
-    } else if (foundList !== null) {
-      if (this.args.length > 1) {
-        this.Error(
-          "Can currently only construct a list from one integer (or an empty list from a given list definition)",
-        );
-      }
-
-      // List item from given int
-      if (this.args.length === 1) {
-        container.AddContent(new StringValue(this.name));
-        this.args[0].GenerateIntoContainer(container);
-        container.AddContent(RuntimeControlCommand.ListFromInt());
-      } else {
-        // Empty list with given origin.
-        const list = new RuntimeInkList();
-        list.SetInitialOriginName(this.name);
-        container.AddContent(new ListValue(list));
-      }
     } else {
       // Normal function call
       container.AddContent(this._proxyDivert.runtimeObject);


### PR DESCRIPTION
Closes #329. Follow-up to #328.

## What is removed

`FunctionCall.GenerateIntoContainer` had a `story.ResolveList(this.name)` arm, inherited from ink, that constructed a list value (`ListFromInt` / an empty `InkList` with an origin name). It is unreachable.

**Sparkdown has no LIST type.** Ink's is replaced by Luau tables — `src/tests/runtime/Lists.test.ts` is `describe.skip` and documented "closed by design" (`docs/runtime/DIVERGENCES.md`). Following that through:

- `Story.ResolveList` reads only `Story._listDefs` (`ParsedHierarchy/Story.ts:583-591`).
- `_listDefs` fills only from parsed `ListDefinition` nodes — `listDecls` via `CollectByType` (`Story.ts:254-259`) and `variableDeclarations[].listDefinition` (`Story.ts:376-379`).
- **No parsed `ListDefinition` is ever constructed anywhere in the repo.** The only `new ListDefinition` is `engine/JsonSerialisation.ts:1351`, which imports the *runtime* class from `./ListDefinition` (line 27) and builds it from serialized JSON — a different class.
- The one route into the parsed tree is `VariableAssignment`'s constructor (`Variable/VariableAssignment.ts:98-102`), and no caller anywhere passes `listDef` (the sole repo-wide `listDef:` match is an unrelated local).

So `foundList` was always `null` and the arm never ran. `FunctionCall` was `ResolveList`'s only caller.

## Why it is worth removing rather than leaving

The arm left `usingProxyDivert` false, so the tail splice dropped `_proxyDivert` from `content` with nothing to re-add it. Had the branch ever flipped back to a normal call on a later compile, the emitted divert would have gone unresolved and undiagnosed — `content` is the spine `ParsedObject.ResolveReferences` recurses over (`ParsedHierarchy/Object.ts:296-302`).

With the arm gone, the branch choice is a pure function of `this.name`, which is fixed at construction (`_proxyDivert` is assigned only in `FunctionCall`'s constructor, `Divert.target` only in `Divert`'s). Every remaining selector is a name comparison or a static registry lookup. So a parsed node carried forward by the incremental pipeline always takes the same branch, and `usingProxyDivert` cannot flip — the hazard is structurally gone, not just unreachable.

That reachability argument is now recorded in a comment at the top of the method, so this does not get re-derived or re-filed a third time (#323 explicitly asked for the negative result to be written down).

## Scope boundary

- `Story.ResolveList` itself is left in place. It now has zero callers, but `_listDefs`, `ResolveListItem` (still called from `List.ts` and `VariableReference.ts`, dead by the same argument) and the parsed `ListDefinition` class all remain, so deleting it would not make the LIST machinery go away — it would just widen the diff and the divergence from upstream inkjs for no behavioural gain.
- The `ListFromInt` **runtime** opcode stays in the engine (`ControlCommand`, `JsonSerialisation`, `Story`); only the compiler's emission of it is removed, so existing serialized programs still deserialize.
- One unused import in this file, `NumberExpression`, is left alone — it was already unused on `main` before this change and is unrelated to the LIST path.

## Verification

Behaviour is unchanged, because the branch never ran.

Suites, run in this worktree on this branch (rebased onto current `main`, which now includes #327 and #330), `--pool=forks`, capped, sequentially:

| suite | result |
| --- | --- |
| `src/tests/compiler` | 30 files, **557 passed** |
| `src/tests/runtime` | 41 files (+2 skipped), **304 passed**, 24 skipped |
| `src/tests/luau-conformance` | 70 files, **759 passed** |

No failures, no `Worker exited unexpectedly`, summary lines present in all three. Note these counts supersede the ones in #328 (28/545): `main` gained two compiler test files from #327 and #330 after that PR was measured, so I re-ran everything against the current tree rather than reusing those numbers.

No test or snapshot referenced the deleted branch — searched for both `listInt` and the deleted `"Can currently only construct a list..."` error string, zero hits.

**Live check:** editor + player booted, script loaded into OPFS, preview scrubbed to the `TURNS_SINCE` line. Game Preview renders `Turns since gamma is -1.` (`gameMounted: true`, `route: main : 1 → main : 8`, `settled: true`) — identical to before the deletion. Servers were restarted first, since the branch switch and a dependency reinstall happened underneath the running build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
