### PR TITLE
perf(compiler): dispatch the cross-flow fingerprint with monomorphic instanceof

### DIFF
--- a/packages/sparkdown/src/inkjs/engine/JsonSerialisation.ts
+++ b/packages/sparkdown/src/inkjs/engine/JsonSerialisation.ts
@@ -644,9 +644,16 @@ export class JsonSerialisation {
   // pre-order stream is anchored: a remote edit that moves a non-zero `#f` from
   // one container to another must change the string, which requires every
   // container to contribute a token.
+  //
+  // Dispatch is written as direct `instanceof` rather than `asOrNull`, and the
+  // contributing types are tested before the fall-through. The walk visits
+  // EVERY object in every flow on every compile, and the common case — string
+  // and control content, which contributes nothing — has to fail every test,
+  // so the per-object constant is the whole cost. `asOrNull` adds two calls per
+  // test on top of the same `instanceof`.
   private static fingerprintCrossFlowInto(obj: InkObject, out: string[]): void {
-    const container = asOrNull(obj, Container);
-    if (container) {
+    if (obj instanceof Container) {
+      const container = obj;
       out.push("f" + container.countFlags);
       const content = container.content;
       for (let i = 0; i < content.length; i++) {
@@ -660,8 +667,8 @@ export class JsonSerialisation {
       }
       return;
     }
-    const divert = asOrNull(obj, Divert);
-    if (divert) {
+    if (obj instanceof Divert) {
+      const divert = obj;
       const target = divert.hasVariableTarget
         ? divert.variableDivertName
         : divert.targetPathString;
@@ -674,8 +681,8 @@ export class JsonSerialisation {
     // read-count depends on whether the named flow exists — a CROSS-FLOW fact: a
     // remote edit that adds/removes/renames a scene flips this reference's form
     // even though the referencing flow's own source is unchanged.
-    const varRef = asOrNull(obj, VariableReference);
-    if (varRef) {
+    if (obj instanceof VariableReference) {
+      const varRef = obj;
       const cnt = varRef.pathStringForCount;
       if (cnt != null) {
         out.push("rC" + cnt.length + ":" + cnt);
@@ -687,22 +694,20 @@ export class JsonSerialisation {
     }
     // Resolved divert-target value (`{^->: path}`) and choice target path are
     // also resolved cross-flow.
-    const divTargetVal = asOrNull(obj, DivertTargetValue);
-    if (divTargetVal) {
-      const p = divTargetVal.value?.componentsString ?? "";
+    if (obj instanceof DivertTargetValue) {
+      const p = obj.value?.componentsString ?? "";
       out.push("T" + p.length + ":" + p);
       return;
     }
-    const choicePoint = asOrNull(obj, ChoicePoint);
-    if (choicePoint) {
+    if (obj instanceof ChoicePoint) {
+      const choicePoint = obj;
       const p = choicePoint.pathStringOnChoice ?? "";
       out.push("P" + p.length + ":" + p + ":" + choicePoint.flags);
       return;
     }
-    const varPtrVal = asOrNull(obj, VariablePointerValue);
-    if (varPtrVal) {
-      const p = varPtrVal.value ?? "";
-      out.push("p" + p.length + ":" + p + ":" + varPtrVal.contextIndex);
+    if (obj instanceof VariablePointerValue) {
+      const p = obj.value ?? "";
+      out.push("p" + p.length + ":" + p + ":" + obj.contextIndex);
       return;
     }
     // Pure-content object (string/value/control/glue/...): part of the flow's OWN


### PR DESCRIPTION
One file, one idea, and it lands on the **default JSON path** — no binary format involved. Split out of the #314 branch, where it was found.

## What

`JsonSerialisation.FingerprintCrossFlow` is how the incremental `ToJson` memo decides a top-level flow's cached serialization is still valid. It walks **every object in every flow on every compile**, and the common case — string and control content, which contributes nothing to the fingerprint — has to **fail every type test** before returning. So the per-object dispatch constant is essentially the entire cost.

Every test went through `asOrNull(obj, Type)`, whose `obj instanceof type` takes the constructor as a **parameter**. V8 can't specialize that the way it does a monomorphic `obj instanceof Container`, and it adds a second call for the assertion on every hit.

Same tests, same order, same emitted string. Only the dispatch changed.

## Measured

Raffles-and-bunny, all 8 top-level flows, one candidate per process, both orderings:

| | ms/compile |
| --- | --- |
| before (`asOrNull`) | 29.51 / 15.27 |
| after (monomorphic `instanceof`) | 4.77 / 2.95 |

**3–5×.** The pairs are cold/warm within each run; the warm figures (2.95 vs 15.27) are the settled ones.

A/B was done by swapping the file, not by stashing — the stash stack is shared across this repo's worktrees.

## What is deliberately NOT changed

The fingerprint is still compared as a **full string, not a hash**. That is load-bearing and documented upstream: injectivity is what makes "unchanged fingerprint" mean "unchanged cross-flow bytes". Weakening it to a hash would trade a correctness guarantee for speed, with **stale bytecode** as the failure mode — the worst kind of bug this cache can produce. Not worth it for a walk that is now ~3 ms.

## Verification

Sparkdown compiler + incremental suites: **39 files / 714 tests**, green.

The one that matters is the randomized **incremental-equivalence oracle** — it exists to catch exactly a fingerprint that stopped detecting cross-flow drift, which is how this change would fail if the reordering or the inlining were wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
