### PR TITLE
perf(compiler): stop serializing bytecode the editor never reads (#345)

### DIFF
--- a/impower-dev/src/modules/spark-editor/workspace/WorkspaceLanguageServer.ts
+++ b/impower-dev/src/modules/spark-editor/workspace/WorkspaceLanguageServer.ts
@@ -287,6 +287,12 @@ export default class WorkspaceLanguageServer {
         // the inlined SVG source that dominated its payload. LS previews
         // re-source it lazily from watched files.
         stripImageData: true,
+        // Nothing on this path reads the bytecode: the relay above is slim
+        // (uri/scripts/files/version) and the player runs its own compiler.
+        // Serializing it cost ~25-30ms per keystroke on a large project purely
+        // to be discarded (#345). ExportRuntime still runs, so diagnostics and
+        // pathLocations are unaffected.
+        emitCompiledProgram: false,
       },
       workspaceFolders: [
         {

--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -44,7 +44,10 @@ import { InkObject } from "../../inkjs/engine/Object";
 import { SimpleJson } from "../../inkjs/engine/SimpleJson";
 import { JsonSerialisation } from "../../inkjs/engine/JsonSerialisation";
 import { Story as RuntimeStory } from "../../inkjs/engine/Story";
-import { asINamedContentOrNull, asOrNull } from "../../inkjs/engine/TypeAssertion";
+import {
+  asINamedContentOrNull,
+  asOrNull,
+} from "../../inkjs/engine/TypeAssertion";
 import { Container } from "../../inkjs/engine/Container";
 import { StringValue } from "../../inkjs/engine/Value";
 import { VariableAssignment } from "../../inkjs/engine/VariableAssignment";
@@ -434,6 +437,16 @@ export class SparkdownCompiler {
       this._config.stripImageData = config.stripImageData;
     }
     if (
+      config.emitCompiledProgram !== undefined &&
+      config.emitCompiledProgram !== this._config.emitCompiledProgram
+    ) {
+      this._config.emitCompiledProgram = config.emitCompiledProgram;
+      // The incremental ToJson cache is only maintained while serializing, so
+      // it goes stale the moment emission is off. Drop it rather than let a
+      // later re-enable serve subtrees from a compile that never ran.
+      this._flowJsonCache = undefined;
+    }
+    if (
       config.workspace !== undefined &&
       config.workspace !== this._config.workspace
     ) {
@@ -750,7 +763,10 @@ export class SparkdownCompiler {
     this._flowReuseDisabled = this._disableFlowReuseNextCompile;
     this._disableFlowReuseNextCompile = false;
     const reuseCountAllVisits = !!params.countAllVisits;
-    if (reuseCountAllVisits || reuseCountAllVisits !== this._lastReuseCountAllVisits) {
+    if (
+      reuseCountAllVisits ||
+      reuseCountAllVisits !== this._lastReuseCountAllVisits
+    ) {
       // countAllVisits changes what GENERATION bakes into every container
       // (count flags), which reuse skips. Only test harnesses set it.
       this._flowReuseDisabled = true;
@@ -819,7 +835,10 @@ export class SparkdownCompiler {
       // `_censusEntries`. Compared here (not per file) so includes can't
       // clobber each other's census.
       const censusKey = (this._censusEntries ?? []).sort().join("");
-      if (this._prevCensusKey !== undefined && this._prevCensusKey !== censusKey) {
+      if (
+        this._prevCensusKey !== undefined &&
+        this._prevCensusKey !== censusKey
+      ) {
         this._flowReuseDisabled = true;
       }
       this._prevCensusKey = censusKey;
@@ -888,76 +907,84 @@ export class SparkdownCompiler {
         this._disableFlowReuseNextCompile = true;
       }
       if (story) {
-        profile("start", this._profilerId, "ink/json", uri);
-        const writer = new SimpleJson.Writer();
-        // Incremental ToJson: reuse the serialized subtree of each top-level flow
-        // whose source content is unchanged AND whose cross-flow fingerprint
-        // (#f flags + resolved divert/reference paths) is unchanged. Content is
-        // covered by the chunk-unchanged signal; the fingerprint covers the
-        // cross-flow bits that change without the flow's own source changing.
-        const { reusable: reusableFlows, ok: flowReuseOk } =
-          this.computeFlowReuse(story);
-        if (this._renamedFlowNames) {
-          // A synthetic rename inside a flow changes its serialized bytes in
-          // ways the fingerprint can't see — its cached JSON must not be
-          // served (see the canonicalize step above).
-          for (const renamed of this._renamedFlowNames) {
-            reusableFlows.delete(renamed);
+        // #345: hosts that never read the bytecode skip SERIALIZATION only.
+        // Everything else in this block still has to run — `state.story`, and
+        // `populateAllLocations` below, which walks the runtime tree for
+        // `pathLocations` (the editor navigates source with those).
+        const emitCompiled = this._config.emitCompiledProgram !== false;
+        if (emitCompiled) {
+          profile("start", this._profilerId, "ink/json", uri);
+          const writer = new SimpleJson.Writer();
+          // Incremental ToJson: reuse the serialized subtree of each top-level flow
+          // whose source content is unchanged AND whose cross-flow fingerprint
+          // (#f flags + resolved divert/reference paths) is unchanged. Content is
+          // covered by the chunk-unchanged signal; the fingerprint covers the
+          // cross-flow bits that change without the flow's own source changing.
+          const { reusable: reusableFlows, ok: flowReuseOk } =
+            this.computeFlowReuse(story);
+          if (this._renamedFlowNames) {
+            // A synthetic rename inside a flow changes its serialized bytes in
+            // ways the fingerprint can't see — its cached JSON must not be
+            // served (see the canonicalize step above).
+            for (const renamed of this._renamedFlowNames) {
+              reusableFlows.delete(renamed);
+            }
           }
-        }
-        if (!flowReuseOk) {
-          // The global guard failed (a changed chunk sits before the first flow,
-          // so an inlined const may have shifted): no flow can be reused this
-          // compile. Take the exact baseline path — no fingerprinting, which
-          // would otherwise be pure overhead — and let the cache lapse so the
-          // next reuse-eligible edit reseeds from a fresh serialization.
-          story.ToJson(writer);
-          this._flowJsonCache = undefined;
-        } else {
-          const prevFlowCache = this._flowJsonCache;
-          const nextFlowCache = new Map<string, { fp: string; value: any }>();
-          const flowMemo = {
-            resolve: (
-              name: string,
-              container: Container,
-              serialize: () => any,
-            ) => {
-              // `global decl` is non-contiguous (scattered declarations) and
-              // cheap; always serialize it fresh, never cache.
-              //
-              // Canonical synthetic flows (`__synth_<n>`, see
-              // `canonicalizeSyntheticFlowNames`) are excluded because their
-              // names are POSITIONAL (document-order ordinals), so a name can
-              // rebind to a DIFFERENT flow when an edit adds/removes a
-              // synthetic earlier in the document — and the cross-flow
-              // fingerprint can't tell two same-shaped function knots apart
-              // (it deliberately records nothing for pure content, relying on
-              // chunk identity for structure, which name rebinding breaks).
-              // These are tiny function knots; serializing fresh is cheap.
-              if (name === "global decl" || CANONICAL_SYNTH_NAME.test(name)) {
-                return serialize();
-              }
-              const fp = JsonSerialisation.FingerprintCrossFlow(container);
-              let value: any;
-              if (reusableFlows.has(name) && prevFlowCache) {
-                const cached = prevFlowCache.get(name);
-                value = cached && cached.fp === fp ? cached.value : serialize();
-              } else {
-                value = serialize();
-              }
-              nextFlowCache.set(name, { fp, value });
-              return value;
-            },
-          };
-          story.ToJson(writer, flowMemo);
-          this._flowJsonCache = nextFlowCache;
-        }
-        const json = writer.toObject();
-        if (json) {
-          program.compiled = json;
+          if (!flowReuseOk) {
+            // The global guard failed (a changed chunk sits before the first flow,
+            // so an inlined const may have shifted): no flow can be reused this
+            // compile. Take the exact baseline path — no fingerprinting, which
+            // would otherwise be pure overhead — and let the cache lapse so the
+            // next reuse-eligible edit reseeds from a fresh serialization.
+            story.ToJson(writer);
+            this._flowJsonCache = undefined;
+          } else {
+            const prevFlowCache = this._flowJsonCache;
+            const nextFlowCache = new Map<string, { fp: string; value: any }>();
+            const flowMemo = {
+              resolve: (
+                name: string,
+                container: Container,
+                serialize: () => any,
+              ) => {
+                // `global decl` is non-contiguous (scattered declarations) and
+                // cheap; always serialize it fresh, never cache.
+                //
+                // Canonical synthetic flows (`__synth_<n>`, see
+                // `canonicalizeSyntheticFlowNames`) are excluded because their
+                // names are POSITIONAL (document-order ordinals), so a name can
+                // rebind to a DIFFERENT flow when an edit adds/removes a
+                // synthetic earlier in the document — and the cross-flow
+                // fingerprint can't tell two same-shaped function knots apart
+                // (it deliberately records nothing for pure content, relying on
+                // chunk identity for structure, which name rebinding breaks).
+                // These are tiny function knots; serializing fresh is cheap.
+                if (name === "global decl" || CANONICAL_SYNTH_NAME.test(name)) {
+                  return serialize();
+                }
+                const fp = JsonSerialisation.FingerprintCrossFlow(container);
+                let value: any;
+                if (reusableFlows.has(name) && prevFlowCache) {
+                  const cached = prevFlowCache.get(name);
+                  value =
+                    cached && cached.fp === fp ? cached.value : serialize();
+                } else {
+                  value = serialize();
+                }
+                nextFlowCache.set(name, { fp, value });
+                return value;
+              },
+            };
+            story.ToJson(writer, flowMemo);
+            this._flowJsonCache = nextFlowCache;
+          }
+          const json = writer.toObject();
+          if (json) {
+            program.compiled = json;
+          }
+          profile("end", this._profilerId, "ink/json", uri);
         }
         state.story = story;
-        profile("end", this._profilerId, "ink/json", uri);
         // Gather source-location maps in a single top-down walk of the
         // runtime tree (see `populateAllLocations`). Done AFTER `ToJson`
         // rather than as its `onWriteRuntimeObject` callback so the path of
@@ -1167,7 +1194,11 @@ export class SparkdownCompiler {
         if ("pathIdentifiers" in c && Array.isArray(c.pathIdentifiers)) {
           for (const p of c.pathIdentifiers) {
             if (p instanceof Identifier && p.debugMetadata) {
-              this.offsetDebugMetadata(p.debugMetadata, lineNumberOffset, version);
+              this.offsetDebugMetadata(
+                p.debugMetadata,
+                lineNumberOffset,
+                version,
+              );
               p.debugMetadata.fileName = fileName;
               p.debugMetadata.filePath = uri;
             }
@@ -1463,7 +1494,10 @@ export class SparkdownCompiler {
       // tell which flows' subtrees must be recomputed vs reused.
       const compiledBlock = rec.block as object;
       this._compilationIds?.add(compiledBlock);
-      if (this._prevCompilationIds && !this._prevCompilationIds.has(compiledBlock)) {
+      if (
+        this._prevCompilationIds &&
+        !this._prevCompilationIds.has(compiledBlock)
+      ) {
         const chunkStart = lineNumberOffset;
         const chunkEnd = document?.lineAt(rec.to) ?? chunkStart;
         this._changedChunkRanges?.push([chunkStart, chunkEnd]);
@@ -1598,7 +1632,8 @@ export class SparkdownCompiler {
             state.fileResolutionState.runStack ??= [];
             state.fileResolutionState.runStack.push(resolvedFilePath);
           }
-          let runStory: ReturnType<typeof this.parseIncrementally> | null = null;
+          let runStory: ReturnType<typeof this.parseIncrementally> | null =
+            null;
           try {
             runStory = this.parseIncrementally(
               virtualUri,
@@ -1663,143 +1698,143 @@ export class SparkdownCompiler {
           }
           this._chunkStampOffset.set(compiledBlock, lineNumberOffset);
         } else {
-        remapContent(content, lineNumberOffset);
-        this._chunkStampOffset.set(compiledBlock, lineNumberOffset);
-        const flow = content[0];
-        if (flow) {
-          if (flow instanceof Knot) {
-            // If the lowerer already populated a rootWeave with body content
-            // (e.g. function definitions whose body lives inside the same
-            // chunk), preserve it. Scene/Branch declarations leave _rootWeave
-            // unset so the staged-chunk pattern still creates an empty weave
-            // for subsequent body chunks to attach to.
-            const rootWeave = flow._rootWeave ?? new Weave([]);
-            rootWeave.debugMetadata = flow.debugMetadata;
-            const knot = new Knot(
-              flow.identifier!,
-              [],
-              flow.args ?? [],
-              flow.isFunction,
-            );
-            knot.debugMetadata = flow.debugMetadata;
-            knot._rootWeave = rootWeave;
-            knot.AddContent(rootWeave);
-            // Preserve nested subFlows that the lowerer attached (e.g.
-            // anonymous-function literals and nested named function
-            // definitions lower to `Function` subFlows so they live at
-            // their lexical position instead of hoisting to top-level).
-            // Re-add them as content so the runtime traversal sees them.
-            for (const [subName, subFlow] of flow._subFlowsByName) {
-              knot._subFlowsByName.set(subName, subFlow);
-              knot.AddContent(subFlow);
-            }
-            topLevelFlowBaseObjs.push(knot);
-            topLevelContent.push(knot);
-            currentRun = { flow: knot, contentChunks: [compiledBlock] };
-            this._nextFlowRuns?.set(compiledBlock, currentRun);
-          } else if (flow instanceof Stitch) {
-            const rootWeave = new Weave([]);
-            const stitch = new Stitch(
-              flow.identifier!,
-              [],
-              flow.args ?? [],
-              flow.isFunction,
-            );
-            stitch.debugMetadata = flow.debugMetadata;
-            stitch._rootWeave = rootWeave;
-            stitch.AddContent(rootWeave);
-            rootWeave.debugMetadata = flow.debugMetadata;
-            const last = topLevelContent.at(-1);
-            if (last instanceof Knot) {
-              if (stitch.identifier?.name) {
-                last.subFlowsByName.set(stitch.identifier?.name, stitch);
+          remapContent(content, lineNumberOffset);
+          this._chunkStampOffset.set(compiledBlock, lineNumberOffset);
+          const flow = content[0];
+          if (flow) {
+            if (flow instanceof Knot) {
+              // If the lowerer already populated a rootWeave with body content
+              // (e.g. function definitions whose body lives inside the same
+              // chunk), preserve it. Scene/Branch declarations leave _rootWeave
+              // unset so the staged-chunk pattern still creates an empty weave
+              // for subsequent body chunks to attach to.
+              const rootWeave = flow._rootWeave ?? new Weave([]);
+              rootWeave.debugMetadata = flow.debugMetadata;
+              const knot = new Knot(
+                flow.identifier!,
+                [],
+                flow.args ?? [],
+                flow.isFunction,
+              );
+              knot.debugMetadata = flow.debugMetadata;
+              knot._rootWeave = rootWeave;
+              knot.AddContent(rootWeave);
+              // Preserve nested subFlows that the lowerer attached (e.g.
+              // anonymous-function literals and nested named function
+              // definitions lower to `Function` subFlows so they live at
+              // their lexical position instead of hoisting to top-level).
+              // Re-add them as content so the runtime traversal sees them.
+              for (const [subName, subFlow] of flow._subFlowsByName) {
+                knot._subFlowsByName.set(subName, subFlow);
+                knot.AddContent(subFlow);
               }
-              if (
-                last.content.length === 1 &&
-                last.content[0] instanceof Weave &&
-                last.content[0].content.length === 0
-              ) {
-                // Remove empty internal weave, since we are not using it
-                last.content.pop();
-              }
-              last.AddContent(stitch);
-              currentRun?.contentChunks.push(compiledBlock);
-            } else {
-              topLevelFlowBaseObjs.push(stitch);
-              topLevelContent.push(stitch);
-              currentRun = { flow: stitch, contentChunks: [compiledBlock] };
+              topLevelFlowBaseObjs.push(knot);
+              topLevelContent.push(knot);
+              currentRun = { flow: knot, contentChunks: [compiledBlock] };
               this._nextFlowRuns?.set(compiledBlock, currentRun);
-            }
-          } else if (flow instanceof ExternalDeclaration) {
-            const weave = new Weave([flow]);
-            topLevelWeaveObjs.push(weave);
-            topLevelContent.push(weave);
-            currentRun = undefined;
-          } else if (flow instanceof Weave) {
-            // This chunk's body weave is about to be UNWRAPPED — its children
-            // are re-parented directly under the closest existing weave (e.g.
-            // a scene's rootWeave) below. Children that carry no OWN debug
-            // metadata only have a source line by INHERITING this weave's; once
-            // re-parented they'd instead inherit the destination weave's line
-            // (the scene-header line), collapsing every body line of the scene
-            // onto that header — so the whole scene's pathLocations resolve to
-            // one line and its content becomes unpreviewable (action/montage
-            // scenes like TEASER lost ALL per-line locations; action lines in
-            // dialogue scenes routed to a later beat). Carry this weave's
-            // (already chunk-offset) metadata down onto its OWN-metadata-less
-            // children first, mirroring `appendBlockContent`. Must guard on
-            // `ownDebugMetadata` (NOT the inheriting `debugMetadata` getter,
-            // which returns this weave's value and would skip everything).
-            // Restrict the carry-down to DISPLAY leaves (Text / Tag) — the
-            // content that needs per-line `pathLocations`. Stamping other
-            // child types (e.g. VariableAssignment, scope/flow ControlCommands)
-            // would give them an own source line they didn't have, which
-            // perturbs declaration-collection and scope/collision analysis
-            // (block-scoped `local` shadowing, scene/function call
-            // restrictions) — a whitelist keeps the fix to its purpose.
-            if (flow.ownDebugMetadata) {
-              for (const child of flow.content) {
-                if (
-                  !child.ownDebugMetadata &&
-                  (child instanceof Text || child instanceof Tag)
-                ) {
-                  child.debugMetadata = flow.ownDebugMetadata;
+            } else if (flow instanceof Stitch) {
+              const rootWeave = new Weave([]);
+              const stitch = new Stitch(
+                flow.identifier!,
+                [],
+                flow.args ?? [],
+                flow.isFunction,
+              );
+              stitch.debugMetadata = flow.debugMetadata;
+              stitch._rootWeave = rootWeave;
+              stitch.AddContent(rootWeave);
+              rootWeave.debugMetadata = flow.debugMetadata;
+              const last = topLevelContent.at(-1);
+              if (last instanceof Knot) {
+                if (stitch.identifier?.name) {
+                  last.subFlowsByName.set(stitch.identifier?.name, stitch);
                 }
+                if (
+                  last.content.length === 1 &&
+                  last.content[0] instanceof Weave &&
+                  last.content[0].content.length === 0
+                ) {
+                  // Remove empty internal weave, since we are not using it
+                  last.content.pop();
+                }
+                last.AddContent(stitch);
+                currentRun?.contentChunks.push(compiledBlock);
+              } else {
+                topLevelFlowBaseObjs.push(stitch);
+                topLevelContent.push(stitch);
+                currentRun = { flow: stitch, contentChunks: [compiledBlock] };
+                this._nextFlowRuns?.set(compiledBlock, currentRun);
               }
-            }
-            // Statements with uuids are wrapped in a Statement container so they can be given a stable runtime path
-            const firstStatement = flow?.content[0];
-            const isWeavePoint =
-              firstStatement instanceof Choice ||
-              firstStatement instanceof Gather;
-            if (uuid && isWeavePoint) {
-              // Ensure choices and gathers use a stable name for their inner container
-              firstStatement.uuid = uuid;
-            }
-            const flowContent =
-              uuid && !isWeavePoint
-                ? [new Statement(uuid, flow.content)] // Wrap non-choice/gather statements in a stably named container
-                : flow.content;
-            const closestWeave = getClosestWeave(topLevelContent);
-            if (closestWeave) {
-              const lastContent = closestWeave.content.at(-1);
-              if (
-                lastContent instanceof Weave &&
-                lastContent.content.length === 0
-              ) {
-                // Remove empty internal weave, since we are not using it
-                closestWeave.content.pop();
-              }
-              closestWeave.AddContent(flowContent);
-              currentRun?.contentChunks.push(compiledBlock);
-            } else {
-              const weave = new Weave(flowContent);
+            } else if (flow instanceof ExternalDeclaration) {
+              const weave = new Weave([flow]);
               topLevelWeaveObjs.push(weave);
               topLevelContent.push(weave);
               currentRun = undefined;
+            } else if (flow instanceof Weave) {
+              // This chunk's body weave is about to be UNWRAPPED — its children
+              // are re-parented directly under the closest existing weave (e.g.
+              // a scene's rootWeave) below. Children that carry no OWN debug
+              // metadata only have a source line by INHERITING this weave's; once
+              // re-parented they'd instead inherit the destination weave's line
+              // (the scene-header line), collapsing every body line of the scene
+              // onto that header — so the whole scene's pathLocations resolve to
+              // one line and its content becomes unpreviewable (action/montage
+              // scenes like TEASER lost ALL per-line locations; action lines in
+              // dialogue scenes routed to a later beat). Carry this weave's
+              // (already chunk-offset) metadata down onto its OWN-metadata-less
+              // children first, mirroring `appendBlockContent`. Must guard on
+              // `ownDebugMetadata` (NOT the inheriting `debugMetadata` getter,
+              // which returns this weave's value and would skip everything).
+              // Restrict the carry-down to DISPLAY leaves (Text / Tag) — the
+              // content that needs per-line `pathLocations`. Stamping other
+              // child types (e.g. VariableAssignment, scope/flow ControlCommands)
+              // would give them an own source line they didn't have, which
+              // perturbs declaration-collection and scope/collision analysis
+              // (block-scoped `local` shadowing, scene/function call
+              // restrictions) — a whitelist keeps the fix to its purpose.
+              if (flow.ownDebugMetadata) {
+                for (const child of flow.content) {
+                  if (
+                    !child.ownDebugMetadata &&
+                    (child instanceof Text || child instanceof Tag)
+                  ) {
+                    child.debugMetadata = flow.ownDebugMetadata;
+                  }
+                }
+              }
+              // Statements with uuids are wrapped in a Statement container so they can be given a stable runtime path
+              const firstStatement = flow?.content[0];
+              const isWeavePoint =
+                firstStatement instanceof Choice ||
+                firstStatement instanceof Gather;
+              if (uuid && isWeavePoint) {
+                // Ensure choices and gathers use a stable name for their inner container
+                firstStatement.uuid = uuid;
+              }
+              const flowContent =
+                uuid && !isWeavePoint
+                  ? [new Statement(uuid, flow.content)] // Wrap non-choice/gather statements in a stably named container
+                  : flow.content;
+              const closestWeave = getClosestWeave(topLevelContent);
+              if (closestWeave) {
+                const lastContent = closestWeave.content.at(-1);
+                if (
+                  lastContent instanceof Weave &&
+                  lastContent.content.length === 0
+                ) {
+                  // Remove empty internal weave, since we are not using it
+                  closestWeave.content.pop();
+                }
+                closestWeave.AddContent(flowContent);
+                currentRun?.contentChunks.push(compiledBlock);
+              } else {
+                const weave = new Weave(flowContent);
+                topLevelWeaveObjs.push(weave);
+                topLevelContent.push(weave);
+                currentRun = undefined;
+              }
             }
           }
-        }
         }
       }
       if (context) {
@@ -2259,8 +2294,8 @@ export class SparkdownCompiler {
     // than the actual call site.
     const metadata =
       precomputedPath !== undefined
-        ? precomputedMetadata ?? null
-        : obj?.ownDebugMetadata ?? obj?.debugMetadata;
+        ? (precomputedMetadata ?? null)
+        : (obj?.ownDebugMetadata ?? obj?.debugMetadata);
     if (metadata) {
       const uri = metadata.filePath ?? program.uri;
       const scriptIndex =
@@ -2980,13 +3015,7 @@ export class SparkdownCompiler {
         const cur = annotations.declarations.iter();
         let scopePathParts: {
           kind:
-            | ""
-            | "function"
-            | "scene"
-            | "branch"
-            | "knot"
-            | "stitch"
-            | "label";
+            "" | "function" | "scene" | "branch" | "knot" | "stitch" | "label";
           name: string;
         }[] = [];
         if (cur) {

--- a/packages/sparkdown/src/compiler/types/SparkdownCompilerConfig.ts
+++ b/packages/sparkdown/src/compiler/types/SparkdownCompilerConfig.ts
@@ -15,6 +15,20 @@ export interface SparkdownCompilerConfig {
    * filtering depends on the inlined source.
    */
   stripImageData?: boolean;
+  /**
+   * Serialize the compiled program into `program.compiled` (#345).
+   *
+   * Defaults to on. Hosts that never read the bytecode turn it OFF: the
+   * language-server instance relays a slim projection that excludes `compiled`,
+   * so serializing it costs ~25-30ms per keystroke on a large project for data
+   * that is discarded, and the full program still rides the compile response
+   * across the worker boundary.
+   *
+   * Only SERIALIZATION is skipped. `ExportRuntime` still runs, because
+   * generation-time diagnostics come out of it and `populateAllLocations`
+   * walks the runtime tree for `pathLocations`.
+   */
+  emitCompiledProgram?: boolean;
   workspace?: string;
   startFrom?: { file: string; line: number };
   simulationOptions?: Record<

--- a/packages/sparkdown/src/tests/compiler/emitCompiledProgram.test.ts
+++ b/packages/sparkdown/src/tests/compiler/emitCompiledProgram.test.ts
@@ -1,0 +1,165 @@
+// Skipping bytecode serialization must change ONLY the bytecode (#345).
+//
+// `ExportRuntime` still runs when emission is off, because generation-time
+// diagnostics come out of it and `populateAllLocations` walks the runtime tree.
+// So the risk is not "does it go faster" — it is that skipping serialization
+// quietly changes something else the host DOES read. These tests pin the parts
+// that must be untouched.
+import "../../inkjs/engine/Container";
+import { describe, expect, it } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+
+const URI = "inmemory:///main.sd";
+
+function quiet<T>(fn: () => T): T {
+  const realWarn = console.warn;
+  const realError = console.error;
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    return fn();
+  } finally {
+    console.warn = realWarn;
+    console.error = realError;
+  }
+}
+
+function compile(text: string, emitCompiledProgram?: boolean) {
+  return quiet(() => {
+    const c = new SparkdownCompiler();
+    c.configure({
+      ...(emitCompiledProgram === undefined ? {} : { emitCompiledProgram }),
+      files: [
+        {
+          uri: URI,
+          type: "script",
+          name: "main",
+          ext: "sd",
+          text,
+          version: 1,
+          languageId: "sparkdown",
+        },
+      ],
+    } as never);
+    return (c.compile({ textDocument: { uri: URI } } as never) as any).program;
+  });
+}
+
+const SOURCE = [
+  "title: Emit Toggle",
+  "",
+  "define hero as character:",
+  `  name = "Hero"`,
+  "",
+  "const LIMIT = 3",
+  "store trust = 0",
+  "",
+  "scene one",
+  ":",
+  "  First beat with {trust} and {LIMIT}.",
+  "hero:",
+  "  A line of dialogue.",
+  "-> two",
+  "end",
+  "",
+  "scene two",
+  ":",
+  "  Second beat.",
+  "end",
+  "",
+].join("\n");
+
+/** A script with real diagnostics, so the diagnostic path is exercised too. */
+const BROKEN = [
+  "title: Broken",
+  "",
+  "-> nowhere_at_all",
+  "",
+].join("\n");
+
+describe("emitCompiledProgram (#345)", () => {
+  it("emits bytecode by default", () => {
+    expect(compile(SOURCE).compiled).toBeTruthy();
+    expect(compile(SOURCE, true).compiled).toBeTruthy();
+  });
+
+  it("omits bytecode when disabled", () => {
+    expect(compile(SOURCE, false).compiled).toBeUndefined();
+  });
+
+  it("leaves pathLocations identical", () => {
+    // The editor navigates source with these; if skipping serialization
+    // perturbed them, PageUp/PageDown would drift with no visible cause.
+    const on = compile(SOURCE, true);
+    const off = compile(SOURCE, false);
+    expect(JSON.stringify(off.pathLocations)).toBe(
+      JSON.stringify(on.pathLocations),
+    );
+    expect(Object.keys(off.pathLocations ?? {}).length).toBeGreaterThan(0);
+  });
+
+  it("leaves diagnostics identical, including generation-time ones", () => {
+    // Generation diagnostics come out of ExportRuntime, which still runs. This
+    // is the assertion that catches someone "optimizing" by skipping that too.
+    for (const source of [SOURCE, BROKEN]) {
+      const on = compile(source, true);
+      const off = compile(source, false);
+      expect(JSON.stringify(off.diagnostics ?? {})).toBe(
+        JSON.stringify(on.diagnostics ?? {}),
+      );
+    }
+    expect(
+      Object.values(compile(BROKEN, false).diagnostics ?? {}).flat().length,
+      "the broken fixture must actually produce diagnostics",
+    ).toBeGreaterThan(0);
+  });
+
+  it("leaves the rest of the program identical apart from `compiled`", () => {
+    const on = compile(SOURCE, true);
+    const off = compile(SOURCE, false);
+    const strip = (p: Record<string, unknown>) => {
+      const { compiled, ...rest } = p;
+      return Object.keys(rest).sort();
+    };
+    // Same shape: no field silently disappears alongside the bytecode.
+    expect(strip(off)).toEqual(strip(on));
+    for (const key of ["scripts", "files", "context"]) {
+      expect(JSON.stringify(off[key]), key).toBe(JSON.stringify(on[key]));
+    }
+  });
+
+  it("still emits after the option is toggled back on", () => {
+    // The incremental ToJson cache is not maintained while emission is off, so
+    // a re-enable must not serve subtrees from a compile that never ran.
+    const c = quiet(() => {
+      const compiler = new SparkdownCompiler();
+      compiler.configure({
+        emitCompiledProgram: false,
+        files: [
+          {
+            uri: URI,
+            type: "script",
+            name: "main",
+            ext: "sd",
+            text: SOURCE,
+            version: 1,
+            languageId: "sparkdown",
+          },
+        ],
+      } as never);
+      return compiler;
+    });
+    expect(
+      quiet(() => (c.compile({ textDocument: { uri: URI } } as never) as any))
+        .program.compiled,
+    ).toBeUndefined();
+
+    quiet(() => c.configure({ emitCompiledProgram: true } as never));
+    const after = quiet(
+      () => (c.compile({ textDocument: { uri: URI } } as never) as any).program,
+    );
+    expect(JSON.stringify(after.compiled)).toBe(
+      JSON.stringify(compile(SOURCE, true).compiled),
+    );
+  });
+});


### PR DESCRIPTION
Closes #345.

**Review with `git diff -w`.** The compiler diff is 445 lines but only **46 insertions / 17 deletions** ignoring whitespace — the rest is re-indentation from wrapping an existing block in a conditional.

## The waste

The language-server compiler instance serialized the compiled program on every keystroke and then relayed a projection that excludes it. Nothing on that path read it:

- the relay whitelists `uri`/`scripts`/`files`/`version` (`SparkdownWorkspace`, the `notificationParams` block);
- the LSP worker never constructs a `Story`;
- the player runs its **own** compiler instance.

Measured on raffles-and-bunny, one candidate per process:

| | `ink/json` | `pathLocations` | `compiled` |
| --- | --- | --- | --- |
| emit ON (today) | 27.4 / 27.6 ms | 12021 | yes |
| emit OFF (#345) | **not run** | 12021 | no |

~27 ms per keystroke, for data that was discarded.

## Only serialization is skipped

`ExportRuntime` still runs — generation-time diagnostics come out of it, and `populateAllLocations` walks the runtime tree for `pathLocations`, which is how the editor navigates source.

My first attempt skipped the whole `if (story)` block and silently dropped `pathLocations`. The equivalence test caught it immediately, which is the reason that test asserts on far more than the bytecode: an optimization here fails by making something *else* disappear, not by being wrong about the bytecode.

## vscode keeps emitting

Scoped to impower-dev deliberately. The vscode extension **does** consume the bytecode — `activateCompilationView.ts:99` reads `program?.compiled` to render its compilation view — so it keeps it.

That also resolves a stale comment #345 flagged: `SparkdownWorkspace.slimProgramNotifications` claims "the vscode extension consumes the full program from this notification", but `activateLanguageClient.ts:76` sets `slimProgramNotifications: true`. It gets the bytecode by another route, not from that notification.

## Verification

New `emitCompiledProgram` suite pins that turning emission off changes **only** the bytecode:

- `pathLocations` identical, and non-empty (a test that passed on two empty maps would prove nothing)
- diagnostics identical, including on a fixture that produces real generation-time diagnostics — and that fixture is asserted to actually produce some
- the program's field set is unchanged; `scripts`/`files`/`context` identical
- re-enabling mid-session yields bytecode byte-identical to a compile that never had it off (the incremental `ToJson` cache is dropped on the transition rather than left to serve subtrees from a compile that never ran)

Compiler + incremental suites: 40 files / 720 tests, green.

**Live in the running editor** — this changes the editor's own path, so vitest alone would not be enough:

- diagnostics still reach the status bar (**"2 Warnings"**)
- source navigation still resolves (**`main : 1`**)
- the game preview still renders — the player's compiler instance is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
