### PR TITLE
fix(player): warm the filtered image url the renderer actually requests (#344)

### DIFF
--- a/packages/spark-web-player/src/main/utils/ImagePreloader.test.ts
+++ b/packages/spark-web-player/src/main/utils/ImagePreloader.test.ts
@@ -1,0 +1,273 @@
+// #344: warming is only useful if it (a) keys on the url the renderer will
+// request and (b) does not queue every asset behind every other one. The
+// previous per-file warm-up fired one request per asset at project open — 261
+// on the real project — so the asset the user reached first arrived no sooner
+// than the last.
+
+import { describe, expect, it } from "vitest";
+import {
+  ImagePreloader,
+  MAX_PRELOAD_ATTEMPTS,
+  type PreloadTarget,
+} from "./ImagePreloader";
+
+class FakeImage implements PreloadTarget {
+  static created: FakeImage[] = [];
+
+  onload: ((this: any, ev: any) => any) | null = null;
+
+  onerror: ((this: any, ev: any) => any) | null = null;
+
+  protected _src = "";
+
+  constructor() {
+    FakeImage.created.push(this);
+  }
+
+  get src() {
+    return this._src;
+  }
+
+  set src(value: string) {
+    this._src = value;
+  }
+
+  finishLoad() {
+    this.onload?.call(this, {});
+  }
+
+  fail() {
+    this.onerror?.call(this, {});
+  }
+}
+
+const makePreloader = (maxConcurrent?: number) => {
+  const created: FakeImage[] = [];
+  const preloader = new ImagePreloader(() => {
+    const img = new FakeImage();
+    created.push(img);
+    return img;
+  }, maxConcurrent);
+  return { preloader, created };
+};
+
+describe("ImagePreloader", () => {
+  it("holds concurrency at the cap and drains the queue as loads finish", () => {
+    const { preloader, created } = makePreloader(2);
+    preloader.warmAll(["a", "b", "c", "d", "e"]);
+
+    expect(created.map((i) => i.src)).toEqual(["a", "b"]);
+    expect(preloader.inFlightCount).toBe(2);
+    expect(preloader.pendingCount).toBe(3);
+
+    created[0]!.finishLoad();
+    expect(created.map((i) => i.src)).toEqual(["a", "b", "c"]);
+
+    created[1]!.finishLoad();
+    created[2]!.finishLoad();
+    expect(created.map((i) => i.src)).toEqual(["a", "b", "c", "d", "e"]);
+    expect(preloader.pendingCount).toBe(0);
+  });
+
+  it("preserves warm order, so the urls that matter go first", () => {
+    const { preloader, created } = makePreloader(1);
+    preloader.warmAll(["variant", "root"]);
+    expect(created.map((i) => i.src)).toEqual(["variant"]);
+    created[0]!.finishLoad();
+    expect(created.map((i) => i.src)).toEqual(["variant", "root"]);
+  });
+
+  it("keys on src, so two urls of one asset are both warmed", () => {
+    const { preloader, created } = makePreloader(4);
+    const root = "/file:/a/bunny.svg?v=1-2";
+    const variant = `${root}&filters=%7B%22i%22%3A%5B%5D%7D`;
+    preloader.warmAll([variant, root]);
+    expect(created.map((i) => i.src)).toEqual([variant, root]);
+    expect(preloader.isWarm(variant)).toBe(true);
+    expect(preloader.isWarm(root)).toBe(true);
+  });
+
+  it("never requests the same src twice", () => {
+    const { preloader, created } = makePreloader(4);
+    preloader.warm("a");
+    preloader.warm("a");
+    created[0]!.finishLoad();
+    preloader.warm("a");
+    expect(created).toHaveLength(1);
+  });
+
+  it("does not dedupe a queued src into oblivion", () => {
+    const { preloader, created } = makePreloader(1);
+    preloader.warmAll(["a", "b", "b"]);
+    expect(preloader.pendingCount).toBe(1);
+    created[0]!.finishLoad();
+    expect(created.map((i) => i.src)).toEqual(["a", "b"]);
+    expect(preloader.pendingCount).toBe(0);
+  });
+
+  it("ignores data: srcs — there is no fetch to get ahead of", () => {
+    const { preloader, created } = makePreloader(4);
+    preloader.warmAll(["data:image/svg+xml,<svg/>", null, undefined, ""]);
+    expect(created).toHaveLength(0);
+    expect(preloader.warmedCount).toBe(0);
+  });
+
+  it("does not report a failed src as warm", () => {
+    const { preloader, created } = makePreloader(4);
+    preloader.warm("a");
+    created[0]!.fail();
+    expect(preloader.isWarm("a")).toBe(false);
+    expect(preloader.warmedCount).toBe(0);
+  });
+
+  it("evicts every url of an asset when its bytes change", () => {
+    const { preloader } = makePreloader(8);
+    const root = "/file:/a/bunny.svg?v=1-2";
+    const variant = `${root}&filters=x`;
+    const other = "/file:/a/room.png?v=1-2";
+    preloader.warmAll([variant, root, other]);
+
+    preloader.evict("/file:/a/bunny.svg?v=9-9");
+
+    expect(preloader.isWarm(variant)).toBe(false);
+    expect(preloader.isWarm(root)).toBe(false);
+    expect(preloader.isWarm(other)).toBe(true);
+  });
+
+  it("evicts urls still waiting in the queue", () => {
+    const { preloader, created } = makePreloader(1);
+    preloader.warmAll(["/file:/a/x.png?v=1", "/file:/a/y.png?v=1"]);
+    expect(preloader.pendingCount).toBe(1);
+
+    preloader.evict("/file:/a/y.png?v=1");
+    expect(preloader.pendingCount).toBe(0);
+
+    created[0]!.finishLoad();
+    expect(created.map((i) => i.src)).toEqual(["/file:/a/x.png?v=1"]);
+  });
+
+  it("does not let a stale failure un-warm a url that is genuinely resident", () => {
+    // evict() drops the map entry but cannot cancel the request already in
+    // flight, so an edited asset can have an old, doomed target running
+    // alongside a new, good one. The old one's onerror must not delete the new
+    // one's entry — that map is the only thing keeping the image resident, so
+    // dropping it makes the next display pop in cold all over again.
+    const { preloader, created } = makePreloader(4);
+    const src = "/file:/a/bunny.svg?v=1-2";
+    preloader.warm(src);
+    preloader.evict(src);
+    preloader.warm(src);
+    expect(created).toHaveLength(2);
+
+    created[1]!.finishLoad();
+    created[0]!.fail();
+
+    expect(preloader.isWarm(src)).toBe(true);
+    expect(preloader.warmedCount).toBe(1);
+  });
+
+  it("releases the slot when creating a target throws", () => {
+    let fail = true;
+    const created: FakeImage[] = [];
+    const preloader = new ImagePreloader(() => {
+      if (fail) {
+        throw new Error("no Image in this realm");
+      }
+      const img = new FakeImage();
+      created.push(img);
+      return img;
+    }, 2);
+
+    preloader.warmAll(["a", "b", "c"]);
+    // Incrementing _inFlight before the create and never releasing it would
+    // pin the pump at its cap and nothing would ever warm again.
+    expect(preloader.inFlightCount).toBe(0);
+
+    fail = false;
+    preloader.warmAll(["d", "e"]);
+    expect(created.map((i) => i.src)).toEqual(["d", "e"]);
+  });
+
+  it("clamps a nonsense concurrency cap instead of stalling forever", () => {
+    for (const cap of [0, -3, Number.NaN]) {
+      const created: FakeImage[] = [];
+      const preloader = new ImagePreloader(() => {
+        const img = new FakeImage();
+        created.push(img);
+        return img;
+      }, cap);
+      preloader.warm("a");
+      expect(created.map((i) => i.src)).toEqual(["a"]);
+      expect(preloader.pendingCount).toBe(0);
+    }
+  });
+
+  it("gives up on a src after a bounded number of failures", () => {
+    // Warming re-runs whenever the program changes. A src that cannot be
+    // served (missing file, offline remote) would otherwise be re-issued
+    // forever AND, being re-queued ahead of anything new, would permanently
+    // occupy the concurrency window. But giving up on the FIRST failure is
+    // just as wrong: on a first visit the service worker may not control the
+    // page yet, so an early sweep can 404 across the board.
+    const { preloader, created } = makePreloader(4);
+    const src = "/file:/a/gone.png?v=1";
+    for (let i = 0; i < MAX_PRELOAD_ATTEMPTS + 4; i += 1) {
+      preloader.warm(src);
+      created[created.length - 1]?.fail();
+    }
+    expect(created).toHaveLength(MAX_PRELOAD_ATTEMPTS);
+    expect(preloader.failedCount).toBe(1);
+  });
+
+  it("retries a failed src once the file behind it changes", () => {
+    const { preloader, created } = makePreloader(4);
+    preloader.warm("/file:/a/gone.png?v=1");
+    created[0]!.fail();
+    preloader.evict("/file:/a/gone.png?v=2");
+    preloader.warm("/file:/a/gone.png?v=2");
+    expect(created.map((i) => i.src)).toEqual([
+      "/file:/a/gone.png?v=1",
+      "/file:/a/gone.png?v=2",
+    ]);
+  });
+
+  it("warmOnly forgets urls the current program no longer renders", () => {
+    // Every authored filter combination mints a new variant url. Without this,
+    // a session spent trying `~happy`, `~sad`, `~angry` keeps all of them
+    // decoded and resident forever, and so does switching projects.
+    const { preloader, created } = makePreloader(8);
+    preloader.warmOnly(["a", "b"]);
+    created.forEach((i) => i.finishLoad());
+    expect(preloader.warmedCount).toBe(2);
+
+    preloader.warmOnly(["b", "c"]);
+    expect(preloader.isWarm("a")).toBe(false);
+    expect(preloader.isWarm("b")).toBe(true);
+    expect(preloader.isWarm("c")).toBe(true);
+    // `b` was already resident and must NOT have been re-requested.
+    expect(created.map((i) => i.src)).toEqual(["a", "b", "c"]);
+  });
+
+  it("survives a target that loads synchronously", () => {
+    const created: FakeImage[] = [];
+    const preloader = new ImagePreloader(() => {
+      const img = new FakeImage();
+      created.push(img);
+      // Assigning src fires onload in the same tick — a cache hit's worst case.
+      Object.defineProperty(img, "src", {
+        get() {
+          return (this as any)._src;
+        },
+        set(value: string) {
+          (this as any)._src = value;
+          this.onload?.call(this, {});
+        },
+      });
+      return img;
+    }, 2);
+    preloader.warmAll(["a", "b", "c", "d"]);
+    expect(created.map((i) => i.src)).toEqual(["a", "b", "c", "d"]);
+    expect(preloader.inFlightCount).toBe(0);
+    expect(preloader.pendingCount).toBe(0);
+  });
+});

--- a/packages/spark-web-player/src/main/utils/ImagePreloader.ts
+++ b/packages/spark-web-player/src/main/utils/ImagePreloader.ts
@@ -1,0 +1,260 @@
+/**
+ * The slice of `HTMLImageElement` a warm-up needs, so tests can pass a fake and
+ * this file stays runnable outside a DOM.
+ */
+export interface PreloadTarget {
+  src: string;
+  onload: ((this: any, ev: any) => any) | null;
+  onerror: ((this: any, ev: any) => any) | null;
+}
+
+/**
+ * How many warm-ups may be in flight at once.
+ *
+ * Not a throttle for its own sake: assets are served by a service worker that
+ * reads OPFS (and, in the cross-origin player, round-trips through the editor),
+ * so an unbounded burst puts every asset behind every other one. The asset the
+ * user reaches first then arrives no sooner than the last — which is how
+ * warming 261 images at project open still left the first portrait cold (#344).
+ */
+export const DEFAULT_MAX_CONCURRENT_PRELOADS = 6;
+
+/** How many times one src may fail before the warm-up stops retrying it. */
+export const MAX_PRELOAD_ATTEMPTS = 3;
+
+/**
+ * Keeps image URLs resident so the renderer paints them without a fetch.
+ *
+ * Keyed by SRC rather than by file uri: one asset can be requested under
+ * several URLs (a filtered SVG variant is `<root>?v=<sig>&filters=<canonical>`),
+ * and warming the wrong one is indistinguishable from not warming at all.
+ */
+export class ImagePreloader {
+  protected _warmed = new Map<string, PreloadTarget>();
+
+  /**
+   * Failure counts per src, and the srcs that have given up.
+   *
+   * Warming re-runs whenever the program changes, so a src that cannot be
+   * served (a file missing from OPFS, an offline remote asset) would otherwise
+   * be re-requested forever and — being re-queued ahead of anything new —
+   * permanently occupy the concurrency window. But giving up on the FIRST
+   * failure is just as wrong: on a first visit the service worker may not be
+   * controlling the page yet, so an early sweep can 404 across the board and
+   * would strand the whole project cold for the session. Hence a small retry
+   * budget rather than either extreme. `evict` clears both, since a changed
+   * file says nothing about the old bytes' failures.
+   */
+  protected _failures = new Map<string, number>();
+
+  protected _failed = new Set<string>();
+
+  protected _queue: string[] = [];
+
+  protected _queued = new Set<string>();
+
+  protected _inFlight = 0;
+
+  protected _pumping = false;
+
+  protected _maxConcurrent: number;
+
+  constructor(
+    protected _createTarget: () => PreloadTarget,
+    maxConcurrent: number = DEFAULT_MAX_CONCURRENT_PRELOADS,
+  ) {
+    // A cap of 0 (or NaN, from a `??`-defaulted config) would leave the pump
+    // loop unable to start anything and the queue growing silently forever.
+    this._maxConcurrent = Math.max(1, Math.floor(maxConcurrent) || 1);
+  }
+
+  get warmedCount() {
+    return this._warmed.size;
+  }
+
+  get pendingCount() {
+    return this._queue.length;
+  }
+
+  get inFlightCount() {
+    return this._inFlight;
+  }
+
+  get failedCount() {
+    return this._failed.size;
+  }
+
+  /** Requested — not necessarily finished loading. */
+  isWarm(src: string) {
+    return this._warmed.has(src);
+  }
+
+  warm(src: string | null | undefined) {
+    // A `data:` src is already in the program — there is no fetch to get ahead
+    // of, and holding a second copy of it decoded would cost memory for nothing.
+    if (!src || src.startsWith("data:")) {
+      return;
+    }
+    if (
+      this._warmed.has(src) ||
+      this._queued.has(src) ||
+      this._failed.has(src)
+    ) {
+      return;
+    }
+    this._queued.add(src);
+    this._queue.push(src);
+    this._pump();
+  }
+
+  warmAll(srcs: Iterable<string | null | undefined>) {
+    for (const src of srcs) {
+      this.warm(src);
+    }
+  }
+
+  /**
+   * Warm exactly this set and forget everything else.
+   *
+   * Retention has to be bounded by what the CURRENT program renders, not by
+   * every url ever seen: each authored filter combination mints a new variant
+   * url, so a session spent trying `~happy`, `~sad`, `~angry` would otherwise
+   * keep all of them decoded and resident forever, as would switching projects.
+   */
+  warmOnly(srcs: Iterable<string | null | undefined>) {
+    const keep = new Set<string>();
+    for (const src of srcs) {
+      if (src) {
+        keep.add(src);
+      }
+      this.warm(src);
+    }
+    for (const src of Array.from(this._warmed.keys())) {
+      if (!keep.has(src)) {
+        this._warmed.delete(src);
+      }
+    }
+    for (const src of Array.from(this._failed)) {
+      if (!keep.has(src)) {
+        this._failed.delete(src);
+      }
+    }
+    for (const src of Array.from(this._failures.keys())) {
+      if (!keep.has(src)) {
+        this._failures.delete(src);
+      }
+    }
+    // The QUEUE too, or a switched-away project's backlog stays ahead of the
+    // urls the user is about to need — which is the failure the concurrency
+    // cap exists to prevent, just relocated.
+    this._queue = this._queue.filter((src) => {
+      if (keep.has(src)) {
+        return true;
+      }
+      this._queued.delete(src);
+      return false;
+    });
+  }
+
+  /**
+   * Forget every warmed URL of one asset.
+   *
+   * Pass any src belonging to the asset: srcs are stamped `?v=<mtime>-<size>`
+   * and variants add more query params, so the path before `?` is what
+   * identifies the file. Editing it mints new URLs and strands the old ones,
+   * which would otherwise be retained decoded forever.
+   */
+  evict(src: string | null | undefined) {
+    if (!src) {
+      return;
+    }
+    const path = src.split("?")[0];
+    const matches = (candidate: string) => candidate.split("?")[0] === path;
+    for (const key of Array.from(this._warmed.keys())) {
+      if (matches(key)) {
+        this._warmed.delete(key);
+      }
+    }
+    // The file changed, so a previous failure says nothing about the new bytes.
+    for (const key of Array.from(this._failed)) {
+      if (matches(key)) {
+        this._failed.delete(key);
+      }
+    }
+    for (const key of Array.from(this._failures.keys())) {
+      if (matches(key)) {
+        this._failures.delete(key);
+      }
+    }
+    this._queue = this._queue.filter((queuedSrc) => {
+      if (matches(queuedSrc)) {
+        this._queued.delete(queuedSrc);
+        return false;
+      }
+      return true;
+    });
+  }
+
+  protected _recordFailure(src: string) {
+    const failures = (this._failures.get(src) ?? 0) + 1;
+    this._failures.set(src, failures);
+    if (failures >= MAX_PRELOAD_ATTEMPTS) {
+      this._failed.add(src);
+    }
+  }
+
+  protected _pump() {
+    // A target that resolves synchronously (a fake in tests, a same-tick cache
+    // hit) calls back into _pump from inside this loop; the guard keeps that
+    // from recursing, and the loop below re-checks _inFlight anyway.
+    if (this._pumping) {
+      return;
+    }
+    this._pumping = true;
+    try {
+      while (this._inFlight < this._maxConcurrent) {
+        const src = this._queue.shift();
+        if (src === undefined) {
+          return;
+        }
+        this._queued.delete(src);
+        this._inFlight += 1;
+        let settled = false;
+        const done = () => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          this._inFlight -= 1;
+          this._pump();
+        };
+        try {
+          const target = this._createTarget();
+          this._warmed.set(src, target);
+          target.onload = done;
+          target.onerror = () => {
+            // Only if the entry is still THIS target's: an `evict` between
+            // warms can leave an older, doomed request running alongside a
+            // newer, good one, and a blind delete would drop the good one —
+            // un-warming a url that is genuinely resident.
+            if (this._warmed.get(src) === target) {
+              this._warmed.delete(src);
+              this._recordFailure(src);
+            }
+            done();
+          };
+          // Assigned LAST so the handlers are attached before the load starts.
+          target.src = src;
+        } catch {
+          // Creating or arming the target threw. Release the slot, or the cap
+          // fills with phantoms and the pump never starts anything again.
+          this._warmed.delete(src);
+          this._recordFailure(src);
+          done();
+        }
+      }
+    } finally {
+      this._pumping = false;
+    }
+  }
+}

--- a/packages/spark-web-player/src/main/utils/getProgramImageSrcs.test.ts
+++ b/packages/spark-web-player/src/main/utils/getProgramImageSrcs.test.ts
@@ -1,0 +1,328 @@
+// #344: a filtered image is displayed through `<root>?v=<sig>&filters=<canonical>`,
+// a url NOTHING else fetches. Warming the root asset therefore leaves the url
+// the renderer actually asks for cold, and the element paints blank for the
+// length of that fetch. These tests pin that the warm set contains the
+// DISPLAYED url, not just the root one.
+
+import { UIModule } from "@impower/spark-engine/src/game/modules/ui/classes/UIModule";
+import { SparkdownCompiler } from "@impower/sparkdown/src/compiler/classes/SparkdownCompiler";
+import { describe, expect, it } from "vitest";
+import { getProgramImageSrcs } from "./getProgramImageSrcs";
+
+/**
+ * The engine's real resolution path, without booting a Game (same technique as
+ * spark-engine's FilteredLayeredImage.test.ts).
+ */
+class ProbeUIModule extends UIModule {
+  constructor(context: any) {
+    super({} as any);
+    (this as any)._context = context;
+    Object.defineProperty(this, "context", {
+      get: () => context,
+      configurable: true,
+    });
+  }
+}
+
+const MAIN_URI = "file://proj/main.sd";
+
+const SVG = `<svg xmlns="http://www.w3.org/2000/svg"><g id='filter hat'><path/></g><g id='filter default body'><path/></g></svg>`;
+
+const BUNNY_SRC = "/file:/local/assets/bunny.svg?v=11-2200";
+const ROOM_SRC = "/file:/local/assets/room.png?v=22-3300";
+
+/**
+ * A real filter definition, in the shape the R&B project uses. Without one, a
+ * `~hat` reference resolves to the SAME empty-filter param as the implicit
+ * whole-asset variant — i.e. the same url — and any test about the two is
+ * silently comparing a value with itself.
+ */
+const HAT_FILTER = `define hat as filter with
+  includes = {
+    "",
+  }
+  excludes = {
+    "hat",
+  }
+end
+
+`;
+
+/** Compile a one-script project the way the player's workspace does (#299). */
+const compileProject = (script: string) => {
+  const compiler = new SparkdownCompiler();
+  compiler.configure({
+    stripImageData: true,
+    files: [
+      {
+        uri: MAIN_URI,
+        type: "script",
+        name: "main",
+        ext: "sd",
+        text: script,
+        version: 1,
+        languageId: "sparkdown",
+      },
+      {
+        uri: "file://proj/assets/bunny.svg",
+        type: "image",
+        name: "bunny",
+        ext: "svg",
+        src: BUNNY_SRC,
+        text: SVG,
+      },
+      {
+        uri: "file://proj/assets/room.png",
+        type: "image",
+        name: "room",
+        ext: "png",
+        src: ROOM_SRC,
+      },
+    ] as any,
+  });
+  return compiler.compile({ textDocument: { uri: MAIN_URI } }).program as any;
+};
+
+describe("getProgramImageSrcs", () => {
+  it("warms the FILTERED url an svg is displayed through, not only its root src", () => {
+    const program = compileProject(`[[show backdrop bunny]]\n`);
+    const srcs = getProgramImageSrcs(program.context);
+
+    // The compiler declares an implicit filtered_image for every svg, so even
+    // a plain reference renders through a variant url.
+    const variant = srcs.find((src) => src.includes("&filters="));
+    expect(variant).toMatch(
+      /^\/file:\/local\/assets\/bunny\.svg\?v=11-2200&filters=/,
+    );
+    // The bug, stated: warming the root is NOT warming what gets displayed.
+    expect(variant).not.toEqual(BUNNY_SRC);
+    // The root is still worth warming — layers of a layered_image, and raster
+    // and remote assets, all render through it.
+    expect(srcs).toContain(BUNNY_SRC);
+  });
+
+  it("never writes back to the program", () => {
+    // `filterImage` memoizes by writing `filtered_src` onto the struct it is
+    // handed, and the player gives the GAME that very object. Resolving in
+    // place would let a warm-up decide what the game renders — and decide it
+    // differently, since `Game.applyBuiltinDefaults` fills a filter's
+    // unauthored includes/excludes from `$default` and this sweep does not.
+    const program = compileProject(`[[show backdrop bunny]]\n`);
+    const before = JSON.stringify(program.context);
+    const srcs = getProgramImageSrcs(program.context);
+    expect(srcs.some((src) => src.includes("&filters="))).toBe(true);
+    expect(JSON.stringify(program.context)).toEqual(before);
+    expect(program.context.filtered_image.bunny.filtered_src).toBeUndefined();
+  });
+
+  it("puts filtered variants ahead of root srcs in the warm order", () => {
+    const program = compileProject(`[[show backdrop bunny]]\n`);
+    const srcs = getProgramImageSrcs(program.context);
+    const variant = srcs.find((src) => src.includes("&filters="))!;
+    expect(srcs).toContain(BUNNY_SRC);
+    expect(srcs.indexOf(variant)).toBeLessThan(srcs.indexOf(BUNNY_SRC));
+  });
+
+  it("warms raster assets, which have no variant url", () => {
+    const program = compileProject(`[[show backdrop room]]\n`);
+    const srcs = getProgramImageSrcs(program.context);
+    expect(srcs).toContain(ROOM_SRC);
+  });
+
+  it("warms the variant of a `~`-tagged reference, filter and all", () => {
+    const program = compileProject(
+      `${HAT_FILTER}[[show portrait bunny~hat]]\n`,
+    );
+    expect(program.context.filtered_image["bunny~hat"]).toBeDefined();
+    const srcs = getProgramImageSrcs(program.context);
+    const variant = srcs.find((src) =>
+      decodeURIComponent(src).includes('"hat"'),
+    )!;
+    // Not merely "a variant url" — the one that encodes THIS filter.
+    expect(variant).toMatch(/^\/file:\/local\/assets\/bunny\.svg\?v=11-2200&/);
+  });
+
+  it("warms `~`-tagged variants BEFORE the implicit whole-asset ones", () => {
+    // `populateImplicitDefs` declares one implicit filtered_image per svg
+    // before it declares the `~`-tagged ones the scripts reference, so warming
+    // in map order buries every referenced variant behind one entry per asset
+    // in the project — 78 ahead of the portrait #344 is about, on the real
+    // project, at a concurrency of 6.
+    const program = compileProject(
+      `${HAT_FILTER}[[show backdrop bunny]]\n[[show portrait bunny~hat]]\n`,
+    );
+    expect(program.context.filter.hat.excludes).toEqual(["hat"]);
+    const srcs = getProgramImageSrcs(program.context);
+    const variants = srcs.filter((src) => src.includes("&filters="));
+    const tagged = variants.find((src) =>
+      decodeURIComponent(src).includes('"hat"'),
+    )!;
+    const implicit = variants.find((src) => src !== tagged)!;
+    expect(tagged).toBeDefined();
+    expect(implicit).toBeDefined();
+    expect(srcs.indexOf(tagged)).toBeLessThan(srcs.indexOf(implicit));
+  });
+
+  it("warms every src the ENGINE's own resolution path asks for", () => {
+    // The invariant the whole change rests on: everything
+    // `UIModule.getImageSrcsByName` (the ACTUAL display path, with its
+    // `sortFilteredName` canonicalization and its layered fallback) asks for is
+    // in the warm set. Compiled twice so the two resolutions run over
+    // independent structs and neither can pass by reading the other's memo.
+    const script = `${HAT_FILTER}[[show backdrop bunny]]\n[[show portrait bunny~hat]]\n[[show backdrop room]]\n`;
+    const warmed = new Set(getProgramImageSrcs(compileProject(script).context));
+    const fresh = compileProject(script);
+    const ui = new ProbeUIModule(fresh.context);
+
+    const names = [
+      ...Object.keys(fresh.context.filtered_image ?? {}),
+      ...Object.keys(fresh.context.image ?? {}),
+    ];
+    const requested = names.flatMap((name) => ui.getImageSrcsByName(name) ?? []);
+
+    expect(requested.length).toBeGreaterThan(0);
+    expect(requested.some((src: string) => src.includes("&filters="))).toBe(
+      true,
+    );
+    for (const src of requested) {
+      expect(Array.from(warmed)).toContain(src);
+    }
+  });
+
+  describe("resolution rules", () => {
+    const makeContext = (
+      image: Record<string, unknown>,
+      filters: unknown[] = [{ $type: "filter", $name: "f" }],
+    ) => ({
+      image: { bunny: { $type: "image", $name: "bunny", ...image } },
+      filtered_image: {
+        b: {
+          $type: "filtered_image",
+          $name: "b",
+          image: { $type: "image", $name: "bunny" },
+          filters,
+        } as any,
+      },
+      filter: { f: { includes: [""], excludes: ["hat"] } },
+    });
+
+    it("resolves a named filter to a `filters=` url", () => {
+      const context = makeContext({ ext: "svg", src: BUNNY_SRC });
+      const srcs = getProgramImageSrcs(context);
+      expect(srcs[0]).toMatch(/^\/file:\/local\/assets\/bunny\.svg\?v=11-2200&filters=/);
+      expect(srcs[0]).toContain(encodeURIComponent('"e":["hat"]'));
+      expect(context.filtered_image.b.filtered_src).toBeUndefined();
+    });
+
+    it("skips inlined-svg hosts, whose variants are data: uris", () => {
+      const context = makeContext({
+        ext: "svg",
+        src: BUNNY_SRC,
+        data: `data:image/svg+xml,${SVG}`,
+      });
+      const srcs = getProgramImageSrcs(context);
+      // Nothing to fetch, so nothing to warm — and crucially the svg was never
+      // parsed and rewritten just to find that out.
+      expect(context.filtered_image.b.filtered_src).toBeUndefined();
+      expect(srcs).toEqual([BUNNY_SRC]);
+    });
+
+    it("skips inlined-svg hosts through a CHAINED root too", () => {
+      // `filtered_image.image` can name another filtered_image. A one-hop
+      // lookup misses that, sending the struct into filterImage's inline
+      // branch — a full parse + rewrite of the svg, on every compile, to
+      // produce a data: uri nobody warms.
+      const context: any = {
+        image: {
+          bunny: {
+            $type: "image",
+            $name: "bunny",
+            ext: "svg",
+            src: BUNNY_SRC,
+            data: `data:image/svg+xml,${SVG}`,
+          },
+        },
+        filtered_image: {
+          once: {
+            $type: "filtered_image",
+            $name: "once",
+            image: { $type: "image", $name: "bunny" },
+            filters: [{ $type: "filter", $name: "f" }],
+          },
+          twice: {
+            $type: "filtered_image",
+            $name: "twice",
+            image: { $type: "filtered_image", $name: "once" },
+            filters: [{ $type: "filter", $name: "f" }],
+          },
+        },
+        filter: { f: { includes: [""], excludes: ["hat"] } },
+      };
+      const srcs = getProgramImageSrcs(context);
+      expect(context.filtered_image.once.filtered_src).toBeUndefined();
+      expect(context.filtered_image.twice.filtered_src).toBeUndefined();
+      expect(srcs).toEqual([BUNNY_SRC]);
+    });
+
+    it("does not loop on a self-referential root chain", () => {
+      const context: any = {
+        image: {},
+        filtered_image: {
+          a: {
+            $type: "filtered_image",
+            $name: "a",
+            image: { $type: "filtered_image", $name: "b" },
+            filters: [],
+          },
+          b: {
+            $type: "filtered_image",
+            $name: "b",
+            image: { $type: "filtered_image", $name: "a" },
+            filters: [],
+          },
+        },
+        filter: {},
+      };
+      expect(getProgramImageSrcs(context)).toEqual([]);
+    });
+
+    it("covers a layered root through its layers", () => {
+      const context: any = {
+        image: {
+          body: { $type: "image", $name: "body", src: "/file:/a.svg?v=1" },
+          hat: { $type: "image", $name: "hat", src: "/file:/b.svg?v=1" },
+        },
+        layered_image: {
+          bunny: {
+            $type: "layered_image",
+            $name: "bunny",
+            assets: {
+              "default body": { $type: "image", $name: "body" },
+              "filter hat": { $type: "image", $name: "hat" },
+            },
+          },
+        },
+        filtered_image: {
+          b: {
+            $type: "filtered_image",
+            $name: "b",
+            image: { $type: "layered_image", $name: "bunny" },
+            filters: [{ $type: "filter", $name: "f" }],
+          },
+        },
+        filter: { f: { includes: [""], excludes: ["hat"] } },
+      };
+      const srcs = getProgramImageSrcs(context);
+      // A layered root has no single flattened src; the surviving layers are
+      // plain `image` structs and must still all be warmed.
+      expect(context.filtered_image.b.filtered_src).toBeUndefined();
+      expect(srcs).toContain("/file:/a.svg?v=1");
+      expect(srcs).toContain("/file:/b.svg?v=1");
+    });
+
+    it("returns nothing for an absent context", () => {
+      expect(getProgramImageSrcs(undefined)).toEqual([]);
+      expect(getProgramImageSrcs({})).toEqual([]);
+    });
+  });
+});

--- a/packages/spark-web-player/src/main/utils/getProgramImageSrcs.ts
+++ b/packages/spark-web-player/src/main/utils/getProgramImageSrcs.ts
@@ -1,0 +1,111 @@
+import { filterImage } from "@impower/sparkdown/src/compiler/utils/filterImage";
+
+/**
+ * Does this filtered image resolve to inlined SVG source?
+ *
+ * `filtered_image.image` can name another `filtered_image` (`a` filtered by one
+ * filter, then filtered again), so a one-hop lookup misses chained roots —
+ * which would send them into `filterImage`'s parse-and-rewrite branch to
+ * produce a `data:` uri nobody warms. Walks the chain the way
+ * `filterImage`'s own `getRootImage` does, with the same cycle guard.
+ */
+const rootHasInlinedData = (
+  context: { [type: string]: { [name: string]: any } },
+  filteredImage: any,
+): boolean => {
+  const seen = new Set<string>();
+  let name = filteredImage?.["image"]?.["$name"];
+  while (typeof name === "string" && !seen.has(name)) {
+    seen.add(name);
+    const image = context["image"]?.[name];
+    if (image) {
+      return !!image["data"];
+    }
+    const nested = context["filtered_image"]?.[name];
+    if (!nested) {
+      // A layered root (or nothing at all) — neither carries inlined source
+      // that `filterImage` would have to parse.
+      return false;
+    }
+    name = nested["image"]?.["$name"];
+  }
+  return false;
+};
+
+/**
+ * Every image URL a compiled program will make the renderer request, ordered by
+ * how likely it is that the user reaches it first.
+ *
+ * The order is load-bearing, not cosmetic. `populateImplicitDefs` declares a
+ * `filtered_image` for EVERY svg asset before it declares the `~`-tagged ones
+ * the scripts actually reference, so warming in map order buries the referenced
+ * variants behind one entry per asset in the project — on the real project
+ * that is ~78 whole-asset variants ahead of the ~268 the script asks for, and
+ * the portrait #344 is about ends up near the back. So:
+ *
+ *   1. `~`-tagged variants — these exist only because a script references them.
+ *   2. bare implicit variants — one per svg, referenced or not.
+ *   3. root srcs — what raster and remote assets render through.
+ *
+ * A filtered image renders through `<root>?v=<sig>&filters=<canonical>`, a URL
+ * nothing else ever fetches, so warming the root asset instead leaves the
+ * variant cold and the element paints blank for the length of the fetch (#344).
+ * Note that this is not only the `~`-tagged references: an empty filter still
+ * serializes to a `filters=` param, so plain `[[show portrait bunny]]` goes
+ * through a variant URL too.
+ *
+ * Resolution mirrors `UIModule.getImageSrcsByName` by calling the same
+ * `filterImage` — but on COPIES of the structs, never the program's own.
+ * `filterImage` memoizes by writing `filtered_src` back onto the struct it is
+ * given, and the player hands the game that very object (`Game` shallow-spreads
+ * `program.context`, so the per-type records are shared). Memoizing from here
+ * would therefore let a warm-up decide what the game renders — and it would
+ * decide it differently, because `Game.applyBuiltinDefaults` fills a `filter`'s
+ * unauthored `includes`/`excludes` from `$default` and this sweep runs against
+ * the raw compiled structs. For `define f as filter end` those disagree: `[]`
+ * removes every filterable non-`default` node, `[""]` removes nothing. A
+ * warm-up must never be able to change a pixel, so it resolves in its own
+ * scratch space and the engine keeps computing its own answer.
+ */
+export const getProgramImageSrcs = (
+  context: { [type: string]: { [name: string]: any } } | undefined,
+): string[] => {
+  const tagged: string[] = [];
+  const implicit: string[] = [];
+  const roots: string[] = [];
+  if (!context) {
+    return roots;
+  }
+  const images = context["image"];
+  const filteredImages = context["filtered_image"];
+  if (filteredImages) {
+    for (const [name, filteredImage] of Object.entries(filteredImages)) {
+      if (rootHasInlinedData(context, filteredImage)) {
+        // Hosts that keep the SVG source inlined resolve variants to a `data:`
+        // URI: nothing to fetch, and building one means parsing and rewriting
+        // the whole SVG. Don't pay that to warm nothing.
+        continue;
+      }
+      // The copy is the whole point — see the note above. It is shallow, which
+      // is enough: `filterImage` only ever writes `filtered_src` and
+      // `filtered_layers` at the top level.
+      const scratch = { ...filteredImage };
+      filterImage(context, scratch);
+      const src = scratch["filtered_src"];
+      if (typeof src === "string") {
+        (name.includes("~") ? tagged : implicit).push(src);
+      }
+      // A LAYERED root yields `filtered_layers` instead of one flattened src.
+      // Those layers are plain `image` structs, so the sweep below covers them.
+    }
+  }
+  if (images) {
+    for (const image of Object.values(images)) {
+      const src = image?.["src"];
+      if (typeof src === "string") {
+        roots.push(src);
+      }
+    }
+  }
+  return [...tagged, ...implicit, ...roots];
+};

--- a/packages/spark-web-player/src/main/workers/installWorkspaceWorker.ts
+++ b/packages/spark-web-player/src/main/workers/installWorkspaceWorker.ts
@@ -10,35 +10,18 @@ import { DidChangeConfigurationMessage } from "@impower/spark-editor-protocol/sr
 import { DidChangeWatchedFilesMessage } from "@impower/spark-editor-protocol/src/protocols/workspace/DidChangeWatchedFilesMessage";
 import { ExecuteCommandMessage } from "@impower/spark-editor-protocol/src/protocols/workspace/ExecuteCommandMessage";
 import { File } from "@impower/sparkdown/src/compiler";
+import { SparkProgram } from "@impower/sparkdown/src/compiler/types/SparkProgram";
 import { SparkdownWorkspace } from "@impower/sparkdown/src/workspace/classes/SparkdownWorkspace";
+import { getProgramImageSrcs } from "../utils/getProgramImageSrcs";
+import { ImagePreloader } from "../utils/ImagePreloader";
 import WORKSPACE_INLINE_WORKER_STRING from "./workspace.worker";
 
 export function installWorkspaceWorker(connection: MessageConnection) {
-  const preloadedImages = new Map<string, HTMLElement>();
-
-  const preloadImage = async (uri: string, src: string) => {
-    if (uri && src) {
-      if (preloadedImages.has(uri)) {
-        return preloadedImages.get(uri);
-      }
-      try {
-        await new Promise((resolve, reject) => {
-          const img = new Image();
-          img.src = src;
-          img.onload = () => resolve(img);
-          img.onerror = () => reject(img);
-          preloadedImages.set(uri, img);
-        });
-      } catch (e) {
-        console.warn("Could not preload: ", src);
-      }
-    }
-    return null;
-  };
-
-  const unloadImage = async (uri: string) => {
-    return preloadedImages.delete(uri);
-  };
+  const imagePreloader = new ImagePreloader(() => new Image());
+  // Keyed by document uri: `program.version` counts per uri, so a single
+  // counter would let one script's version N suppress another script's
+  // version N and leave that program's images unwarmed entirely.
+  let lastWarmedVersions = new Map<string, number>();
 
   class SparkdownGameWorkspace extends SparkdownWorkspace {
     constructor(profilerId?: string) {
@@ -106,25 +89,57 @@ export function installWorkspaceWorker(connection: MessageConnection) {
     }
 
     override async onDeletedFile(file: File) {
-      if (file?.type === "image") {
-        unloadImage(file.uri);
-      }
-      return file;
-    }
-
-    override async onCreatedFile(file: File) {
       if (file?.type === "image" && file?.src) {
-        preloadImage(file.uri, file.src);
+        imagePreloader.evict(file.src);
+        // Force the next compile to re-sweep even if the program itself is
+        // byte-identical, or the urls just evicted would stay cold.
+        lastWarmedVersions = new Map();
       }
       return file;
     }
 
     override async onChangedFile(file: File) {
       if (file?.type === "image" && file?.src) {
-        unloadImage(file.uri);
-        preloadImage(file.uri, file.src);
+        // Editing an asset re-stamps its `?v=` signature, so the warmed URLs
+        // are dead. The compile that follows warms the new ones.
+        imagePreloader.evict(file.src);
+        // Force the next compile to re-sweep even if the program itself is
+        // byte-identical, or the urls just evicted would stay cold.
+        lastWarmedVersions = new Map();
       }
       return file;
+    }
+
+    // Warming is driven by the COMPILED PROGRAM, not by file enumeration.
+    // Enumeration only knows each asset's root url, and an svg is displayed
+    // through `<root>?v=<sig>&filters=<canonical>` — so a per-file warm-up
+    // fetches a url the renderer never asks for and leaves the one it does ask
+    // for cold, which is the pop-in in #344. The program carries the filters.
+    override onCompiledTextDocument(params: {
+      textDocument: { uri: string };
+      program: SparkProgram;
+    }) {
+      try {
+        // This hook fires on EVERY compile, i.e. every debounced keystroke, and
+        // the program arrives structured-cloned from the compiler worker — so
+        // `filterImage`'s memoization does not carry across compiles and the
+        // whole resolution would re-run per keystroke. `version` only moves
+        // when the program actually changed, so gate on it.
+        const uri = params.textDocument?.uri ?? "";
+        const version = params.program?.version;
+        if (version !== undefined && version === lastWarmedVersions.get(uri)) {
+          return;
+        }
+        if (version !== undefined) {
+          lastWarmedVersions.set(uri, version);
+        }
+        imagePreloader.warmOnly(getProgramImageSrcs(params.program?.context));
+      } catch (e) {
+        // `SparkdownWorkspace.compile` calls this hook without a catch, so a
+        // throw here would fail the COMPILE. A warm-up is an optimization; it
+        // must never be able to take the program down with it.
+        console.warn("Could not warm program images:", e);
+      }
     }
   }
 

--- a/packages/sparkdown/src/filters/filteredSvg.ts
+++ b/packages/sparkdown/src/filters/filteredSvg.ts
@@ -193,12 +193,47 @@ export interface FilteredSvgFile extends Blob {
 }
 
 /**
+ * Generations currently running, keyed by cache key.
+ *
+ * Showing an image issues TWO simultaneous requests for the same variant url —
+ * `UIModule.createImage` writes it as the element's `background-image` AND as
+ * the `src` of a hidden `<img>` child — and a preload can race both. Without
+ * this, each of those misses the cache (nothing is stored until the first one
+ * finishes) and runs its own full read + filter + prune, so a first display
+ * costs the work two or three times over (#344).
+ */
+const inFlightGenerations = new Map<string, Promise<string>>();
+
+/**
+ * A fresh response per caller, over the shared filtered SOURCE.
+ *
+ * Deliberately not `clone()`: cloning tees the body, so every clone leaves a
+ * branch that has to be read or the other branch stalls behind it. Re-wrapping
+ * a string has no such coupling and costs nothing here.
+ */
+export const filteredSvgResponse = (body: string) =>
+  new Response(body, {
+    status: 200,
+    headers: new Headers({
+      "Content-Type": "image/svg+xml",
+      "Cache-Control": "max-age=31536000, immutable",
+    }),
+  });
+
+/**
  * Cached-or-freshly-filtered SVG response for one file, or `undefined` if the
  * param is garbage or a no-op (caller serves the unfiltered original).
  *
  * On a fresh generation, entries for the SAME path+filters at an OLDER file
  * signature are pruned — variants accumulate per edit otherwise and nothing
  * else ever deletes them (the activate sweep deliberately keeps this bucket).
+ *
+ * Concurrent callers for one variant share a single generation and each gets
+ * its own `Response` over the shared source. Sharing is best-effort, never
+ * load-bearing: a caller that arrives just outside the window, or whose shared
+ * generation FAILED, falls back to generating for itself — so one transient
+ * read/quota error can't turn into every concurrent caller serving unfiltered
+ * art.
  */
 export const getOrCreateFilteredSvg = async (
   cache: FilteredSvgCache,
@@ -226,28 +261,73 @@ export const getOrCreateFilteredSvg = async (
     file.size,
     canonical,
   )}`;
+  // Checked BEFORE the cache, and again after: `cache.match` is a yield point,
+  // so a caller that started before the winner's `cache.put` can resume after
+  // it, seeing neither a cache entry nor (if only checked once) a generation.
+  const share = async (pending: Promise<string>) => {
+    try {
+      return filteredSvgResponse(await pending);
+    } catch {
+      // The shared generation failed. Don't inherit its failure — falling
+      // through to `undefined` would make the service worker serve the
+      // UNFILTERED svg, i.e. visibly wrong art, for every caller at once.
+      return undefined;
+    }
+  };
   try {
+    const early = inFlightGenerations.get(key);
+    if (early) {
+      const shared = await share(early);
+      if (shared) {
+        return shared;
+      }
+    }
     const cached = await cache.match(key);
     if (cached) {
       return cached;
     }
-    const filtered = filterSVG(await file.text(), filter);
-    const response = new Response(filtered, {
-      status: 200,
-      headers: new Headers({
-        "Content-Type": "image/svg+xml",
-        "Cache-Control": "max-age=31536000, immutable",
-      }),
-    });
-    // Prune superseded signatures of this exact variant before storing.
-    const existing = await cache.keys();
-    await Promise.all(
-      existing
-        .filter((req) => req.url.includes(variantPrefix) && !req.url.endsWith(key))
-        .map((req) => cache.delete(req.url)),
-    );
-    await cache.put(key, response.clone());
-    return response;
+    const pending = inFlightGenerations.get(key);
+    if (pending) {
+      const shared = await share(pending);
+      if (shared) {
+        return shared;
+      }
+    }
+    const generation = (async () => {
+      const filtered = filterSVG(await file.text(), filter);
+      await cache.put(key, filteredSvgResponse(filtered));
+      // Prune superseded signatures of this exact variant AFTER responding.
+      // `cache.keys()` enumerates the whole bucket, so on the critical path it
+      // makes every generation cost O(entries) — and warming a project's whole
+      // variant set turns that into O(n^2) on the very thread that has to serve
+      // the image the user is waiting for. Housekeeping, so best-effort: if the
+      // service worker is torn down first, the next generation prunes instead.
+      void (async () => {
+        try {
+          const existing = await cache.keys();
+          await Promise.all(
+            existing
+              .filter(
+                (req) =>
+                  req.url.includes(variantPrefix) && !req.url.endsWith(key),
+              )
+              .map((req) => cache.delete(req.url)),
+          );
+        } catch {}
+      })();
+      return filtered;
+    })();
+    inFlightGenerations.set(key, generation);
+    try {
+      return filteredSvgResponse(await generation);
+    } finally {
+      // Only if it is still OURS: a caller whose shared generation failed
+      // registers a replacement, and an unconditional delete here would strand
+      // that one for everybody behind it.
+      if (inFlightGenerations.get(key) === generation) {
+        inFlightGenerations.delete(key);
+      }
+    }
   } catch {
     return undefined;
   }

--- a/packages/sparkdown/src/tests/compiler/filteredSvgOnDemand.test.ts
+++ b/packages/sparkdown/src/tests/compiler/filteredSvgOnDemand.test.ts
@@ -175,6 +175,11 @@ describe("getOrCreateFilteredSvg", () => {
       svgFile(222), // the file was edited
       PARAM,
     );
+    // Pruning runs AFTER the response, off the critical path — `cache.keys()`
+    // enumerates the whole bucket and warming generates the project's entire
+    // variant set, so on the critical path that is O(n^2) on the thread serving
+    // the image the user is waiting for.
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(cache.store.size).toBe(1);
     expect(Array.from(cache.store.keys())[0]).toContain("sig=222-");
   });
@@ -200,6 +205,101 @@ describe("getOrCreateFilteredSvg", () => {
       ),
     ).toBeUndefined();
     expect(cache.store.size).toBe(0);
+  });
+
+  it("runs ONE generation for concurrent requests of the same variant", async () => {
+    // Showing an image asks for the variant twice at once (element
+    // `background-image` + the hidden <img> child `UIModule.createImage` adds),
+    // and a preload can race both. Each miss used to do its own read + filter
+    // + prune, so a first display paid the work 2-3x (#344).
+    const cache = makeCache();
+    let reads = 0;
+    const counted = (lastModified: number): FilteredSvgFile => {
+      const blob = svgFile(lastModified);
+      return Object.assign(blob, {
+        text: async () => {
+          reads += 1;
+          // Yield, so the second caller definitely arrives mid-generation.
+          await Promise.resolve();
+          return SVG;
+        },
+      }) as FilteredSvgFile;
+    };
+    const responses = await Promise.all([
+      getOrCreateFilteredSvg(cache, "local/assets/portrait.svg", counted(111), PARAM),
+      getOrCreateFilteredSvg(cache, "local/assets/portrait.svg", counted(111), PARAM),
+      getOrCreateFilteredSvg(cache, "local/assets/portrait.svg", counted(111), PARAM),
+    ]);
+    expect(reads).toBe(1);
+    expect(cache.store.size).toBe(1);
+    // Distinct, independently readable responses. (This does NOT distinguish a
+    // fresh Response from a `clone()` — clones are distinct and readable too.
+    // Why the implementation avoids clone() is a browser-only stall that no
+    // Node test can observe; see the note on `filteredSvgResponse`.)
+    expect(new Set(responses).size).toBe(3);
+    const texts = await Promise.all(responses.map((r) => r!.text()));
+    for (const text of texts) {
+      expect(text).toContain("filter default body");
+      expect(text).not.toContain("filter hat");
+    }
+    // ...and the stored entry is still independently readable afterwards.
+    const stored = Array.from(cache.store.values())[0]!;
+    expect(await stored.clone().text()).toContain("filter default body");
+  });
+
+  it("lets a caller regenerate when the generation it shared failed", async () => {
+    // Sharing must never turn ONE transient read failure into every concurrent
+    // caller serving unfiltered art: `sw.ts` treats `undefined` as "serve the
+    // original", which draws every filter-tagged node.
+    const cache = makeCache();
+    let attempt = 0;
+    const flaky = (): FilteredSvgFile =>
+      Object.assign(svgFile(111), {
+        text: async () => {
+          attempt += 1;
+          await Promise.resolve();
+          if (attempt === 1) {
+            throw new Error("read failed");
+          }
+          return SVG;
+        },
+      }) as FilteredSvgFile;
+    const [first, second] = await Promise.all([
+      getOrCreateFilteredSvg(cache, "local/assets/portrait.svg", flaky(), PARAM),
+      getOrCreateFilteredSvg(cache, "local/assets/portrait.svg", flaky(), PARAM),
+    ]);
+    // One of the two owned the failing generation; the other must not have
+    // inherited it.
+    const survivors = [first, second].filter(Boolean);
+    expect(survivors).toHaveLength(1);
+    expect(await survivors[0]!.text()).toContain("filter default body");
+    expect(cache.store.size).toBe(1);
+  });
+
+  it("does not strand a failed generation for later callers", async () => {
+    const cache = makeCache();
+    const exploding = Object.assign(svgFile(111), {
+      text: async () => {
+        throw new Error("read failed");
+      },
+    }) as FilteredSvgFile;
+    expect(
+      await getOrCreateFilteredSvg(
+        cache,
+        "local/assets/portrait.svg",
+        exploding,
+        PARAM,
+      ),
+    ).toBeUndefined();
+    // The key must be released, or the variant can never be generated again.
+    const recovered = await getOrCreateFilteredSvg(
+      cache,
+      "local/assets/portrait.svg",
+      svgFile(111),
+      PARAM,
+    );
+    expect(recovered).toBeDefined();
+    expect(await recovered!.text()).toContain("filter default body");
   });
 
   it("shares one cache entry across non-canonical spellings of the same filter", async () => {

--- a/sparkdown-player-app/src/workers/sw.ts
+++ b/sparkdown-player-app/src/workers/sw.ts
@@ -1,7 +1,11 @@
 import { MessageProtocolRequestType } from "@impower/jsonrpc/src/common/classes/MessageProtocolRequestType";
 import { FetchGameAssetMessage } from "../../../packages/spark-engine/src/game/core/classes/messages/FetchGameAssetMessage";
 import { filterSVG } from "../../../packages/sparkdown/src/compiler/utils/filterSVG";
-import { parseImageFilterParam } from "../../../packages/sparkdown/src/filters/filteredSvg";
+import {
+  filteredSvgResponse,
+  parseImageFilterParam,
+  type ImageFilter,
+} from "../../../packages/sparkdown/src/filters/filteredSvg";
 
 export {};
 declare const self: ServiceWorkerGlobalScope;
@@ -45,6 +49,59 @@ async function sendRequest<M extends string, P, R>(
   });
 }
 
+/** Filtered-variant generations currently running, keyed by request url. */
+const inFlightFilteredSvgs: Map<string, Promise<string>> = new Map();
+
+/**
+ * Relay the root svg's bytes from the editor, filter them, and cache the
+ * variant. Resolves to the filtered SOURCE, so concurrent callers can each
+ * build their own Response instead of sharing a tee'd body.
+ */
+async function generateFilteredSvg(
+  url: URL,
+  path: string,
+  clientId: string,
+  filter: ImageFilter,
+  filtersParam: string,
+): Promise<string> {
+  const client = await self.clients.get(clientId);
+  if (!client) {
+    throw new Error(`no client ${clientId}`);
+  }
+  const { transfer } = await sendRequest(client, FetchGameAssetMessage.type, {
+    path,
+  });
+  const filtered = filterSVG(new TextDecoder().decode(transfer[0]), filter);
+  try {
+    const cache = await caches.open(SW_FILTERED_CACHE_NAME);
+    await cache.put(url.href, filteredSvgResponse(filtered));
+    // Prune superseded signatures of this exact variant AFTER responding: same
+    // path + same filters at a DIFFERENT url means the file's `?v=` signature
+    // moved (an edit), so the old entry can never be requested again. Kept off
+    // the critical path because `cache.keys()` enumerates the whole bucket, and
+    // warming a project's whole variant set would make that O(n^2) on the
+    // thread serving the image the user is waiting for.
+    void (async () => {
+      try {
+        const keys = await cache.keys();
+        await Promise.all(
+          keys
+            .filter((req) => {
+              const cachedUrl = new URL(req.url);
+              return (
+                cachedUrl.pathname === url.pathname &&
+                cachedUrl.searchParams.get("filters") === filtersParam &&
+                req.url !== url.href
+              );
+            })
+            .map((req) => cache.delete(req)),
+        );
+      } catch {}
+    })();
+  } catch {}
+  return filtered;
+}
+
 async function handleLocalAssetRequest(url: URL, clientId: string) {
   const path = url.pathname.replace(RESOURCE_PROTOCOL, "");
   const filename = path.split("/").at(-1);
@@ -70,9 +127,40 @@ async function handleLocalAssetRequest(url: URL, clientId: string) {
         return cached;
       }
     } catch {}
+    // Showing an image asks for the variant TWICE at once — `createImage`
+    // writes the url as `background-image` and as a hidden <img>'s src — and a
+    // preload can race both. Nothing is cached until the first finishes, so
+    // without this every one of them pays the relay AND filterSVG again
+    // (#344). Sharing is best-effort: a failed generation falls through to the
+    // unfiltered relay below rather than failing every caller at once.
+    const shared = inFlightFilteredSvgs.get(url.href);
+    if (shared) {
+      try {
+        return filteredSvgResponse(await shared);
+      } catch {}
+    }
   }
 
   try {
+    if (filter) {
+      const generation = generateFilteredSvg(
+        url,
+        path,
+        clientId,
+        filter,
+        filtersParam!,
+      );
+      inFlightFilteredSvgs.set(url.href, generation);
+      try {
+        return filteredSvgResponse(await generation);
+      } finally {
+        // Only if it is still ours — see the shared generator's note.
+        if (inFlightFilteredSvgs.get(url.href) === generation) {
+          inFlightFilteredSvgs.delete(url.href);
+        }
+      }
+    }
+
     const client = await self.clients.get(clientId);
     if (client) {
       const { transfer } = await sendRequest(
@@ -83,38 +171,6 @@ async function handleLocalAssetRequest(url: URL, clientId: string) {
         },
       );
       const buffer = transfer[0];
-
-      if (filter) {
-        const filtered = filterSVG(new TextDecoder().decode(buffer), filter);
-        const response = new Response(filtered, {
-          status: 200,
-          headers: new Headers({
-            "Content-Type": "image/svg+xml",
-            "Cache-Control": "max-age=31536000, immutable",
-          }),
-        });
-        try {
-          const cache = await caches.open(SW_FILTERED_CACHE_NAME);
-          // Prune superseded signatures of this exact variant: same path +
-          // same filters at a DIFFERENT url means the file's `?v=` signature
-          // moved (an edit), so the old entry can never be requested again.
-          const keys = await cache.keys();
-          await Promise.all(
-            keys
-              .filter((req) => {
-                const cachedUrl = new URL(req.url);
-                return (
-                  cachedUrl.pathname === url.pathname &&
-                  cachedUrl.searchParams.get("filters") === filtersParam &&
-                  req.url !== url.href
-                );
-              })
-              .map((req) => cache.delete(req)),
-          );
-          await cache.put(url.href, response.clone());
-        } catch {}
-        return response;
-      }
 
       const contentLength = buffer.byteLength;
       const headers = new Headers({


### PR DESCRIPTION
Fixes #344.

## Costs this fix knowingly carries

**1. Warming now generates every filtered variant the program declares**, in the
background, on project open — ~346 on the real Raffles & Bunny project (78 svgs
each with an implicit variant, plus 268 distinct `~`-tagged references). Each is
a service-worker `filterSVG` pass whose result lands in the `filtered-svgs`
Cache Storage bucket, so first open does more background work and that bucket
grows to roughly one filtered svg per variant. Previously only *displayed*
variants were ever generated.

That is the trade this ticket asks for — the cost was being paid interactively,
in front of the user, at the moment a portrait appeared. It is bounded (6 in
flight, once per file signature, deduped by url, retried at most 3 times) and,
with the coalescing below, a display that races a warm-up now *shares* its
generation instead of starting a second one.

**2. Root srcs are still warmed for svgs that only ever render through a
variant.** An svg used as a `layered_image` layer *is* fetched by its root src
(`UIModule.getImageAssets`), and the program cannot tell the two uses apart
cheaply, so both are warmed. Roots are queued last, so they cost bandwidth and
resident memory rather than latency.

## What broke

A filtered image is displayed through `<root>?v=<sig>&filters=<canonical>` —
a url **nothing else ever fetches**. Two separate things went wrong:

1. **The warm-up warmed the wrong url.** `installWorkspaceWorker.ts` warmed
   `file.src`, the *root* asset url, once per file at enumeration. Not just
   `~`-tagged references are affected: `populateImplicitDefs`
   (`packages/sparkdown/src/compiler/classes/SparkdownCompiler.ts:3458`)
   declares an implicit `filtered_image` for **every** svg, and an empty filter
   still serializes to a `filters=` param
   (`packages/sparkdown/src/filters/filteredSvg.ts:83`), so plain
   `[[show portrait bunny]]` goes through a variant url too. Every svg in the
   project was cold on first display.

   That warm-up was also unbounded — one `new Image()` per asset, 261 at once on
   the real project, so the asset the user reached first arrived no sooner than
   the last.

2. **The work was done twice.** `UIModule.createImage`
   (`packages/spark-engine/src/game/modules/ui/classes/UIModule.ts:169`) writes
   the variant url as the element's `background-image` *and* as the `src` of a
   hidden `<img>` child, so showing an image issues two simultaneous requests
   for it. Neither service worker coalesced: both missed the cache (nothing is
   stored until the first finishes) and each ran a full read + `filterSVG` +
   prune + put. Measured on `origin/main`: the same 38,846-byte variant fetched
   **twice**, concurrently, on every run — the duplicate the ticket flagged as
   "worth a look on its own".

## The fix

- **`packages/sparkdown/src/filters/filteredSvg.ts`** — concurrent requests for
  one variant share a single generation, and the O(bucket) `cache.keys()` prune
  moves off the response path. Each caller gets a freshly constructed Response
  over the shared filtered *source*, never a `clone()`.
- **`sparkdown-player-app/src/workers/sw.ts`** — the same coalescing for the
  cross-origin player, which has its own generate path and where a miss is
  *more* expensive (it relays SW → page → editor → OPFS).
- **`packages/spark-web-player/src/main/utils/getProgramImageSrcs.ts`** —
  resolves every url a compiled program makes the renderer request, ordered
  `~`-tagged variants → implicit variants → roots, because the compiler declares
  the whole-asset variants first and warming in map order buried the referenced
  ones behind ~78 others. Resolves on **copies**, never the program's own
  structs (see "Review" below). Roots whose svg source is still inlined
  (VS Code webviews) are skipped — their variants are `data:` uris.
- **`packages/spark-web-player/src/main/utils/ImagePreloader.ts`** — src-keyed,
  bounded-concurrency warm-up with eviction by asset path, retention bounded to
  the current program, and a 3-attempt failure budget.
- **`packages/spark-web-player/src/main/workers/installWorkspaceWorker.ts`** —
  warming is driven by `onCompiledTextDocument`, because only the compiled
  program knows the filters; gated on `program.version` per uri so it does not
  re-run per keystroke. Coverage is unchanged: `populateAssets` gives every
  image file a `context.image` struct with its `src`.

## Measured

Real Raffles & Bunny export seeded into the editor's OPFS (261 visual files,
53.1 MB — audio excluded, as in the ticket), **fresh Chromium profile per run**
so every asset starts cold, seed and measure in one launch. Trusted click on
`main.sd:421` (`[[bunny_guilty~phone~look_right]]`) from the **stopped** preview;
a `MutationObserver` in the player records when `background-image` is written and
a `PerformanceObserver` records when the bytes land. **Blank window** = the
interval in which the element exists, is sized, and has no pixels.

13 runs, interleaved (`base, base, FIX, FIX, FIX, base, base, FIX, base, FIX,
base, FIX, base`):

| build | blank window per run (ms) | median | generations per first display |
| --- | --- | --- | --- |
| `origin/main` | 162, 150, 53, 62, 104, 162, 65 | **104 ms** | **2** (7/7 runs) |
| this branch | 53, 31, 54, 140, 35, 44 | **49 ms** | **1** (6/6 runs) |

**Read the variance, not just the medians.** Both distributions are wide and the
ranges overlap — this machine's run-to-run spread is larger than the effect on
any single pair, which is why the runs are interleaved and reported in full. My
first, non-interleaved reading looked like 162 ms → 10 ms; it was not
reproducible, and the honest figure is roughly a **2× median improvement**.

The **generation count is the robust signal**: 2 on every baseline run, 1 on
every fixed run, load-independent. `FINAL4`'s 140 ms shows warming can still
lose the race when the queue is deep — see "Left for #287".

Harness: a scratch Playwright script, not a repo benchmark — no existing
benchmark drives the service worker's filtered-svg route. It is not committed;
the description above is enough to rebuild it.

One trap worth recording: a `url\(["']?([^"')]+)["']?\)` matcher **truncates**
these urls, because `encodeURIComponent` leaves `(` and `)` alone and the filter
param contains `look-(?!right)`. My first two readings were false negatives from
exactly that.

### No visual change

Before/after screenshots of the same beat are identical — the fix changes *when*
the pixels are there, not what they are. The portrait renders correctly filtered
(phone in hand, looking right) in both.

## Regression tests

| test | pins |
| --- | --- |
| `packages/spark-web-player/src/main/utils/getProgramImageSrcs.test.ts` (13) | the warm set contains the url the renderer displays and not just the root; warm ORDER; that it never writes back to the program; chained/cyclic/layered/inlined roots; **and a cross-check that everything `UIModule.getImageSrcsByName` — the real display path — asks for is warmed, over two independent compiles so neither side can pass by reading the other's memo** |
| `packages/spark-web-player/src/main/utils/ImagePreloader.test.ts` (16) | concurrency cap, warm order, src-keying, eviction, retention, bounded retry, stale-failure identity guard, slot release on a throwing factory, sync-load re-entrancy |
| `packages/sparkdown/src/tests/compiler/filteredSvgOnDemand.test.ts` (+3) | one generation for concurrent requests, each caller with its own readable body; a shared generation that FAILS lets the caller regenerate rather than serving unfiltered art; a failed generation is not stranded |

**Red/green.** Against a simulated pre-fix source (warm set from root srcs only,
unbounded pump, no coalescing), **8 assertions fail** and the positive controls
still pass:

- `warms the FILTERED url an svg is displayed through…` → `.toMatch() expects to receive a string, but got undefined`
- `warms the variant of a ~-tagged reference…` → `expected [ …(2) ] to include undefined`
- `resolves a named filter to a filters= url` → `expected '/file:/…' to deeply equal undefined`
- `holds concurrency at the cap…` → `expected [ 'a','b','c','d','e' ] to deeply equal [ 'a','b' ]`
- `preserves warm order…` → `expected [ 'variant','root' ] to deeply equal [ 'variant' ]`
- `does not dedupe a queued src into oblivion` → `expected +0 to be 1`
- `evicts urls still waiting in the queue` → `expected +0 to be 1`
- `runs ONE generation for concurrent requests of the same variant` → `expected 3 to be 1`

Still green on the pre-fix source (so a red run proves the defect, not a broken
harness): raster warming, the `data:`-uri skip, layered-root coverage, src
dedupe, eviction of warmed entries, and `does not strand a failed generation`.

## Suites

- `packages/spark-web-player` — 4 files / 48 tests passed.
- `packages/sparkdown` `src/tests/compiler` + `src/tests/runtime` — 79 files
  passed / 2 skipped (81), 904 tests passed / 24 skipped (928), 161 s. No
  failures, pre-existing or otherwise.

## Adversarial review

Six read-only reviewers ran against the diff. What they found and what changed:

**Fixed:**
- *The warm-up could have changed rendered art.* `filterImage` memoizes by
  writing `filtered_src` onto the struct it is handed, and the player hands the
  game that very object — while `Game.applyBuiltinDefaults` fills a filter's
  unauthored `includes`/`excludes` from `$default` and this sweep does not. For
  `define f as filter end` those disagree (`[]` removes every filterable
  non-`default` node; `[""]` removes nothing), so whichever ran first would have
  decided the art. Now resolved on copies; a warm-up cannot touch a pixel.
- *Cross-origin player had no coalescing* — added.
- *`Response.clone()` teeing* — the shared-generation path now hands out fresh
  Responses over a shared string.
- *Failed urls re-requested on every compile forever* — 3-attempt budget,
  cleared when the file changes.
- *Unbounded retention* — retention bounded to the current program's set.
- *Referenced variants queued behind every whole-asset variant* — warm order
  reordered; that ordering is now pinned by a test.
- *O(n²) cache prune under warming* — prune moved off the response path.
- *`_inFlight` could drift and deadlock the pump* if the target factory threw;
  *a stale `onerror` could un-warm a genuinely resident url*; *a cap of 0/NaN
  silently disabled warming*; *a single version counter across per-uri version
  streams could skip a program*; *`warmOnly` left a dead project's backlog in
  the queue*; *a throw from the sweep would have failed the compile* — all fixed
  and tested.
- *Chained `filtered_image` roots escaped the inlined-data guard* — now walks
  the chain with a cycle guard.

**Declined, with reasons:**
- *A generation that never settles poisons its key for the SW's lifetime.* True,
  but a hang in OPFS or Cache Storage already hangs the first request; a timeout
  would add a second failure mode (serving duplicate work) to buy resilience
  against a case nothing else recovers from either.
- *N coalesced callers all fall through and regenerate when a shared generation
  fails.* Deliberate: the alternative is one transient read error making every
  concurrent caller serve **unfiltered** art, which is visibly wrong rather than
  merely slower.
- *The cache-hit path returns `cached` directly rather than a fresh Response.*
  Pre-existing, and true of every `Cache.match` implementation in use.
- *A test asserting three distinct Response objects does not distinguish a
  `clone()` from a fresh Response.* Correct — clones are distinct and readable
  too, and the stall is browser-only. The misleading comment was removed rather
  than left standing over an assertion that cannot back it.
- *No test covers the wiring in `installWorkspaceWorker.ts` itself.* Still true;
  `packages/spark-web-player` has no harness for the workspace subclass, and
  standing one up is larger than this ticket.

## Left for #287

Warming still enumerates the whole program rather than the current scene, so on
a large project the tail of the warm set is still arriving while the user reads —
which is why one of the six fixed runs still measured 140 ms. Narrowing that to
per-scene asset references is #287's stated goal and needs the compiler to emit
those references. This ticket stops at warming the *right* urls, in a sensible
order, and not paying for any of them twice.
