### PR TITLE
fix(script-editor): raise top panels above the host chrome (#337)

### DIFF
--- a/impower-dev/src/modules/spark-editor/components/file-dropzone/FileDropzone.tsx
+++ b/impower-dev/src/modules/spark-editor/components/file-dropzone/FileDropzone.tsx
@@ -204,18 +204,20 @@ export default function FileDropzone(_props: FileDropzoneProps) {
     };
   }, []);
 
-  // The overlay sits above every other layer: the z-10 chrome (header, sticky
-  // tab bars, split divider), dialogs (z-50), toasts (z-[60]), and
-  // CodeMirror's own panels and gutters (z-index 300/200). At z-[2] it cleared
-  // none of them, so a drag left the page looking half-covered instead of
-  // presenting one drop target.
+  // The overlay sits above every other layer. At z-[2] it cleared none of
+  // them, so a drag left the page looking half-covered instead of presenting
+  // one drop target.
   //
-  // 400 rather than something just past the app's own z-[60] ceiling because
-  // CodeMirror's `.cm-panels-bottom` is z-index 300 and NOTHING between it and
-  // <body> establishes a stacking context, so that 300 competes here at the
-  // root rather than staying inside the editor. (That leak is worth fixing at
-  // the source -- it also puts the status bar above this app's dialogs -- but
-  // containing it is a wider change than this overlay.)
+  // The full stack it has to clear, lowest first: the z-10 chrome (header,
+  // sticky tab bars, split divider), the editor's search/goto panels
+  // (`.cm-panels-top`, z-30 -- EDITOR_THEME.ts), dialogs (z-50), toasts
+  // (z-[60]). Nothing between the editor's panels and <body> establishes a
+  // stacking context, so those editor layers compete here at the root rather
+  // than staying inside the editor -- which is also why the theme pins them
+  // deliberately low (gutters 1, panels 2, top panels 30) instead of leaving
+  // CodeMirror's defaults of 200/300.
+  //
+  // 400 keeps a wide margin over that whole stack.
   //
   // `absolute inset-0` fills whichever container this is mounted in --
   // currently MainWindow's middle region, so the overlay covers the content

--- a/impower-dev/src/modules/spark-editor/components/header-menu-button/HeaderMenuButton.tsx
+++ b/impower-dev/src/modules/spark-editor/components/header-menu-button/HeaderMenuButton.tsx
@@ -88,8 +88,10 @@ export default function HeaderMenuButton(_p: HeaderMenuButtonProps) {
               if (e.target === e.currentTarget) setOpen(false);
             }}
             style={{
-              // z-index 400 to win against CodeMirror's status bar at z-300
-              // (`.cm-panels-bottom`).
+              // z-index 400 to clear every editor layer that competes at the
+              // document root: the status bar (`.cm-panels-bottom`, z-2) and
+              // the search/goto panels (`.cm-panels-top`, z-30), both pinned
+              // in EDITOR_THEME.ts. Matches FileDropzone's overlay.
               zIndex: 400,
             }}
           >

--- a/packages/sparkdown-document-views/src/modules/script-editor/constants/EDITOR_THEME.ts
+++ b/packages/sparkdown-document-views/src/modules/script-editor/constants/EDITOR_THEME.ts
@@ -321,6 +321,24 @@ const EDITOR_THEME: {
     color: EDITOR_COLORS.white,
   },
   "& .cm-panels.cm-panels-top": {
+    // Top panels are pulled up INTO the host's 48px header band by the
+    // negative margin below, so they have to outrank it as well. The host
+    // chrome (sticky headers, tab bars, the split divider) sits at z-index
+    // 10-20 and nothing between `.cm-panels` and <body> establishes a
+    // stacking context, so that chrome competes with this value directly:
+    // at the inherited 2 the header paints OVER the search panel and the
+    // whole Find row is invisible and unclickable (#337).
+    //
+    // 30 clears the chrome band while staying under the host's dialogs (50),
+    // toasts (60) and drag overlay (400), and under this editor's own popups
+    // (`.cm-tooltip`, 300) -- all of which must still cover the panel.
+    //
+    // Keep the override scoped to the TOP panels. Only they are pulled into
+    // the header band and so only they need to outrank it; the bottom status
+    // bar overlaps nothing and belongs under the host's UI, per the same rule
+    // that pins `.cm-gutters` to 1. Raising `.cm-panels` as a whole would drag
+    // the status bar up to 30 with it for no reason.
+    zIndex: "30",
     "& .cm-panel": {
       // Top panels should cover up panel header
       marginTop: "-48px",

--- a/packages/sparkdown-document-views/test/editor-theme-panel-layering.test.ts
+++ b/packages/sparkdown-document-views/test/editor-theme-panel-layering.test.ts
@@ -1,0 +1,200 @@
+import { openSearchPanel } from "@codemirror/search";
+import { EditorState } from "@codemirror/state";
+import { EditorView, showPanel } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vitest";
+import EDITOR_THEME from "../src/modules/script-editor/constants/EDITOR_THEME";
+import { customSearchPanel } from "../src/modules/script-editor/utils/extensions/customSearch";
+
+// The layers the editor is sandwiched between. Nothing between `.cm-panels`
+// and <body> establishes a stacking context, so the numbers this theme picks
+// compete with the host's directly.
+//
+// Bottom of the host chrome band -- every sticky header and tab bar in the web
+// editor (FileEditorNavigation.tsx:35, MainWindow.tsx:93/125,
+// HeaderNavigation.tsx:116, LogicList.tsx:83, Assets.tsx:73, Share.tsx:31).
+// Editor chrome that does NOT overlap the host must stay under this.
+const HOST_CHROME_Z_MIN = 10;
+// Top of that band: the progress strip this package paints over the host's
+// tab row (SparkdownScriptEditor.tsx:131, `zIndex: 20`). A top panel that
+// covers the header has to clear the whole band, not just its floor.
+const HOST_CHROME_Z_MAX = 20;
+// The host's dialogs (TrashPanel.tsx:179, ConflictDialogHost.tsx:59,
+// AddUrlDialog.tsx:82, ...), toasts (60) and drag overlay (400) must still
+// cover the editor.
+const HOST_DIALOG_Z = 50;
+
+let view: EditorView | undefined;
+
+const mount = (...extensions: readonly unknown[]) => {
+  const parent = document.body.appendChild(document.createElement("div"));
+  view = new EditorView({
+    state: EditorState.create({
+      doc: "$:\n  A MOONLIT ROOFTOP\n",
+      extensions: [
+        ...(extensions as never[]),
+        // `{ dark: true }` mirrors createEditorView.ts:496 -- the production
+        // mount -- so this resolves the same rule set the app does.
+        EditorView.theme(EDITOR_THEME, { dark: true }),
+      ],
+    }),
+    parent,
+  });
+  return view;
+};
+
+// getComputedStyle is NOT usable here: jsdom applies matching rules in source
+// order and ignores specificity, so `.cm-panels.cm-panels-top { z-index: 30 }`
+// reads as 2 whenever it happens to be written ABOVE `.cm-panels`. Verified
+// directly -- a browser resolves that pair to 30, jsdom to 2. Reading the
+// cascade the way a real browser does keeps this test from going red on a
+// pure reordering, and from passing on a rule a browser would discard.
+// Not a general CSS specificity implementation -- just enough for the flat
+// class/descendant selectors these themes emit. The character classes must NOT
+// be \w-based: CodeMirror's generated theme class is a non-ASCII identifier
+// (`.ͼ5`), and \w would skip it and undercount every selector by one.
+const specificity = (selector: string) => {
+  const ids = (selector.match(/#[^\s.:#[>+~,()]+/g) || []).length;
+  const classes = (selector.match(/[.:[][^\s.:#[>+~,()]+/g) || []).length;
+  const types = (
+    selector.replace(/[.#:[][^\s>+~,()]*/g, " ").match(/[a-zA-Z][\w-]*/g) || []
+  ).length;
+  return ids * 10_000 + classes * 100 + types;
+};
+
+/**
+ * The winning declaration for `prop` (kebab-case) on `el` among the top-level
+ * style rules in the document, ordered by (specificity, source order) the way
+ * a browser would. At-rules and `!important` are NOT handled -- this resolves
+ * the flat rule set these themes emit, not the full cascade. Returns null when
+ * no rule declares it, so a selector that stopped matching fails loudly
+ * instead of reading as an empty string.
+ *
+ * Read via getPropertyValue, NOT `rule.style.zIndex`: jsdom's CSSStyleRule
+ * exposes no camelCase accessors, so the camelCase form silently yields
+ * undefined and every assertion built on it passes vacuously.
+ */
+const resolved = (el: Element, prop: string) => {
+  let winner: string | null = null;
+  let bestKey = -1;
+  let order = 0;
+  for (const sheet of Array.from(document.styleSheets)) {
+    let rules: CSSRule[] = [];
+    try {
+      rules = Array.from(sheet.cssRules);
+    } catch {
+      continue;
+    }
+    for (const rule of rules) {
+      order += 1;
+      const styleRule = rule as CSSStyleRule;
+      if (typeof styleRule.selectorText !== "string") continue;
+      const value = styleRule.style?.getPropertyValue(prop);
+      if (!value) continue;
+      for (const selector of styleRule.selectorText.split(",")) {
+        const sel = selector.trim();
+        if (!sel) continue;
+        // Other extensions mount selectors jsdom's matcher cannot parse
+        // (statusPanel.ts uses `:has(...)`). A rule we cannot evaluate must be
+        // skipped, not allowed to red the whole test.
+        let matched = false;
+        try {
+          matched = el.matches(sel);
+        } catch {
+          continue;
+        }
+        if (!matched) continue;
+        const key = specificity(sel) * 1_000_000 + order;
+        if (key > bestKey) {
+          bestKey = key;
+          winner = value;
+        }
+      }
+    }
+  }
+  return winner;
+};
+
+/** Declared z-index, or null if no rule sets one. Never coerces null to 0. */
+const resolvedZ = (el: Element) => {
+  const raw = resolved(el, "z-index");
+  return raw === null ? null : Number(raw);
+};
+
+afterEach(() => {
+  view?.destroy();
+  view = undefined;
+  document.body.innerHTML = "";
+});
+
+describe("editor panel layering vs the host app's chrome (#337)", () => {
+  // The resolver above is the harness the two real tests stand on; if its
+  // specificity ordering is wrong they both assert the wrong rule.
+  it("resolves the theme's own selectors by specificity", () => {
+    expect(specificity(".ͼ5 .cm-panels.cm-panels-top")).toBeGreaterThan(
+      specificity(".ͼ5 .cm-panels")
+    );
+  });
+
+  it("keeps the open search panel above the host's header band", () => {
+    const view = mount(customSearchPanel());
+    openSearchPanel(view);
+
+    const panels = view.dom.querySelector(".cm-panels-top");
+    const panel = view.dom.querySelector<HTMLElement>(".cm-panel.cm-search");
+    expect(panels).toBeTruthy();
+    expect(panel).toBeTruthy();
+
+    // The theme pulls the top panel UP into the host's 48px header band. That
+    // overlap is the whole reason the z-index matters, so assert it directly
+    // rather than guarding on it -- a guard would delete the assertion below
+    // the moment the overlap is expressed some other way.
+    expect(resolved(panel!, "margin-top")).toBe("-48px");
+
+    // Overlapping is only safe if the panel also outranks what it overlaps. At
+    // the inherited z-index 2 the header painted over the entire Find row --
+    // search input, toggles, next/prev and close all invisible and unclickable.
+    const z = resolvedZ(panels!);
+    expect(z).not.toBeNull();
+    expect(Number.isFinite(z)).toBe(true);
+    expect(z!).toBeGreaterThan(HOST_CHROME_Z_MAX);
+    // ...but not so high that it covers the host's dialogs and toasts.
+    expect(z!).toBeLessThan(HOST_DIALOG_Z);
+
+    // The editor's own popups must still overhang an open panel -- autocomplete
+    // and hover tooltips render outside the panel and have to stay on top of
+    // it. Nothing else pins this ceiling, so a future bump past 300 would hide
+    // completions with no other test noticing.
+    const tooltip = document.createElement("div");
+    tooltip.className = "cm-tooltip";
+    view.dom.appendChild(tooltip);
+    const tooltipZ = resolvedZ(tooltip);
+    expect(tooltipZ).not.toBeNull();
+    expect(z!).toBeLessThan(tooltipZ!);
+  });
+
+  it("leaves bottom panels below the whole host chrome band", () => {
+    // Raising `.cm-panels` wholesale would also fix #337, and would reintroduce
+    // the bug the `z-index: 2` exists to prevent: editor chrome climbing over
+    // the host's UI. Bounding this at the FLOOR of the chrome band (not at the
+    // dialog layer) is what makes that shortcut fail here.
+    const view = mount(
+      showPanel.of(() => ({
+        dom: Object.assign(document.createElement("div"), {
+          className: "cm-status-bar",
+        }),
+        top: false,
+      }))
+    );
+
+    const panels = view.dom.querySelector(".cm-panels-bottom");
+    expect(panels).toBeTruthy();
+
+    // Non-vacuity: if the theme's rule stopped reaching this element the
+    // resolver returns null, which fails here instead of coercing to 0 and
+    // sliding under the bound.
+    const z = resolvedZ(panels!);
+    expect(z).not.toBeNull();
+    expect(Number.isFinite(z)).toBe(true);
+    expect(z!).toBeLessThan(HOST_CHROME_Z_MIN);
+  });
+});


### PR DESCRIPTION
Fixes #337.

## Behaviour change worth knowing about, up front

While the Find (or Goto-line) panel is open it now **covers the 48px chrome row above the editor** — the Main/Scripts sub-tabs on the Main route, the Back arrow and filename field on the Scripts route. That row is unclickable until the panel is closed (× at the panel's left, or Escape).

That is the theme's existing design — the `-48px` pull has always meant "top panels cover the header" — but until now the panel lost the paint order, so the chrome stayed clickable and the Find row was the thing that vanished. The trade is deliberate and strictly better than the status quo, but it is a visible change on the Main route and not just a bug fix.

Same mechanism means LSP message bars (`showDialog({top: true})` from `codemirror-vscode-lsp-client`) are now **visible** where they previously rendered behind the header. They keep their inline OK button, so they remain dismissable in one click.

## What broke

Opening Find & Replace (<kbd>Ctrl</kbd>+<kbd>F</kbd> / <kbd>Ctrl</kbd>+<kbd>H</kbd>) showed only the **Replace** row. The whole **Find** row — search input, case/word/regex toggles, next/prev and close — painted behind the app chrome and was neither visible nor clickable.

Two rules in `packages/sparkdown-document-views/src/modules/script-editor/constants/EDITOR_THEME.ts` contradicted each other:

- `& .cm-panels` (line 298) was lowered to `z-index: 2` — from CodeMirror's 300 — so the bottom status bar would stop covering the host's dialogs.
- `& .cm-panels.cm-panels-top .cm-panel` sets `margin-top: -48px`, deliberately pulling the top panel **up into** the host's 48px header band.

The host chrome sits at `z-index: 10`, and nothing between `.cm-panels` and `<body>` establishes a stacking context, so that 10 competes with the panel's 2 directly and the intended overlap rendered inverted.

## The fix

One declaration: `zIndex: "30"` scoped to `& .cm-panels.cm-panels-top`.

`.cm-panels` as a whole stays at 2 — only the top panels are pulled into the header band, so only they need to outrank it; the bottom status bar overlaps nothing and belongs under the host's UI, same rule that pins `.cm-gutters` to 1.

30 clears the chrome band (`z-10` sticky headers / tab bars / split divider, plus the `z-20` LoadingBar strip this package paints at `SparkdownScriptEditor.tsx:131`) while staying under the host's dialogs (50), toasts (60), drag overlay (400) and the editor's own popups (`.cm-tooltip`, 300). Nothing in `impower-dev` or `impower-ui` occupies 21–49.

Also corrected two stale host comments that justified their `z-400` against "CodeMirror's status bar at z-300" — false since `c273ecc42` lowered it to 2, and this change adds a third number to the same contract:
- `impower-dev/.../file-dropzone/FileDropzone.tsx:207`
- `impower-dev/.../header-menu-button/HeaderMenuButton.tsx:91`

## Regression test

`packages/sparkdown-document-views/test/editor-theme-panel-layering.test.ts` — 3 tests, jsdom, driving a real `EditorView` with `customSearchPanel()` + `EditorView.theme(EDITOR_THEME, { dark: true })` (matching the production mount at `createEditorView.ts:496`).

It pins the **invariant**, not the patch: *if* the top panel is pulled into the header band, it must outrank the chrome. Removing the overlap instead would also satisfy it. A second test bounds bottom panels below the *floor* of the chrome band, and a third self-tests the harness.

**`getComputedStyle` is deliberately not used.** jsdom applies matching rules in source order and ignores specificity — verified directly: `.a.b{z-index:30}` written above `.b{z-index:2}` computes to **2** in jsdom and **30** in a browser. So the test resolves the cascade itself by (specificity, source order). Without that, a pure reordering of the theme object — a no-op in every browser — would turn the suite red.

Red/green, via a copy-aside revert (never `git stash`, which is repo-global across ~17 worktrees):

| Route | Result |
| --- | --- |
| Pre-fix source | 🔴 `expected 2 to be greater than 20` |
| Raise `.cm-panels` wholesale instead | 🔴 `expected 30 to be less than 10` |
| Move the rule above the base block (browser no-op) | 🟢 stays green |
| With the fix | 🟢 3 passed |

Positive controls hold on the red runs (panel mounted, `margin-top: -48px` resolved), so the failures are the defect and not a broken harness.

## Suites run

`packages/sparkdown-document-views` full suite: **19 passed | 2 skipped (21 files)**, **67 passed | 4 skipped (71 tests)**, 87s. The 2 skipped files (`dual-real-incremental`, `incremental-sync`) are skipped on `origin/main` too — not caused by this change.

## Live verification

`driver.mjs` against the running editor, viewport 1600×1000:

- **Before** — only the Replace row visible; `elementFromPoint` at the Find input's centre returned a tab-bar `BUTTON`, `isSearchUI: false`.
- **After** — full Find row renders; `.cm-panels-top` computes `z-index: 30`; all six controls hit-test into the search UI (input, ×, three toggles, next/prev).
- **Goto-line** (the other top panel, <kbd>Ctrl</kbd>+<kbd>G</kbd>) also renders correctly over the header — it had the same bug.
- **Dialog layering intact** — with Find open, the hamburger drawer (z-400) still covers the panel, and the panel returns on top when the drawer closes. Confirmed visually and by hit-test.

## Adversarial review — raised and deliberately not changed

Five reviewers. Three findings drove code changes (the wrong justification in my own comment, an `el.matches` call that could throw on `:has()` selectors, and a vacuous-pass hole where jsdom's `CSSStyleRule.style` exposes no camelCase accessors so `zIndex` read as `undefined` and `Number(null) === 0` slid under the bound). The rest:

- **Transient stacking context during route transitions.** `impower-ui`'s `Router` animates `opacity`/`transform` with `fill: "forwards"` on wrappers above the editor, so for ~150–220ms while switching Main↔Scripts with Find open, the panel's 30 is trapped and it drops behind the tab bar. Real, reproducible in principle, **pre-existing and strictly better than before** (at z-2 it was permanent, not transient). Self-heals when `Router` clears the transform at idle. Out of scope — fixing it means containing the editor's layers properly, which is the wider change `FileDropzone`'s comment already calls for.
- **The test can't observe ancestor stacking contexts.** True and inherent: it mounts a bare editor with no host ancestors. A unit test in this package cannot assert a stacking outcome that depends on `impower-dev`'s DOM. The live check above is what covers it.
- **`HOST_CHROME_Z` etc. are hand-copied literals.** Also true — this package doesn't depend on `impower-dev`, so bumping `FileEditorNavigation` to `z-40` would reintroduce #337 with the suite green. Sharing a layer-token module across the two packages is a larger refactor than this fix warrants; the constants carry `file:line` citations so the next reader can re-check them.
- **The `-48px` is only correct because both chrome rows happen to be `h-12`.** True, and unchanged by this PR — but now a mismatch would be visible rather than invisible. Noted, not pinned.
- **LoadingBar (z-20) now covered by the panel** — checked and **not real**: `ScriptEditorController.ts:568-569` sets `editor.visibility = "hidden"` and `loading.opacity = "1"` together, and `revealEditor` reverses both, so the bar and the panel are never on screen at the same time.

## Not verified

I reproduced and fixed this on the **Main** route and did not reach the Scripts-route *file-editor* header live — `main.sd` is excluded from that list (`exclude="main.sd"`, `LogicList.tsx:121`) and the "New Script" flow left the pane empty in a fresh browser profile. That header is the same `sticky top-0 z-10`, `h-12` band (`FileEditorNavigation.tsx:35`), so the same arithmetic applies, but I did not see it with my own eyes.
