### PR TITLE
fix(compiler): rebuild annotator scope state so incremental matches cold (#326)

### DIFF
--- a/packages/sparkdown/src/compiler/classes/SparkdownCombinedAnnotator.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCombinedAnnotator.ts
@@ -23,6 +23,36 @@ import { SparkdownAnnotator } from "./SparkdownAnnotator";
 
 type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 
+/**
+ * Stable identity for an annotation's payload, used to match a re-emitted
+ * annotation against the copy it supersedes. String and `undefined` payloads
+ * compare directly; object payloads are freshly allocated on every pass, so
+ * they only match by value. A payload that cannot be serialized gets a key
+ * that matches nothing, which keeps the caller conservative — it declines to
+ * delete rather than risk dropping a distinct annotation.
+ */
+let uncomparableCounter = 0;
+function annotationValueKey(value: SparkdownAnnotation<any>): string {
+  const type = value?.type;
+  // `p:` / `o:` keep a string payload from ever colliding with the
+  // serialization of an object payload that happens to spell the same thing.
+  if (type == null || typeof type !== "object") {
+    return `p:${String(type)}`;
+  }
+  try {
+    const key = JSON.stringify(type);
+    if (key !== undefined) {
+      return `o:${key}`;
+    }
+  } catch {
+    // Cyclic or otherwise unserializable - fall through.
+  }
+  // Unique per call, so it matches nothing and the caller declines to delete
+  // rather than risk dropping a distinct annotation.
+  uncomparableCounter += 1;
+  return `!:${uncomparableCounter}`;
+}
+
 export type SparkdownAnnotationRanges = {
   [K in keyof SparkdownAnnotators]: Writeable<
     NonNullable<
@@ -157,57 +187,50 @@ export class SparkdownCombinedAnnotator {
   }
 
   /**
-   * Drop re-emissions that the delete-filter would not have removed.
+   * Drop re-emissions the delete-filter would not have removed.
    *
-   * The incremental update deletes every existing annotation overlapping the
-   * re-annotated window `[keptFrom, keptTo]` and re-adds whatever the partial
-   * `tree.iterate` produced. The DELETE half is exact: Lezer only enters a node
-   * that overlaps the iterate range, so an annotation carrying its node's own
-   * `[from, to]` overlaps the window too and is always removed before it can be
-   * re-added.
+   * The filter only deletes what overlaps the re-annotated window, which is
+   * exact for an annotation carrying its entered node's own `[from, to]`:
+   * Lezer only enters a node overlapping the window, so such an annotation
+   * overlaps it too and is always removed before it is re-added.
    *
-   * Annotations anchored somewhere OTHER than the node's full range escape
-   * that. A zero-width mark at a node's START (`top_level_begin`) sits before
-   * `keptFrom` whenever the parser restarts at an in-block split point, and a
-   * mark at a node's END (`frontmatter_end`, `keyword_separator`) can sit past
-   * `keptTo`; either way the node is still entered, so the old copy is KEPT
-   * *and* an identical fresh copy is added. `RangeSet` does not dedup, so the
-   * set grows by one entry per keystroke, unbounded, for as long as typing
-   * continues inside one block (#322).
+   * An annotator may anchor elsewhere, though — a zero-width mark at a node's
+   * edge, `ReferenceAnnotator`'s quote-stripped `[from + 1, to - 1]`, or
+   * `ValidationAnnotator`'s diagnostics anchored on a *sibling* node. Lezer
+   * still enters the node, so the pass re-emits while the filter keeps the old
+   * copy: one duplicate per keystroke, unbounded (#322).
    *
-   * So: for a candidate outside the window, keep it only to the extent that
-   * the surviving copies do not already account for it. Prune is by COUNT, not
-   * by presence: if this pass emits K identical out-of-window annotations and
-   * M survive, keep `K - M` of them. Testing presence alone would collapse a
-   * legitimate 1 → K increase down to M (cold parses really do emit identical
-   * duplicate `formatting` marks — e.g. two `separator`s at the same offset).
+   * So for a candidate outside the window, keep it only to the extent the
+   * survivors do not already account for it. Two properties matter:
    *
-   * Value identity is `===` on `type`. That covers the annotators whose `type`
-   * is a string or `undefined` — `formatting`, `declarations`, `characters`,
-   * `links`. The rest (`semantics`, `colors`, `references`, `lenses`,
-   * `compilations`, `validations`, `implicits`) carry a freshly allocated
-   * object per `enter`, so `===` never holds and this guard is a no-op for
-   * them. That is deliberately conservative — never dropping something that
-   * might not be a duplicate.
+   * - By COUNT, not presence. A cold parse really does emit identical
+   *   duplicate marks at one offset, so collapsing K down to 1 would lose one.
+   * - Drop the NEW copy rather than deleting the old one. They are
+   *   interchangeable in content, but deleting and re-adding moves the
+   *   annotation to the end of its position's insertion order, and zero-width
+   *   marks share offsets — `top_level_begin` and `indent` both sit at a
+   *   block's first column, and the formatter consumes them in order.
    *
-   * What this does NOT fix, all pre-existing and tracked in #326:
-   * - `references` and `validations` also emit non-node-anchored ranges, and
-   *   being object-valued they keep the #322 growth shape.
-   * - The RE-ADD half of the window is not exact in the other direction
-   *   either: a partial pass is not the cold pass restricted to the window,
-   *   because annotators carry cross-window state that `begin()` resets
-   *   (`SemanticAnnotator.scopeStack`, `FormattingAnnotator.processedLineFrom`).
-   *   An in-block window can therefore DROP annotations a cold parse emits.
-   * - Nothing removes an out-of-window annotation the new parse no longer
-   *   emits; the filter keeps it and the partial iterate never visits it.
-   * - A set that already carries N stale copies stays pinned at N: this stops
-   *   the growth, it does not repair a set that has already grown.
+   * Identity is the SERIALIZED payload, not `===`. Most annotators allocate a
+   * fresh object per pass (`semantics`, `references`, `validations`, …), so a
+   * reference comparison silently never matches and leaves them accumulating.
+   * Serialization only runs for candidates already matched on position, so it
+   * stays off the hot path, and a payload that cannot be serialized gets a key
+   * that matches nothing — declining to prune rather than risking a drop.
+   *
+   * `CompilationAnnotator.end` pairs `added[i]` with `removed[i]` POSITIONALLY
+   * to carry `uuid` forward, so a shortened `add` would misalign it. That is
+   * safe only because compilation annotations carry their node's own
+   * `[from, to]` and therefore always hit the in-window `continue` below —
+   * never reaching the serialization, which on a `CompiledBlock` would also be
+   * expensive. Anything that gives compilations an off-node anchor has to
+   * revisit this.
    */
   protected pruneRedundant<T extends SparkdownAnnotation<any>>(
     add: Range<T>[],
     current: RangeSet<T>,
-    keptFrom: number,
-    keptTo: number,
+    windowFrom: number,
+    windowTo: number,
   ): Range<T>[] {
     let redundant: Set<number> | undefined;
     // How many identical copies this pass has already pruned, so a second
@@ -216,16 +239,17 @@ export class SparkdownCombinedAnnotator {
     let prunedSoFar: Map<string, number> | undefined;
     for (let i = 0; i < add.length; i++) {
       const candidate = add[i]!;
-      if (candidate.to >= keptFrom && candidate.from <= keptTo) {
+      if (candidate.to >= windowFrom && candidate.from <= windowTo) {
         // Inside the window: the old copy is deleted, so this is the only one.
         continue;
       }
+      const valueKey = annotationValueKey(candidate.value);
       let survivors = 0;
       current.between(candidate.from, candidate.to, (from, to, value) => {
         if (
           from === candidate.from &&
           to === candidate.to &&
-          value.type === candidate.value.type
+          annotationValueKey(value) === valueKey
         ) {
           survivors += 1;
         }
@@ -234,9 +258,7 @@ export class SparkdownCombinedAnnotator {
       if (survivors === 0) {
         continue;
       }
-      const key = `${candidate.from}:${candidate.to}:${String(
-        candidate.value.type,
-      )}`;
+      const key = `${candidate.from}:${candidate.to}:${valueKey}`;
       prunedSoFar ??= new Map();
       const alreadyPruned = prunedSoFar.get(key) ?? 0;
       if (alreadyPruned < survivors) {
@@ -323,31 +345,35 @@ export class SparkdownCombinedAnnotator {
         editStart = fromB;
       }
     });
+    // The delete window and the annotate window must stay identical, or the
+    // reconciliation loses or duplicates annotations.
+    //
+    // Widening this window out to whole top-level nodes would ALSO give the
+    // annotators the state a cold parse has at the boundary — but measured at
+    // 7x the per-keystroke cost inside a large top-level Luau block (13.9ms ->
+    // 97.2ms per edit event on a 21KB script), because it re-annotates the
+    // whole block on every keystroke. Annotators that depend on preceding
+    // context rebuild it in `begin()` instead; see `SemanticAnnotator`.
+    const windowFrom = editStart;
     if (reparsedTo == null) {
       // Only rebuild annotations after `editStart`
       for (const [key, add] of Object.entries(
-        this.annotate(tree, editStart, undefined, annotate),
+        this.annotate(tree, windowFrom, undefined, annotate),
       )) {
         if (!annotate || annotate?.has(key as keyof SparkdownAnnotators)) {
           const annotator = this.current[key as keyof SparkdownAnnotators];
           if (annotator) {
             const removed: Range<typeof annotator._annotationType>[] = [];
             annotator.current = annotator.current.map(changeDesc);
-            // `end()` receives `kept`, not `add`, so it sees what actually
-            // entered the set. Note `CompilationAnnotator.end` pairs
-            // `added[i]` with `removed[i]` POSITIONALLY; pruning is a no-op
-            // for `compilations` (node-anchored, and object-valued so `===`
-            // never holds), so that pairing is unchanged. Anything that makes
-            // compilation values comparable by value has to revisit this.
             const kept = this.pruneRedundant(
               add as any,
               annotator.current,
-              editStart,
+              windowFrom,
               Infinity,
             );
             annotator.current = annotator.current.update({
               filter: (from, to, value) => {
-                if (to < editStart) {
+                if (to < windowFrom) {
                   return true;
                 }
                 removed.push(value.range(from, to));
@@ -368,27 +394,25 @@ export class SparkdownCombinedAnnotator {
       }
       return this.current;
     }
-    // Only rebuild annotations between `editStart` and reparsedTo
+    // Only rebuild annotations between `windowFrom` and `windowTo`
+    const windowTo = reparsedTo;
     for (const [key, add] of Object.entries(
-      this.annotate(tree, editStart, reparsedTo, annotate),
+      this.annotate(tree, windowFrom, windowTo, annotate),
     )) {
       if (!annotate || annotate?.has(key as keyof SparkdownAnnotators)) {
         const annotator = this.current[key as keyof SparkdownAnnotators];
         if (annotator) {
           const removed: Range<typeof annotator._annotationType>[] = [];
           annotator.current = annotator.current.map(changeDesc);
-          // See the note on the `reparsedTo == null` branch above about
-          // `end()` receiving `kept` and `CompilationAnnotator`'s positional
-          // `added[i]`/`removed[i]` pairing.
           const kept = this.pruneRedundant(
             add as any,
             annotator.current,
-            editStart,
-            reparsedTo,
+            windowFrom,
+            windowTo,
           );
           annotator.current = annotator.current.update({
             filter: (from, to, value) => {
-              if (to < editStart || from > reparsedTo) {
+              if (to < windowFrom || from > windowTo) {
                 return true;
               }
               removed.push(value.range(from, to));

--- a/packages/sparkdown/src/compiler/classes/annotators/SemanticAnnotator.ts
+++ b/packages/sparkdown/src/compiler/classes/annotators/SemanticAnnotator.ts
@@ -1,5 +1,6 @@
 import { Range } from "@codemirror/state";
 import { getDescendent } from "@impower/textmate-grammar-tree/src/tree/utils/getDescendent";
+import { Tree } from "@lezer/common";
 import GRAMMAR_DEFINITION from "../../../../language/sparkdown.language-grammar.json";
 import { SparkdownSyntaxNodeRef } from "../../types/SparkdownSyntaxNodeRef";
 import { SparkdownAnnotation } from "../SparkdownAnnotation";
@@ -133,9 +134,109 @@ export class SemanticAnnotator extends SparkdownAnnotator<
   // LuauVariableDefinition and read it when assignments fire.
   pendingDeclKind: "variable" | "const-variable" | null = null;
 
-  override begin(): void {
+  // True while `primeScopes` is replaying `enter`/`leave` to rebuild state.
+  // Emission is skipped in that mode — see the guard in `enter`.
+  protected priming = false;
+
+  override begin(iterateFrom: number): void {
     this.scopeStack = [makeGlobalScope()];
     this.pendingDeclKind = null;
+    if (iterateFrom > 0 && this.tree) {
+      this.primeScopes(this.tree, iterateFrom);
+    }
+  }
+
+  /**
+   * Rebuild the scope state a cold pass would hold on reaching `upTo`.
+   *
+   * The incremental update re-annotates only a window and deletes whatever it
+   * overlaps, which assumes the annotators reproduce there what a cold parse
+   * would. This annotator does not, unaided: `begin` resets `scopeStack` to the
+   * global frame, so a window opening inside a function body has neither the
+   * document's top-level declarations nor that body's earlier `local`s bound.
+   * References then fail to resolve, no token is emitted, and the old tokens —
+   * which WERE inside the window — have already been deleted. They stay gone
+   * until a cold parse (#326).
+   *
+   * Rather than duplicate the binding rules, replay this annotator's own
+   * `enter`/`leave` over the nodes that precede the window, discarding the
+   * annotations. Two details make that faithful and affordable:
+   *
+   * - `leave` is suppressed for nodes that extend past `upTo`. A cold pass has
+   *   not left those yet, so their scope frames must stay open — popping them
+   *   would discard exactly the enclosing-function bindings we came for.
+   * - The body of a function that CLOSES before `upTo` is skipped wholesale.
+   *   Entering the definition binds its name in the enclosing scope, and
+   *   everything inside dies with the frame `leave` pops, so the subtree cannot
+   *   affect the result. This is what keeps priming proportional to the
+   *   declarations in scope rather than to the whole document; widening the
+   *   annotate window instead measured 7x worse per keystroke.
+   */
+  protected primeScopes(tree: Tree, upTo: number): void {
+    const discard: Range<SparkdownAnnotation<SemanticInfo>>[] = [];
+    this.priming = true;
+    try {
+      this.replayScopes(tree, upTo, discard);
+    } finally {
+      this.priming = false;
+    }
+  }
+
+  private replayScopes(
+    tree: Tree,
+    upTo: number,
+    discard: Range<SparkdownAnnotation<SemanticInfo>>[],
+  ): void {
+    tree.iterate({
+      from: 0,
+      to: upTo,
+      enter: (nodeRef) => {
+        this.enter(discard, nodeRef as SparkdownSyntaxNodeRef);
+        discard.length = 0;
+        // Nodes still open at `upTo` are the ancestor chain of the window;
+        // always descend those.
+        if (nodeRef.to > upTo) {
+          return undefined;
+        }
+        if (
+          nodeRef.name === "LuauFunctionDefinition" &&
+          this.pendingDeclKind === null
+        ) {
+          // Closed before the window: its name is already bound in the
+          // enclosing scope, and every binding inside dies with the frame the
+          // `leave` below pops, so the body cannot change the result.
+          //
+          // Only safe while no declaration is in progress. `pendingDeclKind`
+          // is NOT scope-stack state, so it survives the pop: for
+          // `local a = function() local g = 1 end, b = 2`, a cold pass has the
+          // inner definition's `leave` clear it before `, b = 2` is reached,
+          // while skipping the body would leave it set and bind `b` spuriously.
+          // In that case descend and let the ordinary logic run.
+          this.leave(discard, nodeRef as SparkdownSyntaxNodeRef);
+          discard.length = 0;
+          return false;
+        }
+        // NOTE: it is tempting to also skip closed subtrees whose node name is
+        // not `Luau*`, on the theory that only Luau constructs bind. They do
+        // not: `scene Name(param)` nests its `LuauFunctionParameter` under a
+        // `Scene` node (see the `scene-with-parameters` grammar snapshot), and
+        // that parameter binds into the enclosing scope. Skipping non-Luau
+        // subtrees drops it and loses every token for that parameter's
+        // references — the exact defect this method exists to fix. Measured at
+        // ~1.6x the priming cost to descend them; correctness wins.
+        return undefined;
+      },
+      leave: (nodeRef) => {
+        // Nodes still open at `upTo` must stay open: a cold pass has not left
+        // them yet, and popping their frames would discard exactly the
+        // enclosing-function bindings this method exists to rebuild.
+        if (nodeRef.to > upTo) {
+          return;
+        }
+        this.leave(discard, nodeRef as SparkdownSyntaxNodeRef);
+        discard.length = 0;
+      },
+    });
   }
 
   // Look up `name` in the scope stack, innermost-first. Returns the
@@ -237,6 +338,13 @@ export class SemanticAnnotator extends SparkdownAnnotator<
           this.bindInCurrentScope(name, kind);
         }
       }
+    }
+    // Everything above this point maintains scope state; everything below
+    // only emits. `primeScopes` replays this method purely to rebuild the
+    // state, so it stops here — skipping the per-node text reads and lookups
+    // that would otherwise dominate the cost of walking the prefix.
+    if (this.priming) {
+      return annotations;
     }
     // Reference sites — emit a kind-aware semantic token based on the
     // current scope lookup. Covers the grammar nodes that resolve to

--- a/packages/sparkdown/src/tests/compiler/incrementalAnnotationParity.test.ts
+++ b/packages/sparkdown/src/tests/compiler/incrementalAnnotationParity.test.ts
@@ -1,0 +1,309 @@
+// Incremental annotation parity: the annotations after a burst of edits must
+// equal the annotations a cold parse of the same text produces.
+//
+// `SparkdownCombinedAnnotator.update` re-annotates only `[editStart,
+// reparsedTo]` and deletes whatever that window overlaps. That reconciles only
+// if re-running the annotators over the window reproduces what a cold parse
+// would put there — and several annotators do not, unaided, because `begin()`
+// resets state a cold parse accumulates from earlier in the document.
+// `SemanticAnnotator` is the sharpest case: with `scopeStack` reset to the
+// global frame, a window opening inside a function body has neither the
+// document's top-level declarations nor that body's earlier `local`s bound, so
+// identifier references stop resolving and their tokens are deleted without
+// being re-emitted. They stay gone until a cold parse (#326).
+//
+// EDITS ARE BINDING-PRESERVING BY CONSTRUCTION, and that is load-bearing:
+//
+//  - Inserting at an arbitrary offset lands inside keywords and numbers
+//    (`end` -> `endx`, `1` -> `1x`) and degrades the parse. A cold parse and an
+//    incremental one then legitimately disagree, so the oracle stops being an
+//    oracle. Every edit here keeps the document syntactically valid.
+//  - Renaming a DECLARATION leaves stale tokens on its downstream references,
+//    which sit outside the window and are never re-examined. That is a real
+//    defect, still open, and it needs symbol-level dependency tracking rather
+//    than anything this window can do — so these edits do not rename.
+//
+// `treesMatch` is asserted first: if the incremental and cold parse trees ever
+// differ, an annotation difference is downstream of the parser and this file is
+// pointing at the wrong subsystem.
+import { cachedCompilerProp } from "@impower/textmate-grammar-tree/src/tree/props/cachedCompilerProp";
+import { describe, expect, it } from "vitest";
+import type { SparkdownAnnotators } from "../../compiler/classes/SparkdownCombinedAnnotator";
+import { SparkdownDocumentRegistry } from "../../compiler/classes/SparkdownDocumentRegistry";
+
+const URI = "inmemory:///main.sd";
+
+// The language server's set, plus the two object-valued annotators that also
+// emit non-node-anchored ranges.
+const ANNOTATE: (keyof SparkdownAnnotators)[] = [
+  "characters",
+  "colors",
+  "declarations",
+  "formatting",
+  "links",
+  "lenses",
+  "references",
+  "semantics",
+  "validations",
+  "implicits",
+];
+
+let nextVersion = 2;
+
+function posAt(text: string, offset: number) {
+  let line = 0;
+  let lineStart = 0;
+  for (let i = 0; i < offset; i++) {
+    if (text[i] === "\n") {
+      line++;
+      lineStart = i + 1;
+    }
+  }
+  return { line, character: offset - lineStart };
+}
+
+function open(text: string) {
+  const registry = new SparkdownDocumentRegistry(ANNOTATE);
+  registry.add({
+    textDocument: { uri: URI, text, version: 1, languageId: "sparkdown" },
+  });
+  return registry;
+}
+
+/** The span the parser actually re-tokenized, or null on a full reparse. */
+function reparsedSpan(registry: SparkdownDocumentRegistry) {
+  const cached: any = registry.tree(URI)?.prop(cachedCompilerProp as any);
+  if (!cached || cached.reparsedFrom == null) {
+    return null;
+  }
+  return {
+    from: cached.reparsedFrom as number,
+    to: cached.reparsedTo as number,
+  };
+}
+
+/** Every annotation in every set, as comparable strings. */
+function snapshot(registry: SparkdownDocumentRegistry) {
+  const annotations = registry.annotations(URI) as Record<string, any>;
+  const out: string[] = [];
+  for (const key of ANNOTATE) {
+    const iter = annotations[key]!.iter(0);
+    while (iter.value) {
+      let value: string;
+      try {
+        value = JSON.stringify(iter.value.type) ?? "undefined";
+      } catch {
+        value = "<unserializable>";
+      }
+      out.push(`${key} ${iter.from}-${iter.to} ${value}`);
+      iter.next();
+    }
+  }
+  return out;
+}
+
+/** Multiset difference, so a duplicate counts as a difference. */
+function diff(incremental: string[], cold: string[]) {
+  const tally = (xs: string[]) => {
+    const m = new Map<string, number>();
+    for (const x of xs) m.set(x, (m.get(x) ?? 0) + 1);
+    return m;
+  };
+  const inc = tally(incremental);
+  const col = tally(cold);
+  const missing: string[] = [];
+  const extra: string[] = [];
+  for (const [k, n] of col) {
+    for (let i = 0; i < n - (inc.get(k) ?? 0); i++) missing.push(k);
+  }
+  for (const [k, n] of inc) {
+    for (let i = 0; i < n - (col.get(k) ?? 0); i++) extra.push(k);
+  }
+  return { missing, extra };
+}
+
+/**
+ * A script with the shapes that break window-local annotator state:
+ * a top-level `store` referenced from prose far below it, prose scenes whose
+ * interpolations resolve against it, and large top-level `function` blocks
+ * whose bodies reference their own earlier `local`s.
+ */
+function fixture() {
+  const L: string[] = [];
+  L.push("title: Parity Fixture");
+  L.push("author: Anonymous");
+  L.push("");
+  L.push("store trust = 0");
+  L.push("");
+  for (let s = 0; s < 4; s++) {
+    // Parameterised scenes matter: the grammar nests `LuauFunctionParameter`
+    // under the (non-Luau) `Scene` node, and that parameter binds into the
+    // enclosing scope. A prefix walk that skips non-Luau subtrees drops it.
+    L.push(`scene scene_${s}(companion_${s})`);
+    L.push(`= INT. ROOM ${s} - DAY`);
+    L.push(":");
+    L.push(`  Action describing room ${s} in careful detail here.`);
+    L.push(`hero:`);
+    L.push(
+      `  Line one in scene ${s} with {trust} and {companion_${s}} inline.`,
+    );
+    L.push("end");
+    L.push("");
+  }
+  for (let b = 0; b < 2; b++) {
+    L.push(`function pad_${b}()`);
+    for (let i = 0; i < 40; i++) {
+      L.push(`  local pad_${b}_${i} = ${i} + 1`);
+    }
+    L.push(`  local r_${b} = pad_${b}_1 + pad_${b}_2`);
+    L.push(`  return r_${b}`);
+    L.push("end");
+    L.push("");
+  }
+  return L.join("\n");
+}
+
+// Deterministic LCG — vitest forbids nothing here, but a seeded generator keeps
+// a failure reproducible from the seed alone.
+function rng(seed: number) {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+}
+
+/** Offsets where inserting one character is binding-preserving. */
+function safeEditOffsets(text: string) {
+  const offsets: number[] = [];
+  // Extend a prose word (changes text, binds nothing).
+  for (const m of text.matchAll(
+    /\b(?:describing|careful|detail|Action|Line)\b/g,
+  )) {
+    offsets.push(m.index! + m[0].length);
+  }
+  // Widen the gap before an arithmetic operator inside a function body.
+  for (const m of text.matchAll(/ \+ /g)) {
+    offsets.push(m.index! + 1);
+  }
+  return offsets;
+}
+
+function runBurst(seed: number, steps: number) {
+  let text = fixture();
+  const incremental = open(text);
+  const random = rng(seed);
+  let sawNarrowWindow = false;
+
+  for (let step = 0; step < steps; step++) {
+    const offsets = safeEditOffsets(text);
+    expect(offsets.length).toBeGreaterThan(0);
+    const offset = offsets[Math.floor(random() * offsets.length)]!;
+    const at = posAt(text, offset);
+    // A space before `+` stays a space; a letter after a prose word extends it.
+    const inserted = text[offset] === "+" ? " " : "z";
+    incremental.update({
+      textDocument: { uri: URI, version: nextVersion++ },
+      contentChanges: [{ range: { start: at, end: at }, text: inserted }],
+    });
+    text = text.slice(0, offset) + inserted + text.slice(offset);
+
+    const cold = open(text);
+    expect(
+      incremental.tree(URI)!.toString() === cold.tree(URI)!.toString(),
+      `step ${step} (seed ${seed}): parse trees diverged, so this is a parser difference, not an annotator one`,
+    ).toBe(true);
+
+    const incrementalSnapshot = snapshot(incremental);
+    const coldSnapshot = snapshot(cold);
+    // Multiset first: it names exactly which annotations drifted.
+    const { missing, extra } = diff(incrementalSnapshot, coldSnapshot);
+    expect(
+      { missing, extra },
+      `step ${step} (seed ${seed}) edit at ${offset}`,
+    ).toEqual({ missing: [], extra: [] });
+    // Then ORDER. Zero-width marks share offsets (`top_level_begin` and
+    // `indent` both sit at a block's first column) and the formatter consumes
+    // them in order, so a reconciliation that deletes and re-adds an
+    // annotation instead of keeping it would silently permute them — which a
+    // multiset comparison cannot see.
+    expect(
+      incrementalSnapshot,
+      `step ${step} (seed ${seed}): annotation ORDER diverged`,
+    ).toEqual(coldSnapshot);
+
+    // Non-vacuity: at least one update must have re-annotated a window that
+    // does not start at 0, or none of this exercises the incremental path.
+    const span = reparsedSpan(incremental);
+    if (span && Math.min(span.from, offset) > 0) {
+      sawNarrowWindow = true;
+    }
+  }
+  expect(
+    sawNarrowWindow,
+    `seed ${seed}: every update rebuilt from offset 0, so the incremental path was never exercised`,
+  ).toBe(true);
+}
+
+describe("incremental annotation parity", () => {
+  it("matches a cold parse across a burst of edits (seed 555)", () => {
+    runBurst(555, 25);
+  });
+
+  it("matches a cold parse across a burst of edits (seed 12345)", () => {
+    runBurst(12345, 25);
+  });
+
+  it("keeps resolving bindings declared before the window", () => {
+    // The narrow case behind most of the loss: the window opens inside a
+    // scene body, so both the `store trust = 0` that binds `{trust}` and the
+    // scene's own `(companion_3)` parameter are entirely behind it.
+    let text = fixture();
+    const incremental = open(text);
+    const storeAt = text.indexOf("store trust = 0");
+    const sceneAt = text.indexOf("scene scene_3(");
+    const offset = text.indexOf("careful detail", sceneAt);
+    expect(sceneAt).toBeGreaterThan(storeAt);
+    expect(offset).toBeGreaterThan(sceneAt);
+
+    for (let i = 0; i < 6; i++) {
+      const at = posAt(text, offset);
+      incremental.update({
+        textDocument: { uri: URI, version: nextVersion++ },
+        contentChanges: [{ range: { start: at, end: at }, text: "z" }],
+      });
+      text = text.slice(0, offset) + "z" + text.slice(offset);
+    }
+
+    // Non-vacuity: the window must actually open past the `store`, or the
+    // binding is inside it and nothing here is being tested. Read from the
+    // tree's own recorded reparse span, so a change in the parser's chunking
+    // turns this red rather than hollow. (The window lands at the scene
+    // declaration, so the parameter case is covered by the bursts above,
+    // whose windows land inside scene bodies.)
+    const span = reparsedSpan(incremental);
+    expect(
+      span,
+      "reparse must be incremental, not a full rebuild",
+    ).not.toBeNull();
+    expect(
+      Math.min(span!.from, offset),
+      "window must open after the `store` declaration",
+    ).toBeGreaterThan(text.indexOf("store trust = 0"));
+
+    const named = (registry: SparkdownDocumentRegistry, name: string) =>
+      snapshot(registry).filter((entry) => {
+        const m = /^semantics (\d+)-(\d+) /.exec(entry);
+        return m && text.slice(Number(m[1]), Number(m[2])) === name;
+      });
+
+    // Every `{trust}` interpolation plus the declaration itself.
+    expect(named(incremental, "trust").length).toBe(5);
+    expect(named(incremental, "trust")).toEqual(named(open(text), "trust"));
+    // The scene parameter binds under a non-Luau `Scene` node.
+    expect(named(incremental, "companion_3").length).toBeGreaterThan(0);
+    expect(named(incremental, "companion_3")).toEqual(
+      named(open(text), "companion_3"),
+    );
+  });
+});


### PR DESCRIPTION
Addresses the **loss** half of #326. Leaves the stale-after-rename half open (now with a repro — see below).

> **This carries a ~3.3× per-keystroke cost inside large top-level Luau blocks.** That is the headline trade — details under *Cost*.
>
> **Followed up in #347**, which removes that cost with two caches and brings it back to no measurable regression.

## What broke

`SparkdownCombinedAnnotator.update` re-annotates only `[editStart, reparsedTo]` and deletes whatever that window overlaps. That reconciles only if re-running the annotators over the window reproduces what a cold parse would put there.

`SemanticAnnotator` does not. `begin()` resets `scopeStack` to the global frame, so a window opening inside a function body has neither the document's top-level declarations nor that body's earlier `local`s bound. `lookupBinding` returns null, no token is emitted — and the old tokens *were* inside the window, so the filter already deleted them. They stay gone until a cold parse.

Measured with a seeded incremental-vs-cold differential (40 edits × 2 seeds, full `(from, to, value)` comparison across 10 annotator sets, `ofWhichTreeAlsoDiverged=0` so the parse trees are identical and this is genuinely annotator state):

| | seed 555 | seed 12345 |
| --- | --- | --- |
| before | 35/40 steps diverged | 28/40 |
| after | **0/40** | **0/40** |

## The fix

**`SemanticAnnotator.primeScopes`** replays this annotator's own `enter`/`leave` over the prefix, discarding the annotations, to rebuild the state a cold pass would hold at the window. Replaying rather than reimplementing keeps one set of binding rules. Two details make it faithful:

- `leave` is suppressed for nodes still open at the window — a cold pass has not left them, and popping their frames would discard exactly the enclosing-function bindings we came for.
- The body of a function that *closed* before the window is skipped: its name is already bound in the enclosing scope and everything inside dies with the frame `leave` pops. Only while `pendingDeclKind === null`, though — that flag is not scope-stack state, so it survives the pop and would bind spuriously in `local a = function() local g = 1 end, b = 2`.

**`pruneRedundant`** now matches on the *serialized* payload instead of `===`. Most annotators allocate a fresh object per pass, so the reference comparison silently never matched, leaving `semantics`, `references` and `validations` accumulating a duplicate per keystroke — the #322 shape, still live for them.

## Two approaches tried and rejected, with numbers

- **Widening the window to whole top-level nodes.** Correct, and it gives every annotator the state a cold parse has at the boundary. Rejected at **7×** the per-keystroke cost (13.9 → 97.2 ms on a 21 KB script), because it re-annotates the whole block on every keystroke.
- **Skipping non-`Luau*` subtrees during the replay.** Cut the cost from 2.0× to 1.4×, and was **wrong**: the grammar nests `LuauFunctionParameter` under a `Scene` node, so `scene deal(count)` lost every token for `count` — the exact defect this PR exists to fix. Caught in review; the fixture now uses parameterised scenes, and restoring the skip turns 2 of the 3 parity tests red.

## Regression test

`packages/sparkdown/src/tests/compiler/incrementalAnnotationParity.test.ts` — 3 tests, host-level (`SparkdownDocumentRegistry` with the LSP's annotate set plus `references`/`validations`/`implicits`).

Edits are **binding-preserving by construction**, and that is load-bearing: inserting at an arbitrary offset lands inside keywords and numbers (`end` → `endx`), degrades the parse, and then cold and incremental legitimately disagree — the oracle stops being an oracle. I hit exactly that early on and spent a while chasing "extras" that were my harness, not the code.

The oracle checks, in order: parse trees identical (so a failure points at the right subsystem), then the multiset diff (which names what drifted), then the **ordered** snapshot — zero-width marks share offsets and the formatter consumes them in order, which a multiset cannot see. Plus a non-vacuity guard that fails if no update ever produced a narrow window.

**Red/green:** all 3 fail on the pre-fix source with concrete missing `semantics` tokens; all 3 pass after.

## Suite results

- `packages/sparkdown` compiler + runtime + incremental: **80 files (78 passed, 2 skipped) / 1032 tests (1008 passed, 24 skipped)**.
- `packages/sparkdown-language-server`: 2 pre-existing failures in `deltaFormatEquivalence.test.ts > screen element (bad attr spacing)`, confirmed identical on `origin/main` in the previous PR. Both formatter harnesses go through `annotators.create()` → the full-rebuild branch, which this diff does not touch.

## Cost

Medians of three interleaved runs, one candidate per process (run-to-run variance on this machine is large; the in-prose control is there to catch drift):

| | this PR | main | |
| --- | --- | --- | --- |
| edit inside a 300-line top-level block | 13.7 ms | 4.2 ms | **~3.3×** |
| edit in prose (control) | 4.6 ms | 3.7 ms | 1.25× |

Priming walks the prefix on every annotate call, and `SparkdownDocumentRegistry.updateSyntaxTree` applies content changes one at a time, so a `didChange` with N changes primes N times. Bounding this properly needs a cached global symbol table invalidated only on declaration edits — done in **#347**.

Worth knowing: **no benchmark in the repo exercises `SemanticAnnotator` at all** — `SparkdownCompiler`'s annotate set excludes `semantics`, so `perfProfile.test.ts` never runs `begin()`. These numbers come from a scratch harness driving `SparkdownDocumentRegistry` with the LSP's set.

## Live verification

Same-origin dev servers, 30 real keystroke cycles inside a top-level `function` block driven as genuine contenteditable input. Editor and preview both correct afterwards, document restored byte-for-byte, highlighting intact.

I could **not** demonstrate a visible improvement in the editor: patched and unpatched screenshots of the same state are identical. The on-screen colouring for these identifiers appears to be TextMate-driven rather than LSP-semantic-token-driven, so the loss this fixes is not what those pixels show. The gain is proven at the unit level, not visually.

## Still open

Renaming a declaration leaves stale tokens on its downstream references — they sit outside the window and are never re-examined. Minimal repro, added to #326:

```
step: edit renames the declaration  →  local r_1x = pad_1_1 + pad_1_2
  cold = []          ← `return r_1` is now unbound, correctly no token
  inc  = ["r_1"]     ← stale token survives
```

Pre-existing, not introduced here. Needs symbol→reference dependency tracking.

## Review findings not acted on

- A claimed scope-frame double-push leak (priming pushes a frame for an open function, the real pass pushes another). I built the exact scenario described and it did not reproduce; reporting it as unconfirmed rather than silently dropping it.
- The new test duplicates some coverage with `incrementalAnnotationStability.test.ts` (#322's test) in the same directory. Kept separate: that file pins *duplication under a null edit sequence*, this one pins *parity against cold under real content change*. Merging them would blur two different properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
