### PR TITLE
perf(compiler): serialize bytecode on demand, not per keystroke (#351)

### DIFF
--- a/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
+++ b/packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts
@@ -643,9 +643,161 @@ export class SparkdownCompiler {
     return params;
   }
 
+  /**
+   * Serialize the compiled program into `program`.
+   *
+   * Extracted so the no-change short-circuit can materialize bytecode
+   * LAZILY (#351): a host that normally suppresses emission can still ask
+   * for it per request, and the answer has to come from the retained
+   * runtime story rather than a full recompile.
+   */
+  protected serializeCompiledProgram(
+    story: RuntimeStory,
+    program: SparkProgram,
+    uri: string,
+  ): void {
+    profile("start", this._profilerId, "ink/json", uri);
+    // #314: the binary writer answers the SAME streaming write events as
+    // SimpleJson.Writer, but appends records instead of building a JS
+    // object tree — so on the no-memo path it does strictly less work.
+    const binary = this._config.binaryProgram === true;
+    const writer = binary
+      ? new ProgramBinaryWriter(this._binaryTable, this._binarySlotHint)
+      : new SimpleJson.Writer();
+    // Incremental ToJson: reuse the serialized subtree of each top-level flow
+    // whose source content is unchanged AND whose cross-flow fingerprint
+    // (#f flags + resolved divert/reference paths) is unchanged. Content is
+    // covered by the chunk-unchanged signal; the fingerprint covers the
+    // cross-flow bits that change without the flow's own source changing.
+    const { reusable: reusableFlows, ok: flowReuseOk } =
+      this.computeFlowReuse(story);
+    if (this._renamedFlowNames) {
+      // A synthetic rename inside a flow changes its serialized bytes in
+      // ways the fingerprint can't see — its cached JSON must not be
+      // served (see the canonicalize step above).
+      for (const renamed of this._renamedFlowNames) {
+        reusableFlows.delete(renamed);
+      }
+    }
+    if (!flowReuseOk) {
+      // The global guard failed (a changed chunk sits before the first flow,
+      // so an inlined const may have shifted): no flow can be reused this
+      // compile. Take the exact baseline path — no fingerprinting, which
+      // would otherwise be pure overhead — and let the cache lapse so the
+      // next reuse-eligible edit reseeds from a fresh serialization.
+      story.ToJson(writer as never);
+      this._flowJsonCache = undefined;
+      this._flowChunkCache = undefined;
+    } else if (binary) {
+      // Binary twin of the JSON memo below. The reuse GUARDS are shared —
+      // `reusableFlows` and the `_renamedFlowNames` subtraction are
+      // computed once above — so the two paths can never disagree about
+      // which flows are eligible, only about what a cached value is.
+      const binaryWriter = writer as ProgramBinaryWriter;
+      const prevChunkCache = this._flowChunkCache;
+      const nextChunkCache = new Map<string, CachedFlowChunk>();
+      const flowMemo = {
+        resolve: (name: string, container: Container, serialize: () => any) => {
+          // Same two exclusions as the JSON path, for the same reasons:
+          // `global decl` is non-contiguous and cheap, and canonical
+          // synthetic names are POSITIONAL, so a name can rebind to a
+          // different flow that the fingerprint cannot distinguish.
+          if (name === "global decl" || CANONICAL_SYNTH_NAME.test(name)) {
+            return serialize();
+          }
+          const fp = JsonSerialisation.FingerprintCrossFlow(container);
+          if (reusableFlows.has(name) && prevChunkCache) {
+            const cached = prevChunkCache.get(name);
+            // The generation check is what keeps a reseed sound. Returning
+            // a chunk here means NOT calling serialize(), so a chunk from
+            // an older numbering could not be recovered from downstream —
+            // the writer throws rather than guess, so the decision has to
+            // be made here.
+            if (
+              cached &&
+              cached.fp === fp &&
+              cached.chunk.generation === binaryWriter.generation
+            ) {
+              nextChunkCache.set(name, cached);
+              // `WriteInjected` splices the records; the flow is never
+              // re-walked and its strings are never re-hashed.
+              return cached.chunk;
+            }
+          }
+          // Miss: arm the writer to capture whatever gets injected next,
+          // because `resolve` returns BEFORE the caller injects it.
+          binaryWriter.captureNextInjectedAs(name, fp);
+          return serialize();
+        },
+      };
+      story.ToJson(binaryWriter as never, flowMemo);
+      for (const [name, entry] of binaryWriter.takeCapturedChunks()) {
+        nextChunkCache.set(name, entry);
+      }
+      this._flowChunkCache = nextChunkCache;
+    } else {
+      const prevFlowCache = this._flowJsonCache;
+      const nextFlowCache = new Map<string, { fp: string; value: any }>();
+      const flowMemo = {
+        resolve: (name: string, container: Container, serialize: () => any) => {
+          // `global decl` is non-contiguous (scattered declarations) and
+          // cheap; always serialize it fresh, never cache.
+          //
+          // Canonical synthetic flows (`__synth_<n>`, see
+          // `canonicalizeSyntheticFlowNames`) are excluded because their
+          // names are POSITIONAL (document-order ordinals), so a name can
+          // rebind to a DIFFERENT flow when an edit adds/removes a
+          // synthetic earlier in the document — and the cross-flow
+          // fingerprint can't tell two same-shaped function knots apart
+          // (it deliberately records nothing for pure content, relying on
+          // chunk identity for structure, which name rebinding breaks).
+          // These are tiny function knots; serializing fresh is cheap.
+          if (name === "global decl" || CANONICAL_SYNTH_NAME.test(name)) {
+            return serialize();
+          }
+          const fp = JsonSerialisation.FingerprintCrossFlow(container);
+          let value: any;
+          if (reusableFlows.has(name) && prevFlowCache) {
+            const cached = prevFlowCache.get(name);
+            value = cached && cached.fp === fp ? cached.value : serialize();
+          } else {
+            value = serialize();
+          }
+          nextFlowCache.set(name, { fp, value });
+          return value;
+        },
+      };
+      story.ToJson(writer, flowMemo);
+      this._flowJsonCache = nextFlowCache;
+    }
+    if (binary) {
+      // Pieces, not a packed blob: `nodes`/`numbers` are typed arrays that
+      // transfer in O(1) across a worker boundary, and packing them into
+      // one self-describing byte blob costs ~10ms/compile (it re-encodes
+      // the whole string table to UTF-8) for no benefit on that hop.
+      const buffer = (writer as ProgramBinaryWriter).toBuffer();
+      program.compiledBuffer = buffer;
+      this._binarySlotHint = buffer.nodes.length;
+      // Safe to run AFTER emitting: reseeding installs fresh arrays on the
+      // table rather than clearing them in place, so the buffer just
+      // emitted keeps its own (correct) string array alive.
+      this.maybeReseedBinaryTable();
+    } else {
+      const json = (writer as SimpleJson.Writer).toObject();
+      if (json) {
+        program.compiled = json;
+      }
+    }
+    profile("end", this._profilerId, "ink/json", uri);
+  }
   compile(params: CompileProgramParams) {
     const uri = params.textDocument.uri;
     const startFrom = params.startFrom;
+    // Per-request override of the instance default (#351). A host can suppress
+    // bytecode for its per-keystroke compiles and still ask for it on the one
+    // compile that feeds a view, instead of paying for it every edit.
+    const emitCompiledProgram =
+      params.emitCompiledProgram ?? this._config.emitCompiledProgram !== false;
 
     // No-change short-circuit: if every script the last compile read is at
     // the same version, the file registry hasn't changed, and the visit
@@ -665,6 +817,18 @@ export class SparkdownCompiler {
       )
     ) {
       cached.program.startFrom = startFrom ?? this._config.startFrom;
+      // The cached program may have been built with emission suppressed. If
+      // this request wants bytecode, serialize it now from the RETAINED story
+      // rather than forcing a recompile — and cache it on the program so a
+      // second request does not pay again.
+      if (
+        emitCompiledProgram &&
+        cached.story &&
+        !cached.program.compiled &&
+        !cached.program.compiledBuffer
+      ) {
+        this.serializeCompiledProgram(cached.story, cached.program, uri);
+      }
       const result: {
         textDocument: { uri: string; version: number };
         program: SparkProgram;
@@ -962,150 +1126,12 @@ export class SparkdownCompiler {
         // `pathLocations` (the editor navigates source with those).
         // Orthogonal to `binaryProgram`, which picks the FORM when something
         // is emitted; with emission off neither form is produced.
-        const emitCompiled = this._config.emitCompiledProgram !== false;
-        if (emitCompiled) {
-          profile("start", this._profilerId, "ink/json", uri);
-          // #314: the binary writer answers the SAME streaming write events as
-          // SimpleJson.Writer, but appends records instead of building a JS
-          // object tree — so on the no-memo path it does strictly less work.
-          const binary = this._config.binaryProgram === true;
-          const writer = binary
-            ? new ProgramBinaryWriter(this._binaryTable, this._binarySlotHint)
-            : new SimpleJson.Writer();
-          // Incremental ToJson: reuse the serialized subtree of each top-level flow
-          // whose source content is unchanged AND whose cross-flow fingerprint
-          // (#f flags + resolved divert/reference paths) is unchanged. Content is
-          // covered by the chunk-unchanged signal; the fingerprint covers the
-          // cross-flow bits that change without the flow's own source changing.
-          const { reusable: reusableFlows, ok: flowReuseOk } =
-            this.computeFlowReuse(story);
-          if (this._renamedFlowNames) {
-            // A synthetic rename inside a flow changes its serialized bytes in
-            // ways the fingerprint can't see — its cached JSON must not be
-            // served (see the canonicalize step above).
-            for (const renamed of this._renamedFlowNames) {
-              reusableFlows.delete(renamed);
-            }
-          }
-          if (!flowReuseOk) {
-            // The global guard failed (a changed chunk sits before the first flow,
-            // so an inlined const may have shifted): no flow can be reused this
-            // compile. Take the exact baseline path — no fingerprinting, which
-            // would otherwise be pure overhead — and let the cache lapse so the
-            // next reuse-eligible edit reseeds from a fresh serialization.
-            story.ToJson(writer as never);
-            this._flowJsonCache = undefined;
-            this._flowChunkCache = undefined;
-          } else if (binary) {
-            // Binary twin of the JSON memo below. The reuse GUARDS are shared —
-            // `reusableFlows` and the `_renamedFlowNames` subtraction are
-            // computed once above — so the two paths can never disagree about
-            // which flows are eligible, only about what a cached value is.
-            const binaryWriter = writer as ProgramBinaryWriter;
-            const prevChunkCache = this._flowChunkCache;
-            const nextChunkCache = new Map<string, CachedFlowChunk>();
-            const flowMemo = {
-              resolve: (
-                name: string,
-                container: Container,
-                serialize: () => any,
-              ) => {
-                // Same two exclusions as the JSON path, for the same reasons:
-                // `global decl` is non-contiguous and cheap, and canonical
-                // synthetic names are POSITIONAL, so a name can rebind to a
-                // different flow that the fingerprint cannot distinguish.
-                if (name === "global decl" || CANONICAL_SYNTH_NAME.test(name)) {
-                  return serialize();
-                }
-                const fp = JsonSerialisation.FingerprintCrossFlow(container);
-                if (reusableFlows.has(name) && prevChunkCache) {
-                  const cached = prevChunkCache.get(name);
-                  // The generation check is what keeps a reseed sound. Returning
-                  // a chunk here means NOT calling serialize(), so a chunk from
-                  // an older numbering could not be recovered from downstream —
-                  // the writer throws rather than guess, so the decision has to
-                  // be made here.
-                  if (
-                    cached &&
-                    cached.fp === fp &&
-                    cached.chunk.generation === binaryWriter.generation
-                  ) {
-                    nextChunkCache.set(name, cached);
-                    // `WriteInjected` splices the records; the flow is never
-                    // re-walked and its strings are never re-hashed.
-                    return cached.chunk;
-                  }
-                }
-                // Miss: arm the writer to capture whatever gets injected next,
-                // because `resolve` returns BEFORE the caller injects it.
-                binaryWriter.captureNextInjectedAs(name, fp);
-                return serialize();
-              },
-            };
-            story.ToJson(binaryWriter as never, flowMemo);
-            for (const [name, entry] of binaryWriter.takeCapturedChunks()) {
-              nextChunkCache.set(name, entry);
-            }
-            this._flowChunkCache = nextChunkCache;
-          } else {
-            const prevFlowCache = this._flowJsonCache;
-            const nextFlowCache = new Map<string, { fp: string; value: any }>();
-            const flowMemo = {
-              resolve: (
-                name: string,
-                container: Container,
-                serialize: () => any,
-              ) => {
-                // `global decl` is non-contiguous (scattered declarations) and
-                // cheap; always serialize it fresh, never cache.
-                //
-                // Canonical synthetic flows (`__synth_<n>`, see
-                // `canonicalizeSyntheticFlowNames`) are excluded because their
-                // names are POSITIONAL (document-order ordinals), so a name can
-                // rebind to a DIFFERENT flow when an edit adds/removes a
-                // synthetic earlier in the document — and the cross-flow
-                // fingerprint can't tell two same-shaped function knots apart
-                // (it deliberately records nothing for pure content, relying on
-                // chunk identity for structure, which name rebinding breaks).
-                // These are tiny function knots; serializing fresh is cheap.
-                if (name === "global decl" || CANONICAL_SYNTH_NAME.test(name)) {
-                  return serialize();
-                }
-                const fp = JsonSerialisation.FingerprintCrossFlow(container);
-                let value: any;
-                if (reusableFlows.has(name) && prevFlowCache) {
-                  const cached = prevFlowCache.get(name);
-                  value =
-                    cached && cached.fp === fp ? cached.value : serialize();
-                } else {
-                  value = serialize();
-                }
-                nextFlowCache.set(name, { fp, value });
-                return value;
-              },
-            };
-            story.ToJson(writer, flowMemo);
-            this._flowJsonCache = nextFlowCache;
-          }
-          if (binary) {
-            // Pieces, not a packed blob: `nodes`/`numbers` are typed arrays that
-            // transfer in O(1) across a worker boundary, and packing them into
-            // one self-describing byte blob costs ~10ms/compile (it re-encodes
-            // the whole string table to UTF-8) for no benefit on that hop.
-            const buffer = (writer as ProgramBinaryWriter).toBuffer();
-            program.compiledBuffer = buffer;
-            this._binarySlotHint = buffer.nodes.length;
-            // Safe to run AFTER emitting: reseeding installs fresh arrays on the
-            // table rather than clearing them in place, so the buffer just
-            // emitted keeps its own (correct) string array alive.
-            this.maybeReseedBinaryTable();
-          } else {
-            const json = (writer as SimpleJson.Writer).toObject();
-            if (json) {
-              program.compiled = json;
-            }
-          }
-          profile("end", this._profilerId, "ink/json", uri);
+        // #345/#351: emission is suppressed for hosts that never read the
+        // bytecode, and can be re-requested per compile. Everything else in
+        // this block still runs — `state.story`, and `populateAllLocations`
+        // below, which walks the runtime tree for `pathLocations`.
+        if (emitCompiledProgram) {
+          this.serializeCompiledProgram(story, program, uri);
         }
         state.story = story;
         // Gather source-location maps in a single top-down walk of the

--- a/packages/sparkdown/src/compiler/classes/messages/CompileProgramMessage.ts
+++ b/packages/sparkdown/src/compiler/classes/messages/CompileProgramMessage.ts
@@ -34,6 +34,18 @@ export interface CompileProgramParams {
    * source-level reference need this set.
    */
   countAllVisits?: boolean;
+  /**
+   * Serialize the compiled program for THIS request, overriding
+   * `SparkdownCompilerConfig.emitCompiledProgram` (#351).
+   *
+   * Lets a host suppress bytecode on its per-keystroke compiles and still ask
+   * for it on the one compile that feeds a view. When the no-change
+   * short-circuit serves a cached program that was built without bytecode,
+   * it is materialized from the retained runtime story rather than recompiled.
+   *
+   * Omitted means "use the instance default".
+   */
+  emitCompiledProgram?: boolean;
 }
 
 export interface CompileProgramResult {

--- a/packages/sparkdown/src/tests/compiler/onDemandCompiledProgram.test.ts
+++ b/packages/sparkdown/src/tests/compiler/onDemandCompiledProgram.test.ts
@@ -1,0 +1,174 @@
+// Per-request bytecode, materialized lazily from the retained story (#351).
+//
+// The risk this pins down: `compile()` has a no-change short-circuit that
+// returns the previous program. If that program was built with emission
+// suppressed and a later request asks for bytecode, returning the cache hands
+// back `undefined` — which downstream renders as an empty view rather than an
+// error. So the interesting cases are all "ask AFTER the short-circuit is
+// live", not "ask on a fresh compile".
+import "../../inkjs/engine/Container";
+import { describe, expect, it } from "vitest";
+import { SparkdownCompiler } from "../../compiler/classes/SparkdownCompiler";
+
+const URI = "inmemory:///main.sd";
+
+function quiet<T>(fn: () => T): T {
+  const realWarn = console.warn;
+  const realError = console.error;
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    return fn();
+  } finally {
+    console.warn = realWarn;
+    console.error = realError;
+  }
+}
+
+const SOURCE = [
+  "title: On Demand",
+  "",
+  "define hero as character:",
+  `  name = "Hero"`,
+  "",
+  "const LIMIT = 3",
+  "store trust = 0",
+  "",
+  "scene one",
+  ":",
+  "  First beat with {trust} and {LIMIT}.",
+  "hero:",
+  "  A line of dialogue.",
+  "-> two",
+  "end",
+  "",
+  "scene two",
+  ":",
+  "  Second beat.",
+  "end",
+  "",
+].join("\n");
+
+function makeCompiler(text: string, emitCompiledProgram?: boolean) {
+  const c = new SparkdownCompiler();
+  c.configure({
+    ...(emitCompiledProgram === undefined ? {} : { emitCompiledProgram }),
+    files: [
+      {
+        uri: URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text,
+        version: 1,
+        languageId: "sparkdown",
+      },
+    ],
+  } as never);
+  return c;
+}
+
+const compileWith = (c: SparkdownCompiler, emit?: boolean) =>
+  quiet(
+    () =>
+      (
+        c.compile({
+          textDocument: { uri: URI },
+          ...(emit === undefined ? {} : { emitCompiledProgram: emit }),
+        } as never) as any
+      ).program,
+  );
+
+/** Type an extra character into the dialogue line. */
+function edit(c: SparkdownCompiler, text: string, version: number) {
+  const NL = String.fromCharCode(10);
+  const anchor = "A line of dialogue";
+  const at = text.indexOf(anchor);
+  const off = at + anchor.length;
+  const before = text.slice(0, off);
+  const line = before.split(NL).length - 1;
+  const character = off - (before.lastIndexOf(NL) + 1);
+  quiet(() =>
+    c.updateDocument({
+      textDocument: { uri: URI, version },
+      contentChanges: [
+        {
+          range: { start: { line, character }, end: { line, character } },
+          text: "!",
+        },
+      ],
+    } as never),
+  );
+  return text.slice(0, off) + "!" + text.slice(off);
+}
+
+/** What a compiler that always emits produces for the same text. */
+function coldCompiled(text: string): string {
+  const c = makeCompiler(text, true);
+  return JSON.stringify(compileWith(c).compiled);
+}
+
+describe("on-demand compiled program (#351)", () => {
+  it("honours a per-request opt-in when the instance default is off", () => {
+    const c = makeCompiler(SOURCE, false);
+    expect(compileWith(c).compiled).toBeUndefined();
+    expect(compileWith(c, true).compiled).toBeTruthy();
+  });
+
+  it("honours a per-request opt-OUT when the instance default is on", () => {
+    const c = makeCompiler(SOURCE, true);
+    expect(compileWith(c).compiled).toBeTruthy();
+    // A fresh compiler, so the request is the only thing suppressing it.
+    const c2 = makeCompiler(SOURCE, true);
+    expect(compileWith(c2, false).compiled).toBeUndefined();
+  });
+
+  it("materializes bytecode from the retained story on the SHORT-CIRCUIT path", () => {
+    // The bug this exists for. The second compile is a no-change hit, so the
+    // cached program (built without bytecode) is what gets served — unless the
+    // lazy path fires.
+    const c = makeCompiler(SOURCE, false);
+    expect(compileWith(c).compiled).toBeUndefined();
+    const onDemand = compileWith(c, true);
+    expect(onDemand.compiled, "short-circuit must not serve undefined").toBeTruthy();
+    expect(JSON.stringify(onDemand.compiled)).toBe(coldCompiled(SOURCE));
+  });
+
+  it("matches a cold compile after a sequence of edits", () => {
+    // A single-compile test would never reach the short-circuit. Typing first
+    // is what makes the cached-program path the one under test.
+    const c = makeCompiler(SOURCE, false);
+    let text = SOURCE;
+    compileWith(c);
+    for (let i = 0; i < 4; i += 1) {
+      text = edit(c, text, i + 2);
+      expect(compileWith(c).compiled, `edit ${i + 1}`).toBeUndefined();
+    }
+    const pulled = compileWith(c, true);
+    expect(JSON.stringify(pulled.compiled)).toBe(coldCompiled(text));
+  });
+
+  it("serves the same bytecode when pulled twice without an edit", () => {
+    // The second pull hits the short-circuit with bytecode already attached,
+    // so it must neither re-serialize into something different nor drop it.
+    const c = makeCompiler(SOURCE, false);
+    compileWith(c);
+    const first = JSON.stringify(compileWith(c, true).compiled);
+    const second = JSON.stringify(compileWith(c, true).compiled);
+    expect(second).toBe(first);
+    expect(first).toBe(coldCompiled(SOURCE));
+  });
+
+  it("leaves diagnostics and pathLocations untouched either way", () => {
+    const c = makeCompiler(SOURCE, false);
+    const suppressed = compileWith(c);
+    const pulled = compileWith(c, true);
+    expect(JSON.stringify(pulled.pathLocations)).toBe(
+      JSON.stringify(suppressed.pathLocations),
+    );
+    expect(JSON.stringify(pulled.diagnostics ?? {})).toBe(
+      JSON.stringify(suppressed.diagnostics ?? {}),
+    );
+    expect(Object.keys(pulled.pathLocations ?? {}).length).toBeGreaterThan(0);
+  });
+});

--- a/vscode-sparkdown/src/managers/SparkProgramManager.ts
+++ b/vscode-sparkdown/src/managers/SparkProgramManager.ts
@@ -149,6 +149,11 @@ export class SparkProgramManager {
     const client = await this.languageClientReady;
     const params: CompileProgramParams = {
       textDocument: { uri: uri.toString() },
+      // This is the PULL path: whoever called `getOrCompile` wants the whole
+      // program, bytecode included. Per-keystroke compiles suppress it (see
+      // the initialization options), so it has to be requested here or the
+      // compilation view renders empty (#351).
+      emitCompiledProgram: true,
     };
     const program = await client.sendRequest<SparkProgram>(
       CompileProgramMessage.method,

--- a/vscode-sparkdown/src/utils/activateLanguageClient.ts
+++ b/vscode-sparkdown/src/utils/activateLanguageClient.ts
@@ -74,6 +74,11 @@ export const activateLanguageClient = async (
       // cloned across two threads on every keystroke). Consumers that need
       // the full program pull it on demand via SparkProgramManager.
       slimProgramNotifications: true,
+      // Nothing reads the bytecode per keystroke: the notification above is
+      // slim, and the one consumer (the compilation tree view) pulls the full
+      // program on demand via `SparkProgramManager.getOrCompile`, which asks
+      // for it explicitly. ~27ms/edit on a large project otherwise (#351).
+      emitCompiledProgram: false,
     },
     middleware: {
       provideDocumentSymbols: async (


### PR DESCRIPTION
Closes #351. Builds on #349, which merged while this was in progress — so this now targets `main` directly.

Review the compiler with `git diff -w`: most of its diff is the serialization block moving into a method, unchanged.

## What

#345 stopped the impower-dev language server serializing bytecode nobody reads. vscode was left emitting because its compilation view reads `program?.compiled` — but it only reads it **while that view is visible**, and it already fetches on demand:

```ts
if (!treeView.visible) { treeDataStale = true; return; }
const program = await SparkProgramManager.instance.getOrCompile(uri);
setTreeData(uri, program?.compiled);
```

`SparkProgramManager` is already a pull model — `updateSlim` deletes cached programs every compile, consumers call `getOrCompile`. So the compile that must carry bytecode is the **pull**, never the keystroke.

`CompileProgramParams.emitCompiledProgram` now overrides the instance default per request. vscode sets the instance `false` and passes `true` on the pull. impower-dev is unchanged.

This generalises the switch from "this host never needs it" to "nothing needs it right now".

## The trap

`compile()` short-circuits when nothing changed and returns the previous program. If that program was built with emission suppressed and a later request wants bytecode, serving the cache hands back `undefined` — and the compilation view renders **empty rather than erroring**, so it would look like a content bug, not a caching bug.

`state.story` is retained, so the fix serializes from the **retained runtime story** instead of forcing a recompile. `compiled` becomes lazily materialized: ~27 ms once when something looks at it, instead of ~27 ms every edit. That needed the serialization block callable from two places, hence `serializeCompiledProgram(story, program, uri)` — which also removes the extra indentation #345 introduced.

## Verification

The new suite is written around the **short-circuit**, not around a fresh compile, because a single-compile test never reaches the path that breaks:

- per-request opt-in when the instance default is off, and opt-out when it is on
- the short-circuit **materializes** rather than serving `undefined`
- after a **sequence of edits**, a pull matches a cold compile byte for byte
- pulling twice without an edit returns the same bytecode (second pull hits the short-circuit with bytecode already attached — it must neither drop it nor re-serialize into something different)
- diagnostics and `pathLocations` identical either way

Compiler + incremental: **45 files / 747 tests**, green.

impower-dev verified **live** in the running editor. The extraction touches every host, so the point was that it stays unchanged — diagnostics reach the status bar ("2 Warnings"), navigation resolves ("main : 1"), preview renders.

## Extension host, verified

Run in a real Extension Host (`vscode-test-web`, `--esm`, R&B opened as the workspace):

- **`⊗ 0  ⚠ 369`** in the status bar — the same diagnostic count previously recorded for R&B on `main`. Diagnostics come out of the COMPILE, so this is what proves the pipeline still runs with serialization suppressed.
- first diagnostics at **12.2 s**; after a typing burst they resettle at 369 within ~1 s
- `main.sd` renders with full semantic highlighting, `main.sd 9+` badge, warning marks down the minimap
- the option reaches the compiler as intended — unlike `slimProgramNotifications` it is not destructured out of `...compilerConfig`

One pre-existing page error (`Unknown (FileSystemError): Not Found`) reproduces here and is #300, unrelated.

### What could NOT be gated on

**The Compilation Tree populating.** That view is empty on `main` as well — #301, still open — so it cannot distinguish this change from the pre-existing bug. It is also the *only* reader of `program.compiled` in the extension; the statistics panel calls `getOrCompile` but reads other fields.

Worth being blunt about the consequence: with #301 open, vscode currently has **no working consumer of the bytecode at all**, so this PR mostly removes work whose only client is already broken. The per-request pull is still the right shape — it is what makes the view work once #301 is fixed, instead of requiring the flag to be flipped back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
