### PR TITLE
docs(skills): stop /resolve-issue telling you to `git stash`

### DIFF
--- a/.claude/skills/resolve-issue/SKILL.md
+++ b/.claude/skills/resolve-issue/SKILL.md
@@ -303,20 +303,44 @@ several matching layers and asserts all of them come back.
 **5b — prove the test is honest.** A regression test that passes against the
 *old* code pins nothing.
 
+**Never use `git stash` for this.** The stash stack is per-**repo**, not
+per-worktree, and this checkout has ~17 live worktrees with other sessions
+running concurrently. A `git stash pop` takes whatever is at `stash@{0}` *at
+that moment* — which may be another session's WIP pushed between your push and
+your pop. That lands their work in your tree and leaves your fix on the stack.
+
+Copy the file aside instead, revert it, and copy it back:
+
 ```bash
-git stash push -- <the source file(s) you changed>
+cp packages/sparkdown/src/compiler/utils/filterImage.ts "$SCRATCH/fix.ts"
+git checkout -- packages/sparkdown/src/compiler/utils/filterImage.ts
 ```
 
 Re-run the new test — it **must fail**, and fail for the reason in the ticket,
-not on an import error or a typo. Then restore:
+not on an import error or a typo. Then restore **from the copy**:
 
 ```bash
-git stash pop
+cp "$SCRATCH/fix.ts" packages/sparkdown/src/compiler/utils/filterImage.ts
 ```
 
-Re-run — it must pass. Record both outcomes for the PR body. (If your fix spans
-files that are awkward to stash, revert the single key line by hand instead;
-the point is seeing red, not the mechanism.)
+`git checkout --` reverts to HEAD, so it restores the *pre-fix* file — using it
+to undo the revert silently throws the fix away. **Confirm the restore landed
+before trusting anything downstream:**
+
+```bash
+git diff --stat
+```
+
+The file must still be listed. A test that passed alone and then fails in the
+full suite is usually this, not a flake — check the diff before blaming timing.
+
+Re-run — it must pass. Record both outcomes for the PR body.
+
+Where a whole-file revert would break the test's imports (the fix adds an export
+the test uses), simulate the old behaviour in place instead: disable the one
+branch that matters, or restore the old function body under the new name. Keep a
+**positive control** in the file — an assertion that passes both before and
+after — so a red run proves the defect, not a broken harness.
 
 **5c — run the suite.** Start with the file, widen to the package.
 
@@ -618,6 +642,7 @@ Things that look like they work and don't:
 | `verify` returns `preview.installed: false` | `window.__preview` only exists in same-origin mode. Don't pass `--cross-origin`. |
 | Game Preview pane is blank **white**; `gameMounted: false` | The `#game` scaffold never mounted after a server restart. `down`, `up`, retry. Discard the screenshot. |
 | Scrub lands on the wrong beat; `scrubWarning` set | The target line isn't a playable beat — pick the indented dialogue/action line, not the `NAME:` line, a heading, or a blank line. |
+| `verify` dies with `Timeout 90000ms exceeded` waiting for `.cm-content` | The machine is saturated — usually a vitest suite running in this or another worktree. The server is fine (`status` says UP, the URL returns 200). Wait for the suite and re-run; don't go hunting for a regression. |
 | vitest exits 0 with no `Test Files` / `Tests` summary | An OOM'd worker was killed by the OS. Not a pass. Lower `maxForks`, split the suite. |
 | `minThreads and maxThreads must not conflict` | You passed `maxForks` without `minForks`. Always pass both. |
 | `npm install` dies `ENOSPC`; or `npx esbuild --version` / `npx vitest --version` fails to spawn (`EFTYPE`) | Disk was full; `node_modules` is silently corrupt (truncated binaries, empty dirs). `npm cache clean --force`, prune `%LOCALAPPDATA%\Temp`, delete **all** `node_modules` (root + every workspace — nested ones die with the parent), reinstall **once**. Piecemeal repair is whack-a-mole. |


### PR DESCRIPTION
Three guardrails for `/resolve-issue`, all from failures the skill's own
instructions caused or failed to catch while resolving #321, #331 and #332.

## 1. §5b told you to `git stash` — it now tells you not to

The red/green step said `git stash push` the fix, run the test, `git stash pop`.
The stash stack is per-**repo**, not per-worktree, and this checkout has ~17 live
worktrees with concurrent sessions. The pop takes whatever reached `stash@{0}`
in the meantime.

It happened: a `fix/302-filterimage-layers` session stashed a `UIModule.ts`
change between the push and the pop, so the pop landed *their* work in the
`fix/332` tree and dropped it from the stack, while the intended fix stayed
stashed. Recovery needed `git stash store` with the sha from the
`Dropped refs/stash@{0} (<sha>)` line.

Replaced with copy-aside / `git checkout --` / copy-back.

## 2. `git checkout --` restores the *pre-fix* file

The natural way to undo the revert is another `git checkout --`, which reverts
to HEAD and silently discards the fix. That happened too, and the resulting
suite failure got misread as a flake — a test that passed in isolation and
failed in the full suite.

§5b now says to confirm with `git diff --stat` that the file is still listed,
and names that exact symptom so the next reader checks the diff before blaming
timing.

## 3. A whole-file revert sometimes can't produce an honest red

When the fix adds an export the new test imports, reverting the file fails on an
import error rather than the defect. §5b now says to simulate the old behaviour
in place and keep a **positive control** — an assertion that passes both before
and after — so a red run proves the defect and not a broken harness.

## Troubleshooting row

`verify` timing out on `.cm-content` while a vitest suite saturates the machine.
The server is fine (`status` says UP, the URL returns 200); wait and retry
instead of hunting for a regression.

No behavioural change to the driver — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
