### PR TITLE
docs(resolve-issue): prefer a trusted click for scrubbing the preview

### DIFF
--- a/.claude/skills/resolve-issue/SKILL.md
+++ b/.claude/skills/resolve-issue/SKILL.md
@@ -630,6 +630,13 @@ Things that look like they work and don't:
   for.
 - **Re-dispatching the same cursor position produces no event.** To re-arm a
   scrub you must bounce to another line and back.
+- **A real (trusted) click on the target line is the most reliable scrub.**
+  `view.dispatch({selection})` moves the caret, but the preview can silently
+  fail to follow — the cursor sits on the line you asked for while `route`
+  stays on the old beat, and nothing raises. If the hold-check and the bounce
+  don't move the preview, scroll the line into view and `page.mouse.click()`
+  its coordinates (`view.coordsAtPos(line.from)` gives them); a trusted event
+  drives the real selection path.
 - **`textContent` on the game DOM returns a wall of CSS** — the player injects
   `<style>` blocks and every ancestor inherits their text. And the typewriter
   effect wraps **every character** in its own `<span>`, so "leaf nodes with


### PR DESCRIPTION
Adds one bullet to the resolve-issue skill's scrubbing gotchas.

## Why

The skill already documents that `view.dispatch({selection})` is fragile — the async cursor-restore clobber, the dropped first `selectionSet` on a cold origin, and the need to bounce to re-arm. `driver.mjs` compensates with a dispatch/re-read/re-dispatch loop and a hold-check across three reads.

What it doesn't mention is that a **trusted click** sidesteps the whole class. Hit while reproducing #344: a bare `view.dispatch` moved the caret to the target line and the preview never followed — the route indicator stayed on the old beat for 30s with nothing raised. Clicking the same line with `page.mouse.click()` moved the preview immediately and rendered the portrait being investigated.

The failure mode is the one the surrounding bullets exist to prevent: a verification run reports the line you asked for while the preview is showing something else — a confident false pass.

## What changed

One bullet, placed with the other scrubbing gotchas. No code change; `driver.mjs` keeps its current dispatch-based path.

Worth considering as a follow-up (not done here): have `driver.mjs` fall back to a click after its retry loop exhausts, instead of returning `cursor kept drifting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)